### PR TITLE
[Merged by Bors] - feat(bones_ecs)!: add improved iteration API.

### DIFF
--- a/crates/bones_ecs/examples/pos_vel.rs
+++ b/crates/bones_ecs/examples/pos_vel.rs
@@ -53,24 +53,16 @@ fn setup_system(
 
 /// Update the Pos of all entities with both a Pos and a Vel
 fn pos_vel_system(entities: Res<Entities>, mut pos: CompMut<Pos>, vel: Comp<Vel>) {
-    let mut bitset = pos.bitset().clone();
-    bitset.bit_and(vel.bitset());
-    for entity in entities.iter_with_bitset(&bitset) {
-        let pos = pos.get_mut(entity).unwrap();
-        let vel = vel.get(entity).unwrap();
+    for (_, (pos, vel)) in entities.iter_with((&mut pos, &vel)) {
         **pos += **vel;
     }
 }
 
 /// Print the Pos and Vel of every entity
-fn print_system(entities: Res<Entities>, pos: Comp<Pos>, vel: Comp<Vel>) {
+fn print_system(pos: Comp<Pos>, vel: Comp<Vel>, entities: Res<Entities>) {
     println!("=====");
-    let mut bitset = pos.bitset().clone();
-    bitset.bit_and(vel.bitset());
-    for entity in entities.iter_with_bitset(&bitset) {
-        let pos = pos.get(entity).unwrap();
-        let vel = vel.get(entity).unwrap();
 
+    for (_, (pos, vel)) in entities.iter_with((&pos, &vel)) {
         println!("{pos:?} \t- {vel:?}");
     }
 }

--- a/crates/bones_ecs/src/components/iterator.rs
+++ b/crates/bones_ecs/src/components/iterator.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, rc::Rc};
 
 use crate::prelude::*;
 
@@ -65,7 +65,7 @@ impl<'a, T: 'static> Iterator for ComponentBitsetIteratorMut<'a, T> {
 pub struct UntypedComponentBitsetIterator<'a> {
     pub(crate) current_id: usize,
     pub(crate) components: &'a UntypedComponentStore,
-    pub(crate) bitset: &'a BitSetVec,
+    pub(crate) bitset: Rc<BitSetVec>,
 }
 
 impl<'a> Iterator for UntypedComponentBitsetIterator<'a> {
@@ -96,7 +96,7 @@ impl<'a> Iterator for UntypedComponentBitsetIterator<'a> {
 pub struct UntypedComponentBitsetIteratorMut<'a> {
     pub(crate) current_id: usize,
     pub(crate) components: &'a mut UntypedComponentStore,
-    pub(crate) bitset: &'a BitSetVec,
+    pub(crate) bitset: Rc<BitSetVec>,
 }
 
 impl<'a> Iterator for UntypedComponentBitsetIteratorMut<'a> {
@@ -138,8 +138,8 @@ mod test {
 
         components.insert(e, A);
 
-        let bitset = BitSetVec::default();
-        assert_eq!(components.iter_with_bitset(&bitset).count(), 0);
-        assert_eq!(components.iter_mut_with_bitset(&bitset).count(), 0);
+        let bitset = Rc::new(BitSetVec::default());
+        assert_eq!(components.iter_with_bitset(bitset.clone()).count(), 0);
+        assert_eq!(components.iter_mut_with_bitset(bitset).count(), 0);
     }
 }

--- a/crates/bones_ecs/src/components/typed.rs
+++ b/crates/bones_ecs/src/components/typed.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, marker::PhantomData, sync::Arc};
+use std::{alloc::Layout, marker::PhantomData, rc::Rc, sync::Arc};
 
 use bytemuck::Pod;
 
@@ -121,17 +121,14 @@ impl<T: TypedEcsData> ComponentStore<T> {
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> ComponentBitsetIterator<T> {
+    pub fn iter_with_bitset(&self, bitset: Rc<BitSetVec>) -> ComponentBitsetIterator<T> {
         self.ops.iter_with_bitset(&self.components, bitset)
     }
 
     /// Iterates mutable over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_mut_with_bitset<'a>(
-        &'a mut self,
-        bitset: &'a BitSetVec,
-    ) -> ComponentBitsetIteratorMut<T> {
+    pub fn iter_mut_with_bitset(&mut self, bitset: Rc<BitSetVec>) -> ComponentBitsetIteratorMut<T> {
         self.ops.iter_mut_with_bitset(&mut self.components, bitset)
     }
 
@@ -218,7 +215,7 @@ impl<'a, T: TypedEcsData> AtomicComponentStoreRef<'a, T> {
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_with_bitset<'b>(&'b self, bitset: &'b BitSetVec) -> ComponentBitsetIterator<T> {
+    pub fn iter_with_bitset(&self, bitset: Rc<BitSetVec>) -> ComponentBitsetIterator<T> {
         self.ops.iter_with_bitset(&self.components, bitset)
     }
 
@@ -283,7 +280,7 @@ impl<'a, T: TypedEcsData> AtomicComponentStoreRefMut<'a, T> {
     /// entities.
     ///
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_with_bitset<'b>(&'b self, bitset: &'b BitSetVec) -> ComponentBitsetIterator<T> {
+    pub fn iter_with_bitset(&self, bitset: Rc<BitSetVec>) -> ComponentBitsetIterator<T> {
         self.ops.iter_with_bitset(&self.components, bitset)
     }
 
@@ -291,10 +288,7 @@ impl<'a, T: TypedEcsData> AtomicComponentStoreRefMut<'a, T> {
     /// entities.
     ///
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_mut_with_bitset<'b>(
-        &'b mut self,
-        bitset: &'b BitSetVec,
-    ) -> ComponentBitsetIteratorMut<T> {
+    pub fn iter_mut_with_bitset(&mut self, bitset: Rc<BitSetVec>) -> ComponentBitsetIteratorMut<T> {
         self.ops.iter_mut_with_bitset(&mut self.components, bitset)
     }
 

--- a/crates/bones_ecs/src/components/typed/ops.rs
+++ b/crates/bones_ecs/src/components/typed/ops.rs
@@ -2,6 +2,7 @@ use std::{
     marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
     ops::DerefMut,
+    rc::Rc,
 };
 
 use crate::prelude::*;
@@ -119,7 +120,7 @@ impl<T: Clone + 'static> TypedComponentOps<T> {
     pub fn iter_with_bitset<'a>(
         &'a self,
         components: &'a UntypedComponentStore,
-        bitset: &'a BitSetVec,
+        bitset: Rc<BitSetVec>,
     ) -> ComponentBitsetIterator<'a, T> {
         // SAFE: Constructing `TypedComponentOps` is unsafe and user affirms the type T is valid for
         // the underlying, untyped data.
@@ -131,7 +132,7 @@ impl<T: Clone + 'static> TypedComponentOps<T> {
     pub fn iter_mut_with_bitset<'a>(
         &'a self,
         components: &'a mut UntypedComponentStore,
-        bitset: &'a BitSetVec,
+        bitset: Rc<BitSetVec>,
     ) -> ComponentBitsetIteratorMut<T> {
         // SAFE: Constructing `TypedComponentOps` is unsafe and user affirms the type T is valid for
         // the underlying, untyped data.

--- a/crates/bones_ecs/src/components/untyped.rs
+++ b/crates/bones_ecs/src/components/untyped.rs
@@ -4,6 +4,7 @@ use aligned_vec::AVec;
 use std::{
     alloc::Layout,
     ptr::{self},
+    rc::Rc,
 };
 
 /// Holds components of a given type indexed by `Entity`.
@@ -314,7 +315,7 @@ impl UntypedComponentStore {
     /// entities.
     ///
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> UntypedComponentBitsetIterator {
+    pub fn iter_with_bitset(&self, bitset: Rc<BitSetVec>) -> UntypedComponentBitsetIterator {
         UntypedComponentBitsetIterator {
             current_id: 0,
             components: self,
@@ -326,9 +327,9 @@ impl UntypedComponentStore {
     /// entities.
     ///
     /// Slower than `iter()` but allows joining between multiple component types.
-    pub fn iter_mut_with_bitset<'a>(
-        &'a mut self,
-        bitset: &'a BitSetVec,
+    pub fn iter_mut_with_bitset(
+        &mut self,
+        bitset: Rc<BitSetVec>,
     ) -> UntypedComponentBitsetIteratorMut {
         UntypedComponentBitsetIteratorMut {
             current_id: 0,

--- a/crates/bones_ecs/src/world.rs
+++ b/crates/bones_ecs/src/world.rs
@@ -107,12 +107,7 @@ mod tests {
 
     /// Mutates the positions based on the velocities.
     fn pos_vel_system(entities: Res<Entities>, mut pos: CompMut<Pos>, vel: Comp<Vel>) {
-        let mut bitset = pos.bitset().clone();
-        bitset.bit_and(vel.bitset());
-        for entity in entities.iter_with_bitset(&bitset) {
-            let pos = pos.get_mut(entity).unwrap();
-            let vel = vel.get(entity).unwrap();
-
+        for (_, (pos, vel)) in entities.iter_with((&mut pos, &vel)) {
             pos.0 += vel.0;
             pos.1 += vel.1;
         }
@@ -126,13 +121,10 @@ mod tests {
         marker: Comp<Marker>,
     ) {
         let mut i = 0;
-        let mut bitset = pos.bitset().clone();
-        bitset.bit_and(vel.bitset());
-        bitset.bit_or(marker.bitset());
-        for entity in entities.iter_with_bitset(&bitset) {
-            match (i, pos.get(entity), vel.get(entity), marker.get(entity)) {
-                (0, Some(Pos(0, 100)), Some(Vel(0, -1)), None)
-                | (1, Some(Pos(0, 0)), Some(Vel(1, 1)), Some(Marker)) => (),
+        for (entity, (pos, vel)) in entities.iter_with((&pos, &vel)) {
+            let marker = marker.get(entity);
+            match (i, pos, vel, marker) {
+                (0, Pos(0, 100), Vel(0, -1), None) | (1, Pos(0, 0), Vel(1, 1), Some(Marker)) => (),
                 x => unreachable!("{:?}", x),
             }
             i += 1;
@@ -149,13 +141,11 @@ mod tests {
         marker: Comp<Marker>,
     ) {
         let mut i = 0;
-        let mut bitset = pos.bitset().clone();
-        bitset.bit_and(vel.bitset());
-        bitset.bit_or(marker.bitset());
-        for entity in entities.iter_with_bitset(&bitset) {
-            match (i, pos.get(entity), vel.get(entity), marker.get(entity)) {
-                (0, Some(Pos(0, 99)), Some(Vel(0, -1)), None)
-                | (1, Some(Pos(1, 1)), Some(Vel(1, 1)), Some(Marker)) => (),
+        for (entity, (pos, vel)) in entities.iter_with((&pos, &vel)) {
+            let marker = marker.get(entity);
+            dbg!(i, entity);
+            match (i, pos, vel, marker) {
+                (0, Pos(0, 99), Vel(0, -1), None) | (1, Pos(1, 1), Vel(1, 1), Some(Marker)) => (),
                 x => unreachable!("{:?}", x),
             }
             i += 1;


### PR DESCRIPTION
Added a more convenient replacement for the old `join!` macro.

`Entities::iter_with()` now gives you the ability to join over multiple
entities without a macro.

It doesn't let you provide optional components yet, but that's something
facilitated by the existing traits, it just needs to be implemented.

BREAKING_CHANGE: switched iter_with_bitset functions back to taking an `Rc` bitmap.