### PR TITLE
[Merged by Bors] - feat(bones_bevy_asset): add derive macro for `BonesBevyAssetLoad`.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -22,7 +22,7 @@ pub mod prelude {
 use bones_bevy_utils::BevyWorld;
 use prelude::*;
 
-pub use bones_bevy_asset_macros::BonesBevyAsset;
+pub use bones_bevy_asset_macros::{BonesBevyAsset, BonesBevyAssetLoad};
 
 #[doc(hidden)]
 pub mod _private {


### PR DESCRIPTION
This makes it easier to nest asset structs that have handles that need loading.