### PR TITLE
feat(bones_ecs): make `Entity::new()` public. (#93)

### DIFF
--- a/crates/bones_ecs/src/entities.rs
+++ b/crates/bones_ecs/src/entities.rs
@@ -16,7 +16,11 @@ use crate::prelude::*;
 pub struct Entity(u32, u32);
 impl Entity {
     /// Creates a new `Entity` from the provided index and generation.
-    pub(crate) fn new(index: u32, generation: u32) -> Entity {
+    ///
+    /// > ⚠️ **Warning:** It is not generally recommended to manually create [`Entity`]s unless you
+    /// > know exactly what you are doing. This can be useful in certain advanced or unusual
+    /// > use-cases, but usually you should use [`Entities::create()`] to spawn entities.
+    pub fn new(index: u32, generation: u32) -> Entity {
         Entity(index, generation)
     }
 


### PR DESCRIPTION
This is important for use cases where you need to manually
serialize/load an entity ID.