### PR TITLE
[Merged by Bors] - fix(bones_ecs): fix soundness issues revealed in code-review

### DIFF
--- a/crates/bones_ecs/src/lib.rs
+++ b/crates/bones_ecs/src/lib.rs
@@ -89,20 +89,24 @@ pub trait RawFns {
     /// Drop the value at `ptr`.
     ///
     /// # Safety
-    /// Pointer must point to a valid instance of the type that this implementation is assocated
-    /// wit
+    /// - The pointer must point to a valid instance of the type that this implementation is
+    /// assocated with.
+    /// - The pointer must be writable.
     unsafe extern "C" fn raw_drop(ptr: *mut u8);
 
     /// Clone the value at `src`, writing the new value to `dst`.
     ///
     /// # Safety
-    /// Pointer must point to a valid instance of the type that this implementation is assocated
-    /// with, and the destination pointer must be properly aligned and writable.
+    /// - The src pointer must point to a valid instance of the type that this implementation is
+    /// assocated with.
+    /// - The destination pointer must be properly aligned and writable.
     unsafe extern "C" fn raw_clone(src: *const u8, dst: *mut u8);
 }
 
 impl<T: Clone> RawFns for T {
     unsafe extern "C" fn raw_drop(ptr: *mut u8) {
+        use std::io::{self, Write};
+
         let result = std::panic::catch_unwind(|| {
             if std::mem::needs_drop::<T>() {
                 (ptr as *mut T).drop_in_place()
@@ -110,16 +114,20 @@ impl<T: Clone> RawFns for T {
         });
 
         if result.is_err() {
-            eprintln!(
+            writeln!(
+                io::stderr(),
                 "Rust type {} panicked in destructor.\n\
                 Unable to panic across C ABI: aborting.",
                 std::any::type_name::<T>()
-            );
+            )
+            .ok();
             std::process::abort();
         }
     }
 
     unsafe extern "C" fn raw_clone(src: *const u8, dst: *mut u8) {
+        use std::io::{self, Write};
+
         let result = std::panic::catch_unwind(|| {
             let t = &*(src as *const T);
             let t = t.clone();
@@ -127,11 +135,13 @@ impl<T: Clone> RawFns for T {
         });
 
         if result.is_err() {
-            eprintln!(
+            writeln!(
+                io::stderr(),
                 "Rust type {} panicked in clone implementation.\n\
                 Unable to panic across C ABI: aborting.",
                 std::any::type_name::<T>()
-            );
+            )
+            .ok();
             std::process::abort();
         }
     }


### PR DESCRIPTION
- Fixes safety documentation for some public, unsafe functions.
- Fixes some soundness issues when cloning or creating `UntypedResource`s when allocation fails.

Thanks again to @LegionMammal978 for finding these issues!

<https://users.rust-lang.org/t/review-for-my-small-1917-loc-rust-ecs/86326/4?u=zicklag>