### PR TITLE
[Merged by Bors] - feat: add helper for advancing the Time a fixed timestep. 

### DIFF
--- a/crates/bones_input/src/time.rs
+++ b/crates/bones_input/src/time.rs
@@ -147,6 +147,14 @@ impl Time {
         self.last_update = Some(instant);
     }
 
+    /// Advance the time exactly by the given duration.
+    ///
+    /// This is useful when ticking the time exactly by a fixed timestep.
+    pub fn advance_exact(&mut self, duration: Duration) {
+        let next_instant = self.last_update.unwrap_or_else(Instant::now) + duration;
+        self.update_with_instant(next_instant);
+    }
+
     /// Returns how much time has advanced since the last [`update`](#method.update), as a [`Duration`].
     #[inline]
     pub fn delta(&self) -> Duration {


### PR DESCRIPTION
Adds a configurable `sync_time` option to the `BonesRendererPlugin`
so that you can disable the automatic time synchronization in favor of a
custom implementation.

It also moves the time synchronization to a new stage that happens after
`CoreStage::First` so that the time will be in sync during the
`PreUpdate` and `Update` stages.