### PR TITLE
[Merged by Bors] - chore(bones_ecs): update bevy_derive dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
  "aligned-vec",
  "anyhow",
  "atomic_refcell",
- "bevy_derive 0.8.1",
+ "bevy_derive 0.9.1",
  "bitset-core",
  "bytemuck",
  "either",

--- a/crates/bones_ecs/Cargo.toml
+++ b/crates/bones_ecs/Cargo.toml
@@ -22,7 +22,7 @@ aligned-vec = "0.5.0"
 anyhow = "1.0.68"
 atomic_refcell = "0.1.8"
 # TODO: Replace with our own macros
-bevy_derive = "0.8.1"
+bevy_derive = "0.9.1"
 bitset-core = "0.1.1"
 bytemuck = "1.12.3"
 either = "1.8.0"


### PR DESCRIPTION
Updates to 0.9.1 just to keep up with the latest Bevy version.