### PR TITLE
[Merged by Bors] - feat(bones_bevy_renderer, bones_render): implement atlas sprite rendering.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,12 @@ name = "bones_bevy_renderer"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bones_bevy_asset",
  "bones_lib",
+ "glam",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "type_ulid",
 ]
 

--- a/crates/bones_bevy_renderer/Cargo.toml
+++ b/crates/bones_bevy_renderer/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bones_lib = { path = "../../", features = ["bevy"] }
 type_ulid = { path = "../type_ulid" }
+serde = { version = "1.0.0", features = ["derive"] }
+glam = "0.22.0"
+serde_yaml = "0.9.16"
+serde_json = "1.0.91"
+bones_bevy_asset = { path = "../bones_bevy_asset" }
 
 [dependencies.bevy]
 version = "0.9.1"

--- a/crates/bones_bevy_renderer/src/asset.rs
+++ b/crates/bones_bevy_renderer/src/asset.rs
@@ -1,0 +1,60 @@
+use std::ffi::OsStr;
+
+use bevy::{asset::LoadedAsset, sprite::TextureAtlas};
+use bones_bevy_asset::BonesBevyAssetLoad;
+use glam::Vec2;
+
+/// The YAML/JSON metadata format for texture atlases
+#[derive(serde::Deserialize)]
+pub struct AtlasMeta {
+    pub image: bones_lib::asset::Handle<bones_lib::render::sprite::Image>,
+    pub tile_size: Vec2,
+    pub columns: usize,
+    pub rows: usize,
+    #[serde(default)]
+    pub padding: Option<Vec2>,
+    #[serde(default)]
+    pub offset: Option<Vec2>,
+}
+
+/// An asset loader for [`TextureAtlas`]s from JSON or YAML.
+pub struct TextureAtlasLoader;
+
+impl bevy::asset::AssetLoader for TextureAtlasLoader {
+    fn load<'a>(
+        &'a self,
+        bytes: &'a [u8],
+        load_context: &'a mut bevy::asset::LoadContext,
+    ) -> bevy::utils::BoxedFuture<'a, Result<(), bevy::asset::Error>> {
+        Box::pin(async move {
+            let self_path = &load_context.path().to_owned();
+            let mut dependencies = Vec::with_capacity(1);
+
+            let mut meta: AtlasMeta = if self_path.extension() == Some(OsStr::new("json")) {
+                serde_json::from_slice(bytes)?
+            } else {
+                serde_yaml::from_slice(bytes)?
+            };
+
+            meta.image.load(load_context, &mut dependencies);
+
+            load_context.set_default_asset(
+                LoadedAsset::new(TextureAtlas::from_grid(
+                    meta.image.get_bevy_handle_untyped().typed(),
+                    meta.tile_size,
+                    meta.columns,
+                    meta.rows,
+                    meta.padding,
+                    meta.offset,
+                ))
+                .with_dependencies(dependencies),
+            );
+
+            Ok(())
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["atlas.json", "atlas.yml", "atlas.yaml"]
+    }
+}

--- a/crates/bones_bevy_renderer/src/lib.rs
+++ b/crates/bones_bevy_renderer/src/lib.rs
@@ -15,6 +15,8 @@ pub mod prelude {
     pub use crate::*;
 }
 
+mod asset;
+
 /// This is a trait that must be implemented for your Bevy resource containing the bones
 /// [`World`][bones::World].
 ///
@@ -53,25 +55,23 @@ pub struct BevyBonesEntity;
 
 impl<W: HasBonesWorld> Plugin for BonesRendererPlugin<W> {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(CoreStage::Last, render_world::<W>);
+        app
+            // Install the asset loader for .atlas.yaml files.
+            .add_asset_loader(asset::TextureAtlasLoader)
+            // Add the world sync systems
+            .add_system_to_stage(CoreStage::Last, sync_sprites::<W>)
+            .add_system_to_stage(CoreStage::Last, sync_atlas_sprites::<W>)
+            .add_system_to_stage(CoreStage::Last, sync_cameras::<W>);
     }
 }
 
 /// The system that renders the bones world.
-fn render_world<W: HasBonesWorld>(
+fn sync_sprites<W: HasBonesWorld>(
+    mut has_init: Local<bool>,
     mut commands: Commands,
     world_resource: Option<ResMut<W>>,
     mut bevy_bones_sprites: Query<
-        (Entity, &mut Handle<Image>, &mut Transform),
-        (With<BevyBonesEntity>, Without<Camera>),
-    >,
-    mut bevy_bones_cameras: Query<
-        (
-            Entity,
-            &mut Camera,
-            &mut OrthographicProjection,
-            &mut Transform,
-        ),
+        (Entity, &mut Handle<Image>, &mut Sprite, &mut Transform),
         With<BevyBonesEntity>,
     >,
 ) {
@@ -81,24 +81,30 @@ fn render_world<W: HasBonesWorld>(
 
     let world = world_resource.world();
 
+    if !*has_init {
+        world.components.init::<bones::Sprite>();
+        world.components.init::<bones::Transform>();
+        *has_init = true;
+    }
+
     let entities = world.resources.get::<bones::Entities>();
     let entities = entities.borrow();
     let sprites = world.components.get::<bones::Sprite>();
     let sprites = sprites.borrow();
     let transforms = world.components.get::<bones::Transform>();
     let transforms = transforms.borrow();
-    let cameras = world.components.get::<bones::Camera>();
-    let cameras = cameras.borrow();
 
     // Sync sprites
     let mut sprites_bitset = sprites.bitset().clone();
     sprites_bitset.bit_and(transforms.bitset());
     let mut bones_sprite_entity_iter = entities.iter_with_bitset(&sprites_bitset);
-    for (bevy_ent, mut image, mut transform) in &mut bevy_bones_sprites {
+    for (bevy_ent, mut image, mut sprite, mut transform) in &mut bevy_bones_sprites {
         if let Some(bones_ent) = bones_sprite_entity_iter.next() {
             let bones_sprite = sprites.get(bones_ent).unwrap();
             let bones_transform = transforms.get(bones_ent).unwrap();
 
+            sprite.flip_x = bones_sprite.flip_x;
+            sprite.flip_y = bones_sprite.flip_y;
             *image = bones_sprite.image.get_bevy_handle_untyped().typed();
             *transform = bones_transform.into_bevy();
         } else {
@@ -118,6 +124,109 @@ fn render_world<W: HasBonesWorld>(
             BevyBonesEntity,
         ));
     }
+}
+
+/// The system that renders the bones world.
+fn sync_atlas_sprites<W: HasBonesWorld>(
+    mut has_init: Local<bool>,
+    mut commands: Commands,
+    world_resource: Option<ResMut<W>>,
+    mut bevy_bones_atlases: Query<
+        (
+            Entity,
+            &mut Handle<TextureAtlas>,
+            &mut TextureAtlasSprite,
+            &mut Transform,
+        ),
+        With<BevyBonesEntity>,
+    >,
+) {
+    let Some(mut world_resource) = world_resource else {
+        return;
+    };
+
+    let world = world_resource.world();
+
+    if !*has_init {
+        world.components.init::<bones::AtlasSprite>();
+        world.components.init::<bones::Transform>();
+        *has_init = true;
+    }
+
+    let entities = world.resources.get::<bones::Entities>();
+    let entities = entities.borrow();
+    let atlas_sprites = world.components.get::<bones::AtlasSprite>();
+    let atlas_sprites = atlas_sprites.borrow();
+    let transforms = world.components.get::<bones::Transform>();
+    let transforms = transforms.borrow();
+
+    // Sync atlas sprites
+    let mut atlas_bitset = atlas_sprites.bitset().clone();
+    atlas_bitset.bit_and(transforms.bitset());
+    let mut bones_atlas_sprite_entity_iter = entities.iter_with_bitset(&atlas_bitset);
+    for (bevy_ent, mut image, mut atlas_sprite, mut transform) in &mut bevy_bones_atlases {
+        if let Some(bones_ent) = bones_atlas_sprite_entity_iter.next() {
+            let bones_atlas = atlas_sprites.get(bones_ent).unwrap();
+            let bones_transform = transforms.get(bones_ent).unwrap();
+
+            *image = bones_atlas.atlas.get_bevy_handle_untyped().typed();
+            *transform = bones_transform.into_bevy();
+
+            atlas_sprite.index = bones_atlas.index;
+            atlas_sprite.flip_x = bones_atlas.flip_x;
+            atlas_sprite.flip_y = bones_atlas.flip_y;
+        } else {
+            commands.entity(bevy_ent).despawn();
+        }
+    }
+    for bones_ent in bones_atlas_sprite_entity_iter {
+        let bones_atlas = atlas_sprites.get(bones_ent).unwrap();
+        let bones_transform = transforms.get(bones_ent).unwrap();
+
+        commands.spawn((
+            SpriteSheetBundle {
+                texture_atlas: bones_atlas.atlas.get_bevy_handle_untyped().typed(),
+                transform: bones_transform.into_bevy(),
+                ..default()
+            },
+            BevyBonesEntity,
+        ));
+    }
+}
+
+/// The system that renders the bones world.
+fn sync_cameras<W: HasBonesWorld>(
+    mut has_init: Local<bool>,
+    mut commands: Commands,
+    world_resource: Option<ResMut<W>>,
+    mut bevy_bones_cameras: Query<
+        (
+            Entity,
+            &mut Camera,
+            &mut OrthographicProjection,
+            &mut Transform,
+        ),
+        With<BevyBonesEntity>,
+    >,
+) {
+    let Some(mut world_resource) = world_resource else {
+        return;
+    };
+
+    let world = world_resource.world();
+
+    if !*has_init {
+        world.components.init::<bones::Transform>();
+        world.components.init::<bones::Camera>();
+        *has_init = true;
+    }
+
+    let entities = world.resources.get::<bones::Entities>();
+    let entities = entities.borrow();
+    let transforms = world.components.get::<bones::Transform>();
+    let transforms = transforms.borrow();
+    let cameras = world.components.get::<bones::Camera>();
+    let cameras = cameras.borrow();
 
     // Sync cameras
     let mut cameras_bitset = cameras.bitset().clone();

--- a/crates/bones_render/src/sprite.rs
+++ b/crates/bones_render/src/sprite.rs
@@ -8,10 +8,40 @@ use crate::prelude::*;
 #[ulid = "01GNJGPQ8TKA234G1EA510BD96"]
 pub struct Image;
 
+/// An atlas image asset type, contains no data, but [`Handle<Atlas>`] is still useful becaause it
+/// uniquely represents an atlas asset that may be rendered outside of the core.
+#[derive(Copy, Clone, TypeUlid, Debug)]
+#[ulid = "01GNYXD7FVC46C7A3273HMEBRA"]
+pub struct Atlas;
+
 /// A 2D sprite component
 #[derive(Clone, TypeUlid, Debug)]
 #[ulid = "01GNJXPWZKS6BHJEG1SX5B93DA"]
 pub struct Sprite {
     /// The sprite image handle.
     pub image: Handle<Image>,
+    /// Whether or not the flip the sprite horizontally.
+    pub flip_x: bool,
+    /// Whether or not the flip the sprite vertically.
+    pub flip_y: bool,
+}
+
+/// An animated sprite component.
+///
+/// Represents one or more [`Atlas`]s stacked on top of each other, and possibly animated through a
+/// range of frames out of the atlas.
+#[derive(Debug, Default, Clone, TypeUlid)]
+#[ulid = "01GNYXFHC6T3NS061GMVFBXFYE"]
+pub struct AtlasSprite {
+    /// This is the current index in the animation, with an `idx` of `0` meaning that the index in
+    /// the sprite sheet will be `start`.
+    ///
+    /// If the idx is greater than `end - start`, then the animation will loop around.
+    pub index: usize,
+    /// The atlas handle.
+    pub atlas: Handle<Atlas>,
+    /// Whether or not the flip the sprite horizontally.
+    pub flip_x: bool,
+    /// Whether or not the flip the sprite vertically.
+    pub flip_y: bool,
 }


### PR DESCRIPTION
Adds the `bones_render` types for atlas sprites,
and renders them in `bones_bevy_renderer`.

This also adds an asset loader for `.atlas.yaml`/`.atlas.json` files
which can be used when you need to load a `Handle<Atlas>`
in a `BonesBevyAsset` struct.