### PR TITLE
Release `bones_matchmaker` and `bones_bevy_asset`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "bones_bevy_asset_macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/bones_bevy_asset/CHANGELOG.md
+++ b/crates/bones_bevy_asset/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 (2023-01-18)
+
+<csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/>
+<csr-id-de43e3cf45b9108bebecd4196aa7524c87758e35/>
+<csr-id-ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31/>
+<csr-id-ef12c3fb681cc826199b1564e1a033a56a5ce2d4/>
 
 ### Chore
 
  - <csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/> add missing crate descriptions.
+
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
 
 ### Documentation
 
@@ -21,15 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 
+<csr-id-3206a4d9559df5e9aafdc22e7c464308e3a9eac7/>
+
  - <csr-id-c0a14c5681a82d8e2db725a678b3dbccfa8a80b4/> implement `BonesBevyAssetLoad` for more types.
    Added implementations for `Option`, `HashMap`,
    and `bevy_utils::HashMap` when the values implement
    `BonesBevyAssetLoad`.
  - <csr-id-7fd1c592c61e3032d803b8f70364b826b4a9ebaf/> add extra derive support & type implementations.
    - The derive macro for `BonesBevyAssetLoad` can now be used on enums.
-   - Added more implementations of `BonesBevyAssetLoad` for primitive types.
- - <csr-id-3206a4d9559df5e9aafdc22e7c464308e3a9eac7/> add derive macro for `BonesBevyAssetLoad`.
-   This makes it easier to nest asset structs that have handles that need loading.
+- Added more implementations of `BonesBevyAssetLoad` for primitive types.
 
 ### Style
 
@@ -59,9 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 9 commits contributed to the release over the course of 14 calendar days.
- - 9 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 8 unique issues were worked on: [#29](https://github.com/fishfolk/bones/issues/29), [#33](https://github.com/fishfolk/bones/issues/33), [#37](https://github.com/fishfolk/bones/issues/37), [#39](https://github.com/fishfolk/bones/issues/39), [#41](https://github.com/fishfolk/bones/issues/41), [#52](https://github.com/fishfolk/bones/issues/52), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65)
+ - 11 commits contributed to the release over the course of 14 calendar days.
+ - 10 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 9 unique issues were worked on: [#29](https://github.com/fishfolk/bones/issues/29), [#33](https://github.com/fishfolk/bones/issues/33), [#37](https://github.com/fishfolk/bones/issues/37), [#39](https://github.com/fishfolk/bones/issues/39), [#41](https://github.com/fishfolk/bones/issues/41), [#52](https://github.com/fishfolk/bones/issues/52), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65), [#67](https://github.com/fishfolk/bones/issues/67)
 
 ### Commit Details
 
@@ -85,7 +94,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - prepare for release. ([`ae0a761`](https://github.com/fishfolk/bones/commit/ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31))
  * **[#65](https://github.com/fishfolk/bones/issues/65)**
     - add missing crate descriptions. ([`2725246`](https://github.com/fishfolk/bones/commit/27252465ad0506ff2f8c377531fa079ec64d1750))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
  * **Uncategorized**
+    - Release type_ulid_macros v0.1.0, type_ulid v0.1.0, bones_bevy_utils v0.1.0, bones_ecs v0.1.0, bones_asset v0.1.0, bones_input v0.1.0, bones_render v0.1.0, bones_lib v0.1.0 ([`db0333d`](https://github.com/fishfolk/bones/commit/db0333ddacb6f29aed8664db67973e72ea586dce))
     - implement `BonesBevyAssetLoad` for more types. ([`c0a14c5`](https://github.com/fishfolk/bones/commit/c0a14c5681a82d8e2db725a678b3dbccfa8a80b4))
 </details>
+
+<csr-unknown>
+ add derive macro for BonesBevyAssetLoad.This makes it easier to nest asset structs that have handles that need loading.<csr-unknown/>
 

--- a/crates/bones_bevy_asset/Cargo.toml
+++ b/crates/bones_bevy_asset/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/fishfolk/bones"
 
 [dependencies]
-bones_bevy_asset_macros = { version = "0.1.0", path = "./macros" }
+bones_bevy_asset_macros = { version = "^0.2.0", path = "./macros" }
 type_ulid = { version = "^0.1.0", path = "../type_ulid" }
 uuid = "1.0.0"
 serde = { version = "1.0.0", features = ["derive"] }

--- a/crates/bones_bevy_asset/macros/CHANGELOG.md
+++ b/crates/bones_bevy_asset/macros/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.0 (2023-01-18)
+
+<csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/>
 
 ### Chore
 
  - <csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/> add missing crate descriptions.
+
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
 
 ### Documentation
 
@@ -21,11 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 
+<csr-id-3206a4d9559df5e9aafdc22e7c464308e3a9eac7/>
+
  - <csr-id-7fd1c592c61e3032d803b8f70364b826b4a9ebaf/> add extra derive support & type implementations.
    - The derive macro for `BonesBevyAssetLoad` can now be used on enums.
-   - Added more implementations of `BonesBevyAssetLoad` for primitive types.
- - <csr-id-3206a4d9559df5e9aafdc22e7c464308e3a9eac7/> add derive macro for `BonesBevyAssetLoad`.
-   This makes it easier to nest asset structs that have handles that need loading.
+- Added more implementations of `BonesBevyAssetLoad` for primitive types.
 
 ### New Features (BREAKING)
 
@@ -36,9 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 5 commits contributed to the release over the course of 14 calendar days.
- - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 5 unique issues were worked on: [#29](https://github.com/fishfolk/bones/issues/29), [#33](https://github.com/fishfolk/bones/issues/33), [#37](https://github.com/fishfolk/bones/issues/37), [#39](https://github.com/fishfolk/bones/issues/39), [#65](https://github.com/fishfolk/bones/issues/65)
+ - 6 commits contributed to the release over the course of 14 calendar days.
+ - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 6 unique issues were worked on: [#29](https://github.com/fishfolk/bones/issues/29), [#33](https://github.com/fishfolk/bones/issues/33), [#37](https://github.com/fishfolk/bones/issues/37), [#39](https://github.com/fishfolk/bones/issues/39), [#65](https://github.com/fishfolk/bones/issues/65), [#67](https://github.com/fishfolk/bones/issues/67)
 
 ### Commit Details
 
@@ -56,5 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - add extra derive support & type implementations. ([`7fd1c59`](https://github.com/fishfolk/bones/commit/7fd1c592c61e3032d803b8f70364b826b4a9ebaf))
  * **[#65](https://github.com/fishfolk/bones/issues/65)**
     - add missing crate descriptions. ([`2725246`](https://github.com/fishfolk/bones/commit/27252465ad0506ff2f8c377531fa079ec64d1750))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
 </details>
+
+<csr-unknown>
+ add derive macro for BonesBevyAssetLoad.This makes it easier to nest asset structs that have handles that need loading.<csr-unknown/>
 

--- a/crates/bones_bevy_asset/macros/Cargo.toml
+++ b/crates/bones_bevy_asset/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bones_bevy_asset_macros"
 description = "Macros for the bones_bevy_asset crate."
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["The Fish Folk & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"

--- a/crates/bones_bevy_renderer/CHANGELOG.md
+++ b/crates/bones_bevy_renderer/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 (2023-01-18)
+
+<csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/>
+<csr-id-ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31/>
 
 ### Chore
 
  - <csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/> add missing crate descriptions.
+
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
 
 ### Documentation
 
@@ -42,8 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    placement so that the tiles render from their bottom-left corner.
  - <csr-id-f8f41ede20fa921f10404be22c24062fafef5eae/> fix bugs in tilemap renderer.
    - Fix issue where tiles were being rendered off into the far right side
-     of the map.
-   - Fix issue where tiles were not being cleared from the previous frame
+   of the map.
+- Fix issue where tiles were not being cleared from the previous frame
      before updating them for the current frame.
 
 ### New Features (BREAKING)
@@ -86,9 +93,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 13 commits contributed to the release over the course of 16 calendar days.
- - 13 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 12 unique issues were worked on: [#26](https://github.com/fishfolk/bones/issues/26), [#29](https://github.com/fishfolk/bones/issues/29), [#30](https://github.com/fishfolk/bones/issues/30), [#31](https://github.com/fishfolk/bones/issues/31), [#35](https://github.com/fishfolk/bones/issues/35), [#37](https://github.com/fishfolk/bones/issues/37), [#40](https://github.com/fishfolk/bones/issues/40), [#43](https://github.com/fishfolk/bones/issues/43), [#45](https://github.com/fishfolk/bones/issues/45), [#51](https://github.com/fishfolk/bones/issues/51), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65)
+ - 15 commits contributed to the release over the course of 16 calendar days.
+ - 14 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 13 unique issues were worked on: [#26](https://github.com/fishfolk/bones/issues/26), [#29](https://github.com/fishfolk/bones/issues/29), [#30](https://github.com/fishfolk/bones/issues/30), [#31](https://github.com/fishfolk/bones/issues/31), [#35](https://github.com/fishfolk/bones/issues/35), [#37](https://github.com/fishfolk/bones/issues/37), [#40](https://github.com/fishfolk/bones/issues/40), [#43](https://github.com/fishfolk/bones/issues/43), [#45](https://github.com/fishfolk/bones/issues/45), [#51](https://github.com/fishfolk/bones/issues/51), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65), [#67](https://github.com/fishfolk/bones/issues/67)
 
 ### Commit Details
 
@@ -120,7 +127,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - prepare for release. ([`ae0a761`](https://github.com/fishfolk/bones/commit/ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31))
  * **[#65](https://github.com/fishfolk/bones/issues/65)**
     - add missing crate descriptions. ([`2725246`](https://github.com/fishfolk/bones/commit/27252465ad0506ff2f8c377531fa079ec64d1750))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
  * **Uncategorized**
+    - Release type_ulid_macros v0.1.0, type_ulid v0.1.0, bones_bevy_utils v0.1.0, bones_ecs v0.1.0, bones_asset v0.1.0, bones_input v0.1.0, bones_render v0.1.0, bones_lib v0.1.0 ([`db0333d`](https://github.com/fishfolk/bones/commit/db0333ddacb6f29aed8664db67973e72ea586dce))
     - move entity sync to stage before `CoreStage::PostUpdate`. ([`5116014`](https://github.com/fishfolk/bones/commit/5116014e0fd7f886ba208dd161f567ce021f3f8e))
 </details>
 

--- a/crates/bones_bevy_renderer/Cargo.toml
+++ b/crates/bones_bevy_renderer/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.0", features = ["derive"] }
 glam = "0.22.0"
 serde_yaml = "0.9.16"
 serde_json = "1.0.91"
-bones_bevy_asset = { version = "0.1.0", path = "../bones_bevy_asset" }
+bones_bevy_asset = { version = "^0.1.0", path = "../bones_bevy_asset" }
 # TODO: Update when PR merged: https://github.com/forbjok/bevy_simple_tilemap/pull/9
 bevy_simple_tilemap = { git = "https://github.com/zicklag/bevy_simple_tilemap.git", branch = "build/slim-down-bevy-dependencies" }
 

--- a/crates/bones_matchmaker/CHANGELOG.md
+++ b/crates/bones_matchmaker/CHANGELOG.md
@@ -5,12 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 (2023-01-18)
+
+<csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/>
+<csr-id-49852b7f9d448334dfb66f4ab7c0310ec339f908/>
+<csr-id-a516a68902ebcd4c3e24b6a47b3ff79b92ff5f60/>
+<csr-id-ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31/>
 
 ### Chore
 
  - <csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/> add missing crate descriptions.
  - <csr-id-49852b7f9d448334dfb66f4ab7c0310ec339f908/> update dependencies
+
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
 
 ### Documentation
 
@@ -40,9 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 6 commits contributed to the release over the course of 26 calendar days.
- - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 4 unique issues were worked on: [#37](https://github.com/fishfolk/bones/issues/37), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65), [#7](https://github.com/fishfolk/bones/issues/7)
+ - 7 commits contributed to the release over the course of 26 calendar days.
+ - 7 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 5 unique issues were worked on: [#37](https://github.com/fishfolk/bones/issues/37), [#63](https://github.com/fishfolk/bones/issues/63), [#65](https://github.com/fishfolk/bones/issues/65), [#67](https://github.com/fishfolk/bones/issues/67), [#7](https://github.com/fishfolk/bones/issues/7)
 
 ### Commit Details
 
@@ -56,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - prepare for release. ([`ae0a761`](https://github.com/fishfolk/bones/commit/ae0a761fc9b82ba2fc639c2b6f7af09fb650cd31))
  * **[#65](https://github.com/fishfolk/bones/issues/65)**
     - add missing crate descriptions. ([`2725246`](https://github.com/fishfolk/bones/commit/27252465ad0506ff2f8c377531fa079ec64d1750))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
  * **[#7](https://github.com/fishfolk/bones/issues/7)**
     - update dependencies ([`49852b7`](https://github.com/fishfolk/bones/commit/49852b7f9d448334dfb66f4ab7c0310ec339f908))
  * **Uncategorized**

--- a/crates/bones_matchmaker/Cargo.toml
+++ b/crates/bones_matchmaker/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/fishfolk/bones"
 [dependencies]
 anyhow = "1.0.66"
 bevy_tasks = "0.9.1"
-bones_matchmaker_proto = { version = "0.1.0", path = "../bones_matchmaker_proto" }
+bones_matchmaker_proto = { version = "^0.1.0", path = "../bones_matchmaker_proto" }
 bytes = "1.2.1"
 clap = { version = "4.0.18", features = ["derive", "env"] }
 either = "1.8.0"
@@ -19,7 +19,7 @@ futures-lite = "1.12.0"
 once_cell = "1.15.0"
 postcard = { version = "1.0.2", default-features = false, features = ["alloc"] }
 quinn = { version = "0.9", default-features = false, features = ["futures-io", "native-certs", "tls-rustls"] }
-quinn_runtime_bevy = { version = "0.1.0", path = "../quinn_runtime_bevy" }
+quinn_runtime_bevy = { version = "^0.1.0", path = "../quinn_runtime_bevy" }
 rand = "0.8.5"
 rcgen = "0.10.0"
 rustls = { version = "0.20.7", features = ["dangerous_configuration", "quic"] }

--- a/crates/bones_matchmaker_proto/CHANGELOG.md
+++ b/crates/bones_matchmaker_proto/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 (2023-01-18)
+
+<csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/>
+<csr-id-7444eb5ac898f97eefd3cec0c2687d4bea66da9e/>
 
 ### Chore
 
  - <csr-id-27252465ad0506ff2f8c377531fa079ec64d1750/> add missing crate descriptions.
  - <csr-id-7444eb5ac898f97eefd3cec0c2687d4bea66da9e/> remove unused dependency on `ulid` crate.
+
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
 
 ### Documentation
 
@@ -28,9 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 4 commits contributed to the release over the course of 26 calendar days.
- - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 3 unique issues were worked on: [#14](https://github.com/fishfolk/bones/issues/14), [#37](https://github.com/fishfolk/bones/issues/37), [#65](https://github.com/fishfolk/bones/issues/65)
+ - 5 commits contributed to the release over the course of 26 calendar days.
+ - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 4 unique issues were worked on: [#14](https://github.com/fishfolk/bones/issues/14), [#37](https://github.com/fishfolk/bones/issues/37), [#65](https://github.com/fishfolk/bones/issues/65), [#67](https://github.com/fishfolk/bones/issues/67)
 
 ### Commit Details
 
@@ -44,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - document source repository in cargo manifest. ([`a693894`](https://github.com/fishfolk/bones/commit/a69389412d22b8cb48bab0ed96d739b0fee35348))
  * **[#65](https://github.com/fishfolk/bones/issues/65)**
     - add missing crate descriptions. ([`2725246`](https://github.com/fishfolk/bones/commit/27252465ad0506ff2f8c377531fa079ec64d1750))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
  * **Uncategorized**
     - migrate crates from the jumpy repository ([`3724c69`](https://github.com/fishfolk/bones/commit/3724c69a0bb24828d1710380bb8d139e304b7955))
 </details>

--- a/crates/quinn_runtime_bevy/CHANGELOG.md
+++ b/crates/quinn_runtime_bevy/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 (2023-01-18)
+
+<csr-id-98ae10e7d49a0facc20e08729865c6bc1ebca37a/>
 
 ### Documentation
 
@@ -23,13 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - <csr-id-98ae10e7d49a0facc20e08729865c6bc1ebca37a/> update bevy_tasks dependency to 0.9.1
 
+### Chore
+
+ - <csr-id-a68cb79e6b7d3774c53c0236edf3a12175f297b5/> generate changelogs for all crates.
+
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 3 commits contributed to the release over the course of 26 calendar days.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 2 unique issues were worked on: [#37](https://github.com/fishfolk/bones/issues/37), [#8](https://github.com/fishfolk/bones/issues/8)
+ - 4 commits contributed to the release over the course of 26 calendar days.
+ - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 3 unique issues were worked on: [#37](https://github.com/fishfolk/bones/issues/37), [#67](https://github.com/fishfolk/bones/issues/67), [#8](https://github.com/fishfolk/bones/issues/8)
 
 ### Commit Details
 
@@ -39,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * **[#37](https://github.com/fishfolk/bones/issues/37)**
     - document source repository in cargo manifest. ([`a693894`](https://github.com/fishfolk/bones/commit/a69389412d22b8cb48bab0ed96d739b0fee35348))
+ * **[#67](https://github.com/fishfolk/bones/issues/67)**
+    - generate changelogs for all crates. ([`a68cb79`](https://github.com/fishfolk/bones/commit/a68cb79e6b7d3774c53c0236edf3a12175f297b5))
  * **[#8](https://github.com/fishfolk/bones/issues/8)**
     - update bevy_tasks dependency to 0.9.1 ([`98ae10e`](https://github.com/fishfolk/bones/commit/98ae10e7d49a0facc20e08729865c6bc1ebca37a))
  * **Uncategorized**


### PR DESCRIPTION
Unfortunately, we have a git dependency on `bevy_smiple_tilemap` which broke the automated release of that crate.

Also, trying to release it again, ended up bumping `bones_bevy_asset_macros` to v0.2.0. :/ Not that big a deal I guess.