### PR TITLE
[Merged by Bors] - feat: add `get_many_mut()` method to `CompMut`.

### DIFF
--- a/crates/bones_ecs/src/components/typed.rs
+++ b/crates/bones_ecs/src/components/typed.rs
@@ -255,6 +255,17 @@ impl<'a, T: TypedEcsData> AtomicComponentStoreRefMut<'a, T> {
         self.ops.get_mut(&mut self.components, entity)
     }
 
+    /// Get mutable pointers to the component data for multiple entities at the same time.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the same entity is specified multiple times. This is invalid because it
+    /// would mean you would have two mutable references to the same component data at the same
+    /// time.
+    pub fn get_many_mut<const N: usize>(&mut self, entities: [Entity; N]) -> [Option<&mut T>; N] {
+        self.ops.get_many_mut(&mut self.components, entities)
+    }
+
     /// Removes the component of [`Entity`].
     ///
     /// Returns the component that was on the entity, if any.

--- a/crates/bones_ecs/src/entities.rs
+++ b/crates/bones_ecs/src/entities.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 /// Entities are conceptual "things" which possess attributes (Components). As an exemple, a Car
 /// (Entity) has a Color (Component), a Position (Component) and a Speed (Component).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Entity(u32, u32);
 impl Entity {
     /// Creates a new `Entity` from the provided index and generation.


### PR DESCRIPTION
This allows you to mutably borrow the component for multiple entities
at the same time, which was otherwise difficult, unsafe, or inefficient
to do previously.