### PR TITLE
[Merged by Bors] - feat!: add `from_world` implementation similar to Bevy.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -163,7 +163,8 @@ impl_default_traits!(
     glam::Vec2,
     glam::Vec3,
     glam::UVec2,
-    bool
+    bool,
+    bones_lib::prelude::Key
 );
 
 /// Bones [`SystemParam`][bones_lib::ecs::system::SystemParam] for borrowing bevy
@@ -189,7 +190,7 @@ impl<'a, T: bevy_asset::Asset> bones_lib::ecs::system::SystemParam for BevyAsset
     fn initialize(_world: &mut bones::World) {}
 
     fn get_state(world: &bones::World) -> Self::State {
-        world.resources.get::<BevyWorld>()
+        world.resource::<BevyWorld>()
     }
 
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {

--- a/crates/bones_bevy_renderer/src/lib.rs
+++ b/crates/bones_bevy_renderer/src/lib.rs
@@ -92,9 +92,9 @@ fn sync_clear_color<W: HasBonesWorld>(
         return;
     };
     let world = world_resource.world();
-    world.resources.init::<bones::ClearColor>();
+    world.init_resource::<bones::ClearColor>();
 
-    let bones_clear_color = world.resources.get::<bones::ClearColor>();
+    let bones_clear_color = world.resource::<bones::ClearColor>();
     let bones_clear_color = bones_clear_color.borrow();
 
     clear_color.0 = Color::from(bones_clear_color.0);
@@ -120,7 +120,7 @@ fn sync_sprites<W: HasBonesWorld>(
     world.components.init::<bones::Sprite>();
     world.components.init::<bones::Transform>();
 
-    let entities = world.resources.get::<bones::Entities>();
+    let entities = world.resource::<bones::Entities>();
     let entities = entities.borrow();
     let sprites = world.components.get::<bones::Sprite>();
     let sprites = sprites.borrow();
@@ -183,7 +183,7 @@ fn sync_atlas_sprites<W: HasBonesWorld>(
     world.components.init::<bones::AtlasSprite>();
     world.components.init::<bones::Transform>();
 
-    let entities = world.resources.get::<bones::Entities>();
+    let entities = world.resource::<bones::Entities>();
     let entities = entities.borrow();
     let atlas_sprites = world.components.get::<bones::AtlasSprite>();
     let atlas_sprites = atlas_sprites.borrow();
@@ -248,7 +248,7 @@ fn sync_cameras<W: HasBonesWorld>(
     world.components.init::<bones::Transform>();
     world.components.init::<bones::Camera>();
 
-    let entities = world.resources.get::<bones::Entities>();
+    let entities = world.resource::<bones::Entities>();
     let entities = entities.borrow();
     let transforms = world.components.get::<bones::Transform>();
     let transforms = transforms.borrow();
@@ -322,7 +322,7 @@ fn sync_tilemaps<W: HasBonesWorld>(
     world.components.init::<bones::Tile>();
     world.components.init::<bones::TileLayer>();
 
-    let entities = world.resources.get::<bones::Entities>();
+    let entities = world.resource::<bones::Entities>();
     let entities = entities.borrow();
     let tiles = world.components.get::<bones::Tile>();
     let tiles = tiles.borrow();
@@ -449,7 +449,7 @@ fn sync_path2ds<W: HasBonesWorld>(
     world.components.init::<bones::Path2d>();
     world.components.init::<bones::Transform>();
 
-    let entities = world.resources.get::<bones::Entities>();
+    let entities = world.resource::<bones::Entities>();
     let entities = entities.borrow();
     let path2ds = world.components.get::<bones::Path2d>();
     let path2ds = path2ds.borrow();

--- a/crates/bones_ecs/src/resources.rs
+++ b/crates/bones_ecs/src/resources.rs
@@ -1,13 +1,11 @@
 //! World resource storage.
 
-use std::ops::DerefMut;
 use std::{
     alloc::{self, Layout},
     any::TypeId,
     io::Write,
     marker::PhantomData,
     mem,
-    ops::Deref,
     ptr::NonNull,
     sync::Arc,
 };
@@ -297,21 +295,6 @@ impl<T: TypedEcsData> AtomicResource<T> {
         let borrow = self.untyped.borrow_mut();
         // SAFE: We know that the data pointer is valid for type T.
         AtomicRefMut::map(borrow, |data| unsafe { &mut *data.cast::<T>() })
-    }
-}
-impl<R: TypedEcsData> Deref for AtomicResource<R> {
-    type Target = R;
-
-    fn deref(&self) -> &Self::Target {
-        // SAFE: We know that the data pointer is valid for type UntypedResource.
-        unsafe { &*self.untyped.borrow().cast::<R>() }
-    }
-}
-
-impl<R: TypedEcsData> DerefMut for AtomicResource<R> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFE: We know that the data pointer is valid for type UntypedResource.
-        unsafe { &mut *self.untyped.borrow_mut().cast::<R>() }
     }
 }
 

--- a/crates/bones_ecs/src/stage.rs
+++ b/crates/bones_ecs/src/stage.rs
@@ -76,13 +76,15 @@ impl SystemStages {
         &mut self,
         label: L,
         stage: S,
-    ) {
+    ) -> &mut Self {
         let stage_idx = self
             .stages
             .iter()
-            .position(|x| x.id() == CoreStage::PreUpdate.id())
+            .position(|x| x.id() == label.id())
             .unwrap_or_else(|| panic!("Could not find stage with label `{}`", label.name()));
         self.stages.insert(stage_idx, Box::new(stage));
+
+        self
     }
 
     /// Insert a new stage, after another existing stage
@@ -91,13 +93,15 @@ impl SystemStages {
         &mut self,
         label: L,
         stage: S,
-    ) {
+    ) -> &mut Self {
         let stage_idx = self
             .stages
             .iter()
-            .position(|x| x.id() == CoreStage::PreUpdate.id())
+            .position(|x| x.id() == label.id())
             .unwrap_or_else(|| panic!("Could not find stage with label `{}`", label.name()));
         self.stages.insert(stage_idx + 1, Box::new(stage));
+
+        self
     }
 }
 
@@ -161,7 +165,7 @@ impl SystemStage for SimpleSystemStage {
 
         // Drain the command queue
         {
-            let command_queue = world.resources.get::<CommandQueue>();
+            let command_queue = world.resource::<CommandQueue>();
             let mut command_queue = command_queue.borrow_mut();
 
             for mut system in command_queue.queue.drain(..) {
@@ -174,7 +178,7 @@ impl SystemStage for SimpleSystemStage {
     }
 
     fn initialize(&mut self, world: &mut World) {
-        world.resources.init::<CommandQueue>();
+        world.init_resource::<CommandQueue>();
         for system in &mut self.systems {
             system.initialize(world);
         }
@@ -270,7 +274,7 @@ impl<'a> SystemParam for Commands<'a> {
     fn initialize(_world: &mut World) {}
 
     fn get_state(world: &World) -> Self::State {
-        world.resources.get::<CommandQueue>()
+        world.resource::<CommandQueue>()
     }
 
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {

--- a/crates/bones_ecs/src/system.rs
+++ b/crates/bones_ecs/src/system.rs
@@ -159,10 +159,10 @@ impl<'a, T: TypedEcsData + Default> SystemParam for Res<'a, T> {
     type Param<'p> = Res<'p, T>;
 
     fn initialize(world: &mut World) {
-        world.resources.init::<T>()
+        world.init_resource::<T>()
     }
     fn get_state(world: &World) -> Self::State {
-        world.resources.get::<T>()
+        world.resource::<T>()
     }
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         Res(state.borrow())
@@ -174,10 +174,10 @@ impl<'a, T: TypedEcsData + Default> SystemParam for ResMut<'a, T> {
     type Param<'p> = ResMut<'p, T>;
 
     fn initialize(world: &mut World) {
-        world.resources.init::<T>();
+        world.init_resource::<T>();
     }
     fn get_state(world: &World) -> Self::State {
-        world.resources.get::<T>()
+        world.resource::<T>()
     }
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         ResMut(state.borrow_mut())
@@ -390,7 +390,7 @@ mod tests {
     #[test]
     fn manual_system_run() {
         let mut world = World::default();
-        world.resources.init::<u32>();
+        world.init_resource::<u32>();
     }
 
     #[test]
@@ -414,15 +414,15 @@ mod tests {
         assert!(world.resources.try_get::<B>().is_none());
         my_system.initialize(&mut world);
 
-        let res = world.resources.get::<B>();
+        let res = world.resource::<B>();
         assert_eq!(res.borrow().x, 0);
 
         my_system.run(&world).unwrap();
 
-        let res = world.resources.get::<B>();
+        let res = world.resource::<B>();
         assert_eq!(res.borrow().x, 45);
 
-        let res = world.resources.get::<A>();
+        let res = world.resource::<A>();
         assert_eq!(*res.borrow(), A);
     }
 }

--- a/crates/bones_ecs/src/system.rs
+++ b/crates/bones_ecs/src/system.rs
@@ -161,9 +161,11 @@ impl<'a, T: TypedEcsData + Default> SystemParam for Res<'a, T> {
     fn initialize(world: &mut World) {
         world.init_resource::<T>()
     }
+
     fn get_state(world: &World) -> Self::State {
         world.resource::<T>()
     }
+
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         Res(state.borrow())
     }
@@ -176,9 +178,11 @@ impl<'a, T: TypedEcsData + Default> SystemParam for ResMut<'a, T> {
     fn initialize(world: &mut World) {
         world.init_resource::<T>();
     }
+
     fn get_state(world: &World) -> Self::State {
         world.resource::<T>()
     }
+
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         ResMut(state.borrow_mut())
     }
@@ -196,9 +200,11 @@ impl<'a, T: TypedEcsData> SystemParam for Comp<'a, T> {
     fn initialize(world: &mut World) {
         world.components.init::<T>();
     }
+
     fn get_state(world: &World) -> Self::State {
         world.components.get::<T>()
     }
+
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         state.borrow()
     }
@@ -211,9 +217,11 @@ impl<'a, T: TypedEcsData> SystemParam for CompMut<'a, T> {
     fn initialize(world: &mut World) {
         world.components.init::<T>();
     }
+
     fn get_state(world: &World) -> Self::State {
         world.components.get::<T>()
     }
+
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
         state.borrow_mut()
     }

--- a/crates/bones_ecs/src/world.rs
+++ b/crates/bones_ecs/src/world.rs
@@ -104,7 +104,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if you try to insert a Rust type with a different [`TypeId`], but the same
+    /// Panics if you try to insert a Rust type with a different [`std::any::TypeId`], but the same
     /// [`TypeUlid`] as another resource in the store.
     pub fn insert_resource<R: TypedEcsData>(&mut self, resource: R) {
         self.resources.insert(resource)


### PR DESCRIPTION
Allows resources to be added with either a `Default` implementation,
or a custom `FromWorld` implementation that allows them to derive their,
value from any other data currently in the world.

BREAKING_CHANGE: `world.resources` is now private in favor of functions directly on `World`.
_ _ _