### PR TITLE
[Merged by Bors] - refactor(bones_lib): temporarily vendor 1D perlin noise.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,17 +2167,18 @@ source = "git+https://github.com/bsurmanski/noise-rs?rev=5abdde1b819eccc47e74969
 dependencies = [
  "num-traits",
  "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand_xorshift",
 ]
 
 [[package]]
 name = "noise"
 version = "0.8.2"
-source = "git+https://github.com/Razaekel/noise-rs?rev=1a2b5e0880656e8d2ae1025df576d70180d7592a#1a2b5e0880656e8d2ae1025df576d70180d7592a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba869e17168793186c10ca82c7079a4ffdeac4f1a7d9e755b9491c028180e40"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
- "rand_xorshift 0.3.0",
+ "rand 0.7.3",
+ "rand_xorshift",
 ]
 
 [[package]]
@@ -2696,15 +2697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ bevy = ["bones_asset/bevy", "bones_asset/has_load_progress", "bones_render/bevy"
 serde = ["dep:serde", "bones_render/serde"]
 
 [dependencies]
-bones_ecs = { path = "./crates/bones_ecs" }
-bones_render = { path = "./crates/bones_render" }
-bones_input = { path = "./crates/bones_input" }
-bones_asset = { path = "./crates/bones_asset" }
-bones_bevy_utils = { path = "./crates/bones_bevy_utils", optional = true }
-type_ulid = { path = "./crates/type_ulid" }
+bones_ecs = { version = "0.1.0", path = "./crates/bones_ecs" }
+bones_render = { version = "0.1.0", path = "./crates/bones_render" }
+bones_input = { version = "0.1.0", path = "./crates/bones_input" }
+bones_asset = { version = "0.1.0", path = "./crates/bones_asset" }
+bones_bevy_utils = { version = "0.1.0", path = "./crates/bones_bevy_utils", optional = true }
+type_ulid = { version = "0.1.0", path = "./crates/type_ulid" }
 serde = { version = "1.0.0", features = ["derive"], optional = true }
-# For now we are pointing at a git rev but this should be rectified when a new release is made.
-# See https://github.com/Razaekel/noise-rs/pull/281.
-noise = { git = "https://github.com/Razaekel/noise-rs", rev = "1a2b5e0880656e8d2ae1025df576d70180d7592a" }
+noise = "0.8.2"


### PR DESCRIPTION
We're waiting on the noise crate to publish a release supporting
1D perlin noise, so in the meantime we vendor the `perlin_1d` function
and use it directly.