### PR TITLE
[Merged by Bors] - feat(bones_lib)!: make `bones_bevy_utils` an optional dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [features]
-bevy = ["bones_asset/bevy", "bones_asset/has_load_progress", "bones_render/bevy"]
+bevy = ["bones_asset/bevy", "bones_asset/has_load_progress", "bones_render/bevy", "dep:bones_bevy_utils"]
 serde = ["dep:serde", "bones_render/serde"]
 
 [dependencies]
@@ -22,6 +22,6 @@ bones_ecs = { path = "./crates/bones_ecs" }
 bones_render = { path = "./crates/bones_render" }
 bones_input = { path = "./crates/bones_input" }
 bones_asset = { path = "./crates/bones_asset" }
-bones_bevy_utils = { path = "./crates/bones_bevy_utils" }
+bones_bevy_utils = { path = "./crates/bones_bevy_utils", optional = true }
 type_ulid = { path = "./crates/type_ulid" }
 serde = { version = "1.0.0", features = ["derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! Opinionated game meta-engine built on Bevy.
 
 #[doc(inline)]
-pub use {
-    bones_asset as asset, bones_bevy_utils as bevy_utils, bones_ecs as ecs, bones_input as input,
-    bones_render as render,
-};
+pub use {bones_asset as asset, bones_ecs as ecs, bones_input as input, bones_render as render};
+
+#[cfg(feature = "bevy")]
+pub use bones_bevy_utils as bevy_utils;
 
 /// Bones lib prelude
 pub mod prelude {


### PR DESCRIPTION
This reduces dependencies if you want to use `bones_lib` without Bevy.

BREAKING_CHANGE: the `bevy` feature must be provided to use the `bevy_utils` module.