### PR TITLE
[Merged by Bors] - feat: implement `BonesBevyAssetLoad` for `Duration`.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(rustdoc::all)]
 
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use bevy_app::App;
 use bevy_asset::{prelude::*, Asset};
@@ -64,6 +65,8 @@ pub trait BonesBevyAssetLoad {
         let _ = (load_context, dependencies);
     }
 }
+
+impl BonesBevyAssetLoad for Duration {}
 
 impl<T: TypeUlid> BonesBevyAssetLoad for bones::Handle<T> {
     fn load(


### PR DESCRIPTION
_ _ _
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19tfHmnEDMBt3YYaDMbpaJOT27tGrOiojs%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Cpw2L9s)

For some reason the ignore proerty was not working for me forcing me to derive BonesBevyAssetLoad for duration. LEt me know if there is a better way