### PR TITLE
[Merged by Bors] - feat(type_ulid)!: have `TypeUlid` trait require an associated constant instead of a function.

### DIFF
--- a/crates/bones_asset/src/lib.rs
+++ b/crates/bones_asset/src/lib.rs
@@ -29,7 +29,7 @@ impl AssetProviders {
         A: AssetProvider<T> + UntypedAssetProvider + 'static,
     {
         let type_id = TypeId::of::<T>();
-        let type_ulid = T::ulid();
+        let type_ulid = T::ULID;
 
         match self.type_ids.entry(type_ulid) {
             Entry::Occupied(entry) => {
@@ -52,7 +52,7 @@ impl AssetProviders {
 
     /// Get the asset provider for the given asset type, if it exists.
     pub fn try_get<T: TypeUlid>(&self) -> Option<AssetProviderRef<T>> {
-        self.providers.get(&T::ulid()).map(|x| {
+        self.providers.get(&T::ULID).map(|x| {
             let untyped = x.as_ref();
 
             AssetProviderRef {
@@ -69,7 +69,7 @@ impl AssetProviders {
 
     /// Get the asset provider for the given asset type, if it exists.
     pub fn try_get_mut<T: TypeUlid>(&mut self) -> Option<AssetProviderMut<T>> {
-        self.providers.get_mut(&T::ulid()).map(|x| {
+        self.providers.get_mut(&T::ULID).map(|x| {
             let untyped = x.as_mut();
 
             AssetProviderMut {

--- a/crates/bones_ecs/src/components.rs
+++ b/crates/bones_ecs/src/components.rs
@@ -17,7 +17,7 @@ pub use untyped::*;
 fn validate_type_uuid_match<T: TypeUlid + 'static>(
     type_ids: &UlidMap<TypeId>,
 ) -> Result<(), EcsError> {
-    if type_ids.get(&T::ulid()).ok_or(EcsError::NotInitialized)? != &TypeId::of::<T>() {
+    if type_ids.get(&T::ULID).ok_or(EcsError::NotInitialized)? != &TypeId::of::<T>() {
         Err(EcsError::TypeUlidCollision)
     } else {
         Ok(())
@@ -59,7 +59,7 @@ impl ComponentStores {
     pub fn try_init<T: Clone + TypeUlid + Send + Sync + 'static>(
         &mut self,
     ) -> Result<(), EcsError> {
-        match self.components.entry(T::ulid()) {
+        match self.components.entry(T::ULID) {
             std::collections::hash_map::Entry::Occupied(_) => {
                 validate_type_uuid_match::<T>(&self.type_ids)
             }
@@ -67,7 +67,7 @@ impl ComponentStores {
                 entry.insert(Arc::new(AtomicRefCell::new(
                     UntypedComponentStore::for_type::<T>(),
                 )));
-                self.type_ids.insert(T::ulid(), TypeId::of::<T>());
+                self.type_ids.insert(T::ULID, TypeId::of::<T>());
 
                 Ok(())
             }
@@ -88,7 +88,7 @@ impl ComponentStores {
         &self,
     ) -> Result<AtomicComponentStore<T>, EcsError> {
         validate_type_uuid_match::<T>(&self.type_ids)?;
-        let untyped = self.try_get_by_uuid(T::ulid())?;
+        let untyped = self.try_get_by_uuid(T::ULID)?;
 
         // Safe: We've made sure that the data initialized in the untyped components matches T
         unsafe { Ok(AtomicComponentStore::from_components_unsafe(untyped)) }

--- a/crates/bones_ecs/src/resources.rs
+++ b/crates/bones_ecs/src/resources.rs
@@ -208,7 +208,7 @@ impl Resources {
     /// Errors if you try to insert a Rust type with a different [`TypeId`], but the same
     /// [`TypeUlid`] as another resource in the store.
     pub fn try_insert<T: TypedEcsData>(&mut self, resource: T) -> Result<(), EcsError> {
-        let uuid = T::ulid();
+        let uuid = T::ULID;
         let type_id = TypeId::of::<T>();
 
         match self.type_ids.entry(uuid) {
@@ -247,12 +247,12 @@ impl Resources {
     ///
     /// See [get()][Self::get]
     pub fn contains<T: TypedEcsData>(&self) -> bool {
-        self.untyped.resources.contains_key(&T::ulid())
+        self.untyped.resources.contains_key(&T::ULID)
     }
 
     /// Gets a resource handle from the store if it exists.
     pub fn try_get<T: TypedEcsData>(&self) -> Option<AtomicResource<T>> {
-        let untyped = self.untyped.get(T::ulid())?;
+        let untyped = self.untyped.get(T::ULID)?;
 
         Some(AtomicResource {
             untyped,

--- a/crates/type_ulid/macros/src/lib.rs
+++ b/crates/type_ulid/macros/src/lib.rs
@@ -63,9 +63,7 @@ fn impl_type_ulid(input: &syn::DeriveInput) -> TokenStream2 {
     let id = ulid.0;
     quote! {
         impl ::type_ulid::TypeUlid for #item_ident {
-            fn ulid() -> ::type_ulid::Ulid {
-                ::type_ulid::Ulid(#id)
-            }
+            const ULID: ::type_ulid::Ulid = ::type_ulid::Ulid(#id);
         }
     }
 }

--- a/crates/type_ulid/src/lib.rs
+++ b/crates/type_ulid/src/lib.rs
@@ -19,8 +19,8 @@ pub use ulid::Ulid;
 /// > **⚠️ Warning:** there is nothing enforcing that the [`Ulid`]s returned by different types will
 /// > be different.
 pub trait TypeUlid {
-    /// Get the type's [`Ulid`].
-    fn ulid() -> Ulid;
+    /// The type's [`Ulid`].
+    const ULID: Ulid;
 }
 
 /// Allows reading a type's [`Ulid`] from the context of a trait object when the concrete Rust type
@@ -34,7 +34,7 @@ pub trait TypeUlidDynamic: private::Sealed {
 
 impl<T: TypeUlid> TypeUlidDynamic for T {
     fn ulid(&self) -> Ulid {
-        Self::ulid()
+        Self::ULID
     }
 }
 
@@ -47,9 +47,7 @@ mod private {
 macro_rules! impl_ulid {
     ($t:ty, $ulid:expr) => {
         impl TypeUlid for $t {
-            fn ulid() -> Ulid {
-                Ulid($ulid)
-            }
+            const ULID: Ulid = Ulid($ulid);
         }
     };
 }


### PR DESCRIPTION
This makes it possible to access the type's Ulid at compile time,
possibly in const functions.