### PR TITLE
[Merged by Bors] - feat!: draft bones_lib architecture.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,11 @@
 {
     "conventionalCommits.scopes": [
+        "bones_lib",
         "bones_ecs",
+        "bones_asset",
+        "bones_render",
+        "bones_input",
+        "bones_bevy_renderer",
         "bones_has_load_progress",
         "bones_matchmaker",
         "bones_matchmaker_proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
+ "bevy_sprite",
  "bevy_tasks",
  "bevy_time",
  "bevy_transform",
@@ -600,6 +601,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_sprite"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec01c7db7f698d95bcb70708527c3ae6bcdc78fc247abe74f935cae8f0a1145"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_log",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bitflags",
+ "bytemuck",
+ "fixedbitset",
+ "guillotiere",
+ "rectangle-pack",
+ "thiserror",
+]
+
+[[package]]
 name = "bevy_tasks"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,11 +729,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "bones"
-version = "2.0.0"
+name = "bones_asset"
+version = "0.1.0"
 dependencies = [
- "bones_camera_shake",
  "bones_ecs",
+ "ulid",
+]
+
+[[package]]
+name = "bones_bevy_renderer"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bones_lib",
+ "type_ulid",
 ]
 
 [[package]]
@@ -757,6 +792,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bones_input"
+version = "0.1.0"
+dependencies = [
+ "type_ulid",
+]
+
+[[package]]
+name = "bones_lib"
+version = "0.1.0"
+dependencies = [
+ "bones_asset",
+ "bones_camera_shake",
+ "bones_ecs",
+ "bones_input",
+ "bones_render",
+]
+
+[[package]]
 name = "bones_matchmaker"
 version = "0.1.1"
 dependencies = [
@@ -787,6 +840,16 @@ name = "bones_matchmaker_proto"
 version = "0.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bones_render"
+version = "0.1.0"
+dependencies = [
+ "bones_asset",
+ "bones_ecs",
+ "glam",
+ "type_ulid",
 ]
 
 [[package]]
@@ -1242,6 +1305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1558,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
+dependencies = [
+ "euclid",
+ "svg_fmt",
 ]
 
 [[package]]
@@ -2438,6 +2520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rectangle-pack"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "svg_fmt"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3017,9 @@ name = "ulid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a3aaa69b04e5b66cc27309710a569ea23593612387d67daaf102e73aa974fd"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bones"
-version = "2.0.0"
+name = "bones_lib"
+version = "0.1.0"
 description = "Opinionated game meta-engine built on Bevy"
 authors = ["The Fish Folks & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
@@ -17,4 +17,7 @@ camera_shake = ["dep:bones_camera_shake"]
 
 [dependencies]
 bones_ecs = { path = "./crates/bones_ecs" }
+bones_render = { path = "./crates/bones_render" }
+bones_input = { path = "./crates/bones_input" }
+bones_asset = { path = "./crates/bones_asset" }
 bones_camera_shake = { path = "./crates/bones_camera_shake", optional = true }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,4 +5,4 @@
 
 ---
 
-[API Documentation](./rustdoc/bones/index.html)
+[API Documentation](./rustdoc/bones_lib/index.html)

--- a/crates/bones_asset/Cargo.toml
+++ b/crates/bones_asset/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bones_asset"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Fish Folk & Spicy Lobster Developers"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+bones_ecs = { path = "../bones_ecs" }
+ulid = "1.0.0"

--- a/crates/bones_asset/src/lib.rs
+++ b/crates/bones_asset/src/lib.rs
@@ -1,0 +1,227 @@
+//! An asset interface for Bones.
+
+#![warn(missing_docs)]
+// This cfg_attr is needed because `rustdoc::all` includes lints not supported on stable
+#![cfg_attr(doc, allow(unknown_lints))]
+#![deny(rustdoc::all)]
+
+use std::{any::TypeId, collections::hash_map::Entry, marker::PhantomData};
+
+use bones_ecs::ulid::{TypeUlid, Ulid, UlidMap};
+
+/// The prelude.
+pub mod prelude {
+    pub use crate::*;
+}
+
+/// A resource that may be used to access [`AssetProvider`]s for all the different registered asset
+/// types.
+pub struct AssetProviders {
+    providers: UlidMap<Box<dyn UntypedAssetProvider>>,
+    type_ids: UlidMap<TypeId>,
+}
+
+impl AssetProviders {
+    /// Add an asset provider for a specific asset type.
+    pub fn add<T, A>(&mut self, provider: A)
+    where
+        T: TypeUlid + 'static,
+        A: AssetProvider<T> + UntypedAssetProvider + 'static,
+    {
+        let type_id = TypeId::of::<T>();
+        let type_ulid = T::ulid();
+
+        match self.type_ids.entry(type_ulid) {
+            Entry::Occupied(entry) => {
+                if entry.get() != &type_id {
+                    panic!("Multiple Rust types with the same Type ULID");
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(type_id);
+            }
+        }
+
+        self.providers.insert(type_ulid, Box::new(provider));
+    }
+
+    /// Get the asset provider for the given type
+    pub fn get<T: TypeUlid>(&self) -> AssetProviderRef<T> {
+        self.try_get::<T>().unwrap()
+    }
+
+    /// Get the asset provider for the given asset type, if it exists.
+    pub fn try_get<T: TypeUlid>(&self) -> Option<AssetProviderRef<T>> {
+        self.providers.get(&T::ulid()).map(|x| {
+            let untyped = x.as_ref();
+
+            AssetProviderRef {
+                untyped,
+                _phantom: PhantomData,
+            }
+        })
+    }
+
+    /// Get the asset provider for the given type
+    pub fn get_mut<T: TypeUlid>(&mut self) -> AssetProviderMut<T> {
+        self.try_get_mut::<T>().unwrap()
+    }
+
+    /// Get the asset provider for the given asset type, if it exists.
+    pub fn try_get_mut<T: TypeUlid>(&mut self) -> Option<AssetProviderMut<T>> {
+        self.providers.get_mut(&T::ulid()).map(|x| {
+            let untyped = x.as_mut();
+
+            AssetProviderMut {
+                untyped,
+                _phantom: PhantomData,
+            }
+        })
+    }
+}
+
+/// Trait implemented for asset providers that can return untyped pointers to their assets.
+pub trait UntypedAssetProvider {
+    /// Returns a read-only pointer to the asset for the given handle, or a null pointer if it
+    /// doesn't exist.
+    fn get(&self, handle: UntypedHandle) -> *const u8;
+    /// Returns a mutable-only pointer to the asset for the given handle, or a null pointer if it
+    /// doesn't exist.
+    fn get_mut(&mut self, handle: UntypedHandle) -> *mut u8;
+}
+
+/// Trait for asset providers.
+///
+/// Asset providers are reponsible for returning references to assets out of their backing asset store, when giving handles to the asset to laod
+pub trait AssetProvider<T: TypeUlid> {
+    /// Get a reference to an asset, if it exists in the store.
+    fn get(&self, handle: Handle<T>) -> Option<&T>;
+    /// Get a mutable reference to an asset, if it exists in the store.
+    fn get_mut(&mut self, handle: Handle<T>) -> Option<&mut T>;
+}
+
+impl<T: TypeUlid> UntypedAssetProvider for dyn AssetProvider<T> {
+    fn get(&self, handle: UntypedHandle) -> *const u8 {
+        let asset = <Self as AssetProvider<T>>::get(self, handle.typed());
+        asset
+            .map(|x| x as *const T as *const u8)
+            .unwrap_or(std::ptr::null())
+    }
+
+    fn get_mut(&mut self, handle: UntypedHandle) -> *mut u8 {
+        let asset = <Self as AssetProvider<T>>::get_mut(self, handle.typed());
+        asset
+            .map(|x| x as *mut T as *mut u8)
+            .unwrap_or(std::ptr::null_mut())
+    }
+}
+
+/// A borrow of an [`AssetProvider`].
+pub struct AssetProviderRef<'a, T: TypeUlid> {
+    untyped: &'a dyn UntypedAssetProvider,
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T: TypeUlid> AssetProviderRef<'a, T> {
+    /// Get an asset, given it's handle
+    pub fn get(&self, handle: Handle<T>) -> Option<&T> {
+        let ptr = self.untyped.get(handle.untyped()) as *const T;
+
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFE: AssetProviderRef may only be constructed by us, and we only construct it ( see
+            // AssetProviders ) when we know the untyped provider matches T.
+            unsafe { Some(&*ptr) }
+        }
+    }
+}
+
+/// A mutable borrow of an [`AssetProvider`].
+pub struct AssetProviderMut<'a, T: TypeUlid> {
+    untyped: &'a mut dyn UntypedAssetProvider,
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T: TypeUlid> AssetProviderMut<'a, T> {
+    /// Get an asset, given it's handle
+    pub fn get(&self, handle: Handle<T>) -> Option<&T> {
+        let ptr = self.untyped.get(handle.untyped()) as *const T;
+
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFE: AssetProviderRef may only be constructed by us, and we only construct it ( see
+            // AssetProviders ) when we know the untyped provider matches T.
+            unsafe { Some(&*ptr) }
+        }
+    }
+
+    /// Get an asset, given it's handle
+    pub fn get_mut(&mut self, handle: Handle<T>) -> Option<&mut T> {
+        let ptr = self.untyped.get_mut(handle.untyped()) as *mut T;
+
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFE: AssetProviderRef may only be constructed by us, and we only construct it ( see
+            // AssetProviders ) when we know the untyped provider matches T.
+            unsafe { Some(&mut *ptr) }
+        }
+    }
+}
+
+/// A typed handle to an asset.
+///
+/// The type of the handle is used to help reduce errros at runtime, but internally, the handle's
+/// only data is it's [`Ulid`] `id`.
+///
+/// It can be converted to an untyped handle with the [`untyped()`][Self::untyped] method.
+#[derive(Copy, Clone, Debug)]
+pub struct Handle<T: TypeUlid> {
+    /// The unique identifier of the asset this handle represents.
+    pub id: Ulid,
+    phantom: PhantomData<T>,
+}
+
+impl<T: TypeUlid> Default for Handle<T> {
+    fn default() -> Self {
+        Self {
+            id: Default::default(),
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T: TypeUlid> Handle<T> {
+    /// Convert the handle to an [`UntypedHandle`].
+    pub fn untyped(self) -> UntypedHandle {
+        UntypedHandle { id: self.id }
+    }
+}
+
+/// An untyped handle to an asset.
+///
+/// This simply contains the asset's unique [`Ulid`] id.
+///
+/// Can be converted to a typed handle with the [`typed()`][Self::typed] method.
+#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct UntypedHandle {
+    /// The unique identifier of the asset this handle represents.
+    pub id: Ulid,
+}
+
+impl UntypedHandle {
+    /// Create a new, random [`UntypedHandle`].
+    pub fn new() -> Self {
+        Self { id: Ulid::new() }
+    }
+
+    /// Create a typed [`Handle<T>`] from this [`UntypedHandle`].
+    pub fn typed<T: TypeUlid>(self) -> Handle<T> {
+        Handle {
+            id: self.id,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/crates/bones_bevy_renderer/Cargo.toml
+++ b/crates/bones_bevy_renderer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bones_bevy_renderer"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Fish Folk & Spicy Lobster Developers"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+bones_lib = { path = "../../" }
+type_ulid = { path = "../type_ulid" }
+
+[dependencies.bevy]
+version = "0.9.1"
+default-features = false
+features = [
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_sprite",
+]

--- a/crates/bones_bevy_renderer/src/lib.rs
+++ b/crates/bones_bevy_renderer/src/lib.rs
@@ -1,0 +1,199 @@
+//! Bevy plugin for rendering Bones framework games.
+
+#![warn(missing_docs)]
+// This cfg_attr is needed because `rustdoc::all` includes lints not supported on stable
+#![cfg_attr(doc, allow(unknown_lints))]
+#![deny(rustdoc::all)]
+
+use std::{marker::PhantomData, rc::Rc};
+
+use bevy::{prelude::*, render::camera::ScalingMode, utils::HashMap};
+use bones_lib::prelude::{self as bones, BitSet};
+
+/// The prelude
+pub mod prelude {
+    pub use crate::*;
+}
+
+/// Helper trait for converting bones types to Bevy types.
+pub trait IntoBevy<To> {
+    /// Convert the type to a Bevy type.
+    fn into_bevy(self) -> To;
+}
+
+/// Convert bones transforms to bevy transforms
+impl IntoBevy<Transform> for bones::Transform {
+    #[inline]
+    fn into_bevy(self) -> Transform {
+        Transform {
+            translation: self.translation,
+            rotation: self.rotation,
+            scale: self.scale,
+        }
+    }
+}
+
+/// Mapping of bones asset handles to corresponding Bevy asset handles.
+#[derive(Default, Deref, DerefMut, Resource)]
+pub struct BonesAssetMap(HashMap<bones::UntypedHandle, HandleUntyped>);
+
+/// This is a trait that must be implemented for your Bevy resource containing the bones
+/// [`World`][bones::World].
+///
+/// It gives the [`BonesRendererPlugin`] a way to know how to read the bones world from your world
+/// resource.
+pub trait HasBonesWorld: Resource {
+    /// Return a mutable reference to the bones world stored by the resource.
+    fn world(&mut self) -> &mut bones::World;
+}
+
+/// The bones renderer plugin.
+///
+/// This will render the bones world stored in the resource of type `W`.
+pub struct BonesRendererPlugin<W: HasBonesWorld> {
+    _phantom: PhantomData<W>,
+}
+
+impl<W: HasBonesWorld> Default for BonesRendererPlugin<W> {
+    fn default() -> Self {
+        Self {
+            _phantom: default(),
+        }
+    }
+}
+
+impl<W: HasBonesWorld> BonesRendererPlugin<W> {
+    /// Create a new [`BonesRendererPlugin`] instance.
+    pub fn new() -> Self {
+        default()
+    }
+}
+
+/// Marker component for entities that are rendered in Bevy for bones.
+#[derive(Component)]
+pub struct BevyBonesEntity;
+
+impl<W: HasBonesWorld> Plugin for BonesRendererPlugin<W> {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<BonesAssetMap>()
+            .add_system_to_stage(CoreStage::Last, render_world::<W>);
+    }
+}
+
+/// The system that renders the bones world.
+fn render_world<W: HasBonesWorld>(
+    mut commands: Commands,
+    world_resource: Option<ResMut<W>>,
+    mut bevy_bones_sprites: Query<
+        (Entity, &mut Handle<Image>, &mut Transform),
+        (With<BevyBonesEntity>, Without<Camera>),
+    >,
+    mut bevy_bones_cameras: Query<
+        (
+            Entity,
+            &mut Camera,
+            &mut OrthographicProjection,
+            &mut Transform,
+        ),
+        With<BevyBonesEntity>,
+    >,
+    handle_map: Res<BonesAssetMap>,
+) {
+    let Some(mut world_resource) = world_resource else {
+        return;
+    };
+
+    let world = world_resource.world();
+
+    let entities = world.resources.get::<bones::Entities>();
+    let entities = entities.borrow();
+    let sprites = world.components.get::<bones::Sprite>();
+    let sprites = sprites.borrow();
+    let transforms = world.components.get::<bones::Transform>();
+    let transforms = transforms.borrow();
+    let cameras = world.components.get::<bones::Camera>();
+    let cameras = cameras.borrow();
+
+    // Sync sprites
+    let mut sprites_bitset = entities.bitset().clone();
+    sprites_bitset.bit_and(sprites.bitset());
+    sprites_bitset.bit_and(transforms.bitset());
+    let mut bones_sprite_entity_iter = entities.iter_with_bitset(Rc::new(sprites_bitset)).flatten();
+    for (bevy_ent, mut image, mut transform) in &mut bevy_bones_sprites {
+        if let Some(bones_ent) = bones_sprite_entity_iter.next() {
+            let bones_sprite = sprites.get(bones_ent).unwrap();
+            let bones_transform = transforms.get(bones_ent).unwrap();
+
+            *image = handle_map
+                .get(&bones_sprite.image.untyped())
+                .unwrap()
+                .clone()
+                .typed();
+            *transform = bones_transform.into_bevy();
+        } else {
+            commands.entity(bevy_ent).despawn();
+        }
+    }
+    for bones_ent in bones_sprite_entity_iter {
+        let bones_sprite = sprites.get(bones_ent).unwrap();
+        let bones_transform = transforms.get(bones_ent).unwrap();
+
+        let texture = handle_map
+            .get(&bones_sprite.image.untyped())
+            .expect("Unkonwn image handle in Bones ECS sprite component")
+            .clone_weak()
+            .typed();
+
+        commands.spawn((
+            SpriteBundle {
+                texture,
+                transform: bones_transform.into_bevy(),
+                ..default()
+            },
+            BevyBonesEntity,
+        ));
+    }
+
+    // Sync cameras
+    let mut cameras_bitset = entities.bitset().clone();
+    cameras_bitset.bit_and(cameras.bitset());
+    let mut bones_camera_entity_iter = entities.iter_with_bitset(Rc::new(cameras_bitset)).flatten();
+    for (bevy_ent, mut camera, mut projection, mut transform) in &mut bevy_bones_cameras {
+        if let Some(bones_ent) = bones_camera_entity_iter.next() {
+            let bones_camera = cameras.get(bones_ent).unwrap();
+            let bones_transform = transforms.get(bones_ent).unwrap();
+
+            camera.is_active = bones_camera.active;
+            match projection.scaling_mode {
+                ScalingMode::FixedVertical(height) if height != bones_camera.height => {
+                    projection.scaling_mode = ScalingMode::FixedVertical(bones_camera.height)
+                }
+                _ => (),
+            }
+
+            *transform = bones_transform.into_bevy();
+        } else {
+            commands.entity(bevy_ent).despawn();
+        }
+    }
+    for bones_ent in bones_camera_entity_iter {
+        let bones_camera = cameras.get(bones_ent).unwrap();
+        let bones_transform = transforms.get(bones_ent).unwrap();
+
+        commands.spawn((
+            Camera2dBundle {
+                camera: Camera {
+                    is_active: bones_camera.active,
+                    ..default()
+                },
+                projection: OrthographicProjection {
+                    scaling_mode: ScalingMode::FixedVertical(bones_camera.height),
+                    ..default()
+                },
+                transform: bones_transform.into_bevy(),
+                ..default()
+            },
+            BevyBonesEntity,
+        ));
+    }
+}

--- a/crates/bones_input/Cargo.toml
+++ b/crates/bones_input/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bones_input"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Fish Folk & Spicy Lobster Developers"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+type_ulid = { path = "../type_ulid" }

--- a/crates/bones_input/src/lib.rs
+++ b/crates/bones_input/src/lib.rs
@@ -1,0 +1,21 @@
+//! Standardized types meant to be provided to Bones games from the outside environment.
+
+#![warn(missing_docs)]
+// This cfg_attr is needed because `rustdoc::all` includes lints not supported on stable
+#![cfg_attr(doc, allow(unknown_lints))]
+#![deny(rustdoc::all)]
+
+use type_ulid::TypeUlid;
+
+/// The prelude.
+pub mod prelude {
+    pub use crate::*;
+}
+
+/// Resource representing the current game time.
+#[derive(Clone, Copy, Debug, TypeUlid, Default)]
+#[ulid = "01GNR4DNDZRH0E9XCSV79WRGXH"]
+pub struct Time {
+    /// The time elapsed since the start of the game session.
+    pub elapsed: f32,
+}

--- a/crates/bones_render/Cargo.toml
+++ b/crates/bones_render/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bones_render"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Fish Folk & Spicy Lobster Developers"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+bones_ecs = { path = "../bones_ecs" }
+bones_asset = { path = "../bones_asset" }
+type_ulid = { path = "../type_ulid" }
+glam = "0.22.0"

--- a/crates/bones_render/src/camera.rs
+++ b/crates/bones_render/src/camera.rs
@@ -1,0 +1,27 @@
+//! Camera components.
+
+use crate::prelude::*;
+
+/// Makes an entity behave like a camera.
+///
+/// The entity must also have a [`Transform`] component for the camera to render anything.
+#[derive(Clone, Copy, Debug, TypeUlid)]
+#[ulid = "01GNR2978NRN7PH5XWBXP3KMD7"]
+#[repr(C)]
+pub struct Camera {
+    /// The height of the camera in in-game pixels.
+    ///
+    /// The width of the camera will be determined from the window aspect ratio.
+    pub height: f32,
+    /// Whether or not the camera is enabled and rendering.
+    pub active: bool,
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self {
+            height: 400.0,
+            active: true,
+        }
+    }
+}

--- a/crates/bones_render/src/lib.rs
+++ b/crates/bones_render/src/lib.rs
@@ -1,0 +1,18 @@
+//! Standardized rendering components for Bones.
+
+#![warn(missing_docs)]
+// This cfg_attr is needed because `rustdoc::all` includes lints not supported on stable
+#![cfg_attr(doc, allow(unknown_lints))]
+#![deny(rustdoc::all)]
+
+pub mod camera;
+pub mod sprite;
+pub mod tilemap;
+pub mod transform;
+
+/// The prelude
+pub mod prelude {
+    pub use {bones_asset::prelude::*, bones_ecs::prelude::*, glam::*, type_ulid::TypeUlid};
+
+    pub use crate::{camera::*, sprite::*, tilemap::*, transform::*};
+}

--- a/crates/bones_render/src/sprite.rs
+++ b/crates/bones_render/src/sprite.rs
@@ -1,0 +1,17 @@
+//! Sprite rendering components.
+
+use crate::prelude::*;
+
+/// Image asset type, contains no data, but [`Handle<Image>`] is still useful because it uniquely
+/// represents an image that may be rendered outside of the core.
+#[derive(Copy, Clone, TypeUlid, Debug)]
+#[ulid = "01GNJGPQ8TKA234G1EA510BD96"]
+pub struct Image;
+
+/// A 2D sprite component
+#[derive(Copy, Clone, TypeUlid, Debug)]
+#[ulid = "01GNJXPWZKS6BHJEG1SX5B93DA"]
+pub struct Sprite {
+    /// The sprite image handle.
+    pub image: Handle<Image>,
+}

--- a/crates/bones_render/src/tilemap.rs
+++ b/crates/bones_render/src/tilemap.rs
@@ -1,0 +1,24 @@
+//! Tile map rendering components.
+
+use crate::prelude::*;
+
+/// A tilemap layer.
+#[derive(Clone, Debug, TypeUlid)]
+#[ulid = "01GNF7SRDRN4K8HPW32JAHKMX1"]
+pub struct TileLayer {
+    /// The vector of tile slots in this layer.
+    pub tiles: Vec<Option<Entity>>,
+    /// The size of the layer in tiles.
+    pub grid_size: UVec2,
+    /// The size of each tile in the layer.
+    pub tile_size: Vec2,
+}
+
+impl TileLayer {
+    /// Get's the tile at the given position in the layer, indexed with the top-left of the layer
+    /// being (0, 0).
+    pub fn get(&self, pos: UVec2) -> Option<Entity> {
+        let idx = self.grid_size.x * pos.y + pos.x;
+        self.tiles.get(idx as usize).cloned().flatten()
+    }
+}

--- a/crates/bones_render/src/transform.rs
+++ b/crates/bones_render/src/transform.rs
@@ -1,0 +1,28 @@
+//! Transform component.
+
+use crate::prelude::*;
+
+/// The main transform component.
+///
+/// Currently we don't have a hierarchy, and this is therefore a global transform.
+#[derive(Clone, Copy, Debug, TypeUlid)]
+#[ulid = "01GNFQWJWWXJJEXZQEDQJWZQWP"]
+#[repr(C)]
+pub struct Transform {
+    /// The position of the entity in the world.
+    pub translation: Vec3,
+    /// The rotation of the entity.
+    pub rotation: Quat,
+    /// The scale of the entity.
+    pub scale: Vec3,
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self {
+            translation: Default::default(),
+            rotation: Default::default(),
+            scale: Vec3::ONE,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 //! Opinionated game meta-engine built on Bevy.
 
-/// Entity component system for the bones library.
-pub mod ecs {
-    pub use bones_ecs::*;
+#[doc(inline)]
+pub use {bones_asset as asset, bones_ecs as ecs, bones_input as input, bones_render as render};
+
+/// Bones lib prelude
+pub mod prelude {
+    pub use crate::{asset::prelude::*, ecs::prelude::*, input::prelude::*, render::prelude::*};
 }
 
 /// This crate provides 2D camera shake using the methodology described in this excellent [GDC


### PR DESCRIPTION
Renames `bones` to `bones_lib` ( mostly because `bones` was already taken )
and adds the `bones_asset`, `bones_bevy_renderer`, `bones_input`, and
`bones_render` crates.

This sets up the overall structure for the bones library,
though changes to some aspects of the design are likely to change.