### PR TITLE
[Merged by Bors] - refactor(bones_bevy_asset,bones_bevy_utils)!: make world in `BevyWorld` resource optional.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -141,7 +141,10 @@ pub struct BevyAssets<'a, T: bevy_asset::Asset> {
 impl<'a, T: bevy_asset::Asset> std::ops::Deref for BevyAssets<'a, T> {
     type Target = bevy_asset::Assets<T>;
     fn deref(&self) -> &Self::Target {
-        self.cell.resource::<Assets<T>>()
+        self.cell
+            .as_ref()
+            .expect("Bevy world not present in `BevyWorld` resource.")
+            .resource::<Assets<T>>()
     }
 }
 

--- a/crates/bones_bevy_utils/src/lib.rs
+++ b/crates/bones_bevy_utils/src/lib.rs
@@ -5,8 +5,6 @@
 #![cfg_attr(doc, allow(unknown_lints))]
 #![deny(rustdoc::all)]
 
-use std::sync::Arc;
-
 use type_ulid::TypeUlid;
 
 /// The prelude.
@@ -27,12 +25,22 @@ pub trait IntoBevy<To> {
 /// One way to do this is to [`std::mem::swap`] an empty world in the [`BevyWorld`]` resource, with
 /// the actual Bevy world, immediatley before running the bones ECS systems. Then you can swap it
 /// back once the bones systems finish.
-#[derive(TypeUlid, Clone, Default)]
+#[derive(TypeUlid, Default)]
 #[ulid = "01GNX5CJAAHS31DA9HXZ2CF74B"]
-pub struct BevyWorld(Arc<bevy_ecs::world::World>);
+pub struct BevyWorld(pub Option<bevy_ecs::world::World>);
+
+impl Clone for BevyWorld {
+    fn clone(&self) -> Self {
+        if self.0.is_some() {
+            panic!("BevyWorld may not be cloned.");
+        } else {
+            Self(None)
+        }
+    }
+}
 
 impl std::ops::Deref for BevyWorld {
-    type Target = Arc<bevy_ecs::world::World>;
+    type Target = Option<bevy_ecs::world::World>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
Since the bevy world can't be cloned, we previously had it in
an Arc, but that didn't play nicely with world snapshots.

Now the bevy world inside the `BevyWorld` resource is an
option, with the `BevyAssets` system param panicking if it
doesn't find the world when it needs it.