### PR TITLE
[Merged by Bors] - feat(bones_ecs)!: implement `Commands` system parameter.

### DIFF
--- a/crates/bones_ecs/examples/pos_vel.rs
+++ b/crates/bones_ecs/examples/pos_vel.rs
@@ -32,7 +32,7 @@ fn main() {
 
     // Run our game loop for 10 frames
     for _ in 0..10 {
-        dispatcher.run(&world).unwrap();
+        dispatcher.run(&mut world).unwrap();
     }
 }
 


### PR DESCRIPTION
The `Commands` parameter can be used to schedule systems that
should run at the end of the current stage.

BREAKING_CHANGE: the `SystemStage::run()` method now takes &mut World instead of &World.