### PR TITLE
docs: document source repository in cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Opinionated game meta-engine built on Bevy"
 authors = ["The Fish Folks & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+repository = "https://github.com/fishfolk/bones"
 
 [workspace]
 members = [

--- a/crates/bones_asset/Cargo.toml
+++ b/crates/bones_asset/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 bones_ecs = { path = "../bones_ecs" }

--- a/crates/bones_bevy_asset/Cargo.toml
+++ b/crates/bones_bevy_asset/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 bones_bevy_asset_macros = { path = "./macros" }

--- a/crates/bones_bevy_asset/macros/Cargo.toml
+++ b/crates/bones_bevy_asset/macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [lib]
 proc-macro = true

--- a/crates/bones_bevy_renderer/Cargo.toml
+++ b/crates/bones_bevy_renderer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 bones_lib = { path = "../../", features = ["bevy"] }

--- a/crates/bones_bevy_utils/Cargo.toml
+++ b/crates/bones_bevy_utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 type_ulid = { path = "../type_ulid" }

--- a/crates/bones_ecs/Cargo.toml
+++ b/crates/bones_ecs/Cargo.toml
@@ -7,7 +7,7 @@ description = "A tiny but very powerful ECS framework."
 keywords = ["game", "ecs"]
 categories = ["game-engines"]
 license = "Apache-2.0"
-repository = "https://github.com/fishfolk/jumpy"
+repository = "https://github.com/fishfolk/bones"
 
 [features]
 default = ["keysize16"]

--- a/crates/bones_has_load_progress/Cargo.toml
+++ b/crates/bones_has_load_progress/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies.bevy]
 version = "0.9.1"

--- a/crates/bones_has_load_progress/macros/Cargo.toml
+++ b/crates/bones_has_load_progress/macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [lib]
 proc-macro = true

--- a/crates/bones_input/Cargo.toml
+++ b/crates/bones_input/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 type_ulid = { path = "../type_ulid" }

--- a/crates/bones_matchmaker/Cargo.toml
+++ b/crates/bones_matchmaker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 anyhow = "1.0.66"

--- a/crates/bones_matchmaker_proto/Cargo.toml
+++ b/crates/bones_matchmaker_proto/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }

--- a/crates/bones_render/Cargo.toml
+++ b/crates/bones_render/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 bones_ecs = { path = "../bones_ecs" }

--- a/crates/quinn_runtime_bevy/Cargo.toml
+++ b/crates/quinn_runtime_bevy/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
 quinn = { version = "0.9.1", default-features = false, features = ["native-certs", "tls-rustls"] }

--- a/crates/type_ulid/Cargo.toml
+++ b/crates/type_ulid/Cargo.toml
@@ -2,6 +2,7 @@
 name = "type_ulid"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/fishfolk/bones"
 
 [features]
 default = ["std"]

--- a/crates/type_ulid/macros/Cargo.toml
+++ b/crates/type_ulid/macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fishfolk/bones"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
I noticed that the `repository` key under `bones_ecs` pointed to https://github.com/fishfolk/jumpy.

From the [cargo reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field):
> The repository field should be a URL to the source repository for your package.

While fixing this I decided I might as well include the manifest key for the other crates in the repository. This will be helpful if we plan to publish this crate to crates.io in future.