### PR TITLE
[Merged by Bors] - ci: fix bors commit lint initial failure.

### DIFF
--- a/.github/workflows/bors-commit-lint.yml
+++ b/.github/workflows/bors-commit-lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - uses: wagoid/commitlint-github-action@v5
         with:
           commitDepth: 1


### PR DESCRIPTION
Currently, every time we try to have bors merge a PR,it fails the first time,
presumably because the checkout action is shallow.

This makes sure the checkout action will pull that last two commits, hopefully fixing the error.