### PR TITLE
[Merged by Bors] - fix(bones_lib): fix sprite animation bug.

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -106,7 +106,10 @@ pub fn animate_sprites(
 
         if animated_sprite.timer > 1.0 / animated_sprite.fps.max(f32::MIN_POSITIVE) {
             animated_sprite.timer = 0.0;
-            if atlas_sprite.index >= animated_sprite.end {
+
+            if atlas_sprite.index < animated_sprite.start {
+                atlas_sprite.index = animated_sprite.start;
+            } else if atlas_sprite.index >= animated_sprite.end {
                 if animated_sprite.repeat {
                     atlas_sprite.index = animated_sprite.start;
                 } else {


### PR DESCRIPTION
Fixes the behavior when an atlas sprite's current index is less
than the starting index of an animated sprite.

Previously it would play the animation from wherever the current
index happened to be, but it was supposed to skip to the animation
start frame.