### PR TITLE
[Merged by Bors] - chore: add crates to the conventional commits scope list in VSCode settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "conventionalCommits.scopes": [
+        "bones_ecs",
+        "bones_has_load_progress",
+        "bones_matchmaker",
+        "bones_matchmaker_proto",
+        "quinn_runtime_bevy",
+    ]
+}


### PR DESCRIPTION
This makes it easier to make conventional commits for specific crates when using the VSCode plugin.