### PR TITLE
[Merged by Bors] - build(bones_bevy_renderer): switch to released version of `bevy_simple_tilemap`.

### DIFF
--- a/crates/bones_bevy_renderer/Cargo.toml
+++ b/crates/bones_bevy_renderer/Cargo.toml
@@ -16,7 +16,7 @@ serde_yaml = "0.9.16"
 serde_json = "1.0.91"
 bones_bevy_asset = { version = "^0.1.0", path = "../bones_bevy_asset" }
 # TODO: Update when PR merged: https://github.com/forbjok/bevy_simple_tilemap/pull/9
-bevy_simple_tilemap = { git = "https://github.com/zicklag/bevy_simple_tilemap.git", branch = "build/slim-down-bevy-dependencies" }
+bevy_simple_tilemap = "0.10.0"
 
 [dependencies.bevy]
 version = "0.9.1"


### PR DESCRIPTION
This temporarily increases our list of Bevy feature dependencies as we wait for the
[PR](https://github.com/forbjok/bevy_simple_tilemap/pull/9) to reduce the required
bevy features, but it allows us to publish the crate to crates.io.