### PR TITLE
[Merged by Bors] - fix(bones_ecs)!: fix unsound component iterators.

### DIFF
--- a/crates/bones_ecs/src/components/untyped.rs
+++ b/crates/bones_ecs/src/components/untyped.rs
@@ -332,15 +332,8 @@ impl UntypedComponentStore {
     ) -> UntypedComponentBitsetIteratorMut {
         UntypedComponentBitsetIteratorMut {
             current_id: 0,
-            components: if self.layout.size() > 0 {
-                Some(self.storage.chunks_exact_mut(self.layout.size()))
-            } else {
-                None
-            },
-            components_bitset: &self.bitset,
+            components: self,
             bitset,
-            layout: self.layout,
-            max_id: self.max_id,
         }
     }
 


### PR DESCRIPTION
The component iterators were casting pointers to byte slices,
but they should have been returning raw pointers instead.

This also simplified the mutable iterator implementation.

This fixed strange behavior in a non-minimal test repository,
where mutating the transform component of one entity somehow
applied to the transform of another entity at the same time.

BREAKING_CHANGE: untyped component iterators now return raw pointers instead of slices.