### PR TITLE
[Merged by Bors] - feat: implement BonesBevyAssetLoad for `Key`.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -163,7 +163,8 @@ impl_default_traits!(
     glam::Vec2,
     glam::Vec3,
     glam::UVec2,
-    bool
+    bool,
+    bones_lib::prelude::Key
 );
 
 /// Bones [`SystemParam`][bones_lib::ecs::system::SystemParam] for borrowing bevy


### PR DESCRIPTION
This makes it easier to deserialize `Key`s in bevy assets.