### PR TITLE
[Merged by Bors] - fix(bones_ecs): fix returned component order in `get_many_mut()`.

### DIFF
--- a/crates/bones_ecs/src/components.rs
+++ b/crates/bones_ecs/src/components.rs
@@ -135,7 +135,7 @@ mod test {
                     my_datas.insert(ent2, MyData(8));
 
                     {
-                        let [data1, data2] = my_datas.get_many_mut([ent1, ent2]).unwrap_many();
+                        let [data2, data1] = my_datas.get_many_mut([ent2, ent1]).unwrap_many();
 
                         data1.0 = 0;
                         data2.0 = 1;

--- a/crates/bones_ecs/src/components/untyped.rs
+++ b/crates/bones_ecs/src/components/untyped.rs
@@ -203,19 +203,17 @@ impl UntypedComponentStore {
     /// This will panic if the same entity is specified multiple times. This is invalid because it
     /// would mean you would have two mutable references to the same component data at the same
     /// time.
-    pub fn get_many_mut<const N: usize>(
-        &mut self,
-        mut entities: [Entity; N],
-    ) -> [Option<*mut u8>; N] {
-        // Sort the slice
-        entities.sort_unstable();
+    pub fn get_many_mut<const N: usize>(&mut self, entities: [Entity; N]) -> [Option<*mut u8>; N] {
+        // Sort a copy of the passed in entities list.
+        let mut sorted = entities;
+        sorted.sort_unstable();
         // Detect duplicates.
         //
-        // Since we have sorted the slice, any duplicates be adjacent to each-other, and we only
-        // have to make sure that for every item in the slice, the one after it is not the same as
-        // it.
+        // Since we have sorted the slice, any duplicates will be adjacent to each-other, and we
+        // only have to make sure that for every item in the slice, the one after it is not the same
+        // as it.
         for i in 0..(N - 1) {
-            if entities[i] == entities[i + 1] {
+            if sorted[i] == sorted[i + 1] {
                 panic!("All entities passed to `get_multiple_mut()` must be unique.");
             }
         }


### PR DESCRIPTION
`get_many_mut()` was previously not returning the components
in the same order as the entities list.