### PR TITLE
docs: remove old TODO comment re two-step component borrow.

### DIFF
--- a/framework_crates/bones_ecs/src/components.rs
+++ b/framework_crates/bones_ecs/src/components.rs
@@ -52,10 +52,6 @@ impl ComponentStores {
     }
 
     /// Get the components of a certain type
-    // TODO: Attempt to refactor component store so we can avoid the two-step borrow process.
-    //
-    // With resources we were able to avoid this step, but component stores are structured
-    // differently and might need more work.
     pub fn get_cell<T: HasSchema>(&self) -> Result<AtomicComponentStore<T>, EcsError> {
         let untyped = self.get_cell_by_schema_id(T::schema().id())?;
 


### PR DESCRIPTION
This was already fixed in #132.