### PR TITLE
[Merged by Bors] - fix: makes bones asset path representation more consistent.

### DIFF
--- a/crates/bones_bevy_asset/src/lib.rs
+++ b/crates/bones_bevy_asset/src/lib.rs
@@ -78,10 +78,7 @@ impl<T: TypeUlid> BonesBevyAssetLoad for bones::Handle<T> {
         self.path.normalize_relative_to(load_context.path());
 
         // Create a bevy asset path from this bones handle
-        let asset_path = bevy_asset::AssetPath::new(
-            self.path.path.to_path_buf(),
-            self.path.clone().label.map(|x| x.to_string()),
-        );
+        let asset_path = self.path.get_bevy_asset_path();
         let path_id = asset_path.get_id();
         dependencies.push(asset_path);
 


### PR DESCRIPTION
Previously the normalize method on a bones path would remove the leading
`/` to make it support Bevy paths, which can't start with a `/`, but
this was not consistent with the way that the handle was serialized.

Now, the bones path representations always maintain the leading `/` to
indicate a root path, and the leading `/` is removed when converting to
a Bevy handle.

This fixes issues run into when trying to read serialized bones handles
during map saving in Jumpy.