### PR TITLE
fix: fix soundess issue in bones_ecs related to `UntypedResource` access.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
 
 [[package]]
+name = "atomicell"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157342dd84c64f16899b4b16c1fb2cce54b887990362aac3c590b3d13810890f"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1080,7 @@ name = "bones_ecs"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "atomic_refcell",
+ "atomicell",
  "bitset-core",
  "bones_schema",
  "bones_utils",

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -23,12 +23,12 @@ keysize32 = []
 bones_utils  = { version = "0.3", path = "../bones_utils" }
 bones_schema = { version = "0.3", path = "../bones_schema" }
 
-anyhow         = "1.0"
-atomic_refcell = "0.1"
-bitset-core    = "0.1"
-thiserror      = "1.0"
-glam           = { version = "0.24", optional = true }
-paste          = { version = "1.0", optional = true }
+anyhow      = "1.0"
+atomicell   = "0.1"
+bitset-core = "0.1"
+thiserror   = "1.0"
+glam        = { version = "0.24", optional = true }
+paste       = { version = "1.0", optional = true }
 
 [dev-dependencies]
 glam = "0.24"

--- a/framework_crates/bones_ecs/src/lib.rs
+++ b/framework_crates/bones_ecs/src/lib.rs
@@ -9,7 +9,7 @@ pub mod atomic {
     //! Atomic Refcells are from the [`atomic_refcell`] crate.
     //!
     //! [`atomic_refcell`]: https://docs.rs/atomic_refcell
-    pub use atomic_refcell::*;
+    pub use atomicell::*;
 }
 pub mod bitset;
 pub mod components;
@@ -30,7 +30,7 @@ pub use world::{FromWorld, World};
 /// The prelude.
 pub mod prelude {
     pub use {
-        atomic_refcell::*, bitset_core::BitSet, bones_schema::prelude::*, bones_utils::prelude::*,
+        atomicell::*, bitset_core::BitSet, bones_schema::prelude::*, bones_utils::prelude::*,
     };
 
     pub use crate::{

--- a/framework_crates/bones_ecs/src/stage.rs
+++ b/framework_crates/bones_ecs/src/stage.rs
@@ -301,7 +301,7 @@ impl CommandQueue {
 ///
 /// This is a shortcut for [`ResMut<CommandQueue>`].
 #[derive(Deref, DerefMut)]
-pub struct Commands<'a>(AtomicRefMut<'a, CommandQueue>);
+pub struct Commands<'a>(RefMut<'a, CommandQueue>);
 
 impl<'a> SystemParam for Commands<'a> {
     type State = AtomicResource<CommandQueue>;

--- a/framework_crates/bones_ecs/src/system.rs
+++ b/framework_crates/bones_ecs/src/system.rs
@@ -141,7 +141,7 @@ pub trait SystemParam: Sized {
 /// [`SystemParam`] for getting read access to a resource.
 ///
 /// Use [`Res`] if you want to automatically initialize the resource.
-pub struct Res<'a, T: HasSchema>(AtomicRef<'a, T>);
+pub struct Res<'a, T: HasSchema>(Ref<'a, T>);
 impl<'a, T: HasSchema> std::ops::Deref for Res<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -153,7 +153,7 @@ impl<'a, T: HasSchema> std::ops::Deref for Res<'a, T> {
 /// exist.
 ///
 /// Use [`Res`] if you don't want to automatically initialize the resource.
-pub struct ResInit<'a, T: HasSchema + FromWorld>(AtomicRef<'a, T>);
+pub struct ResInit<'a, T: HasSchema + FromWorld>(Ref<'a, T>);
 impl<'a, T: HasSchema + FromWorld> std::ops::Deref for ResInit<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -164,7 +164,7 @@ impl<'a, T: HasSchema + FromWorld> std::ops::Deref for ResInit<'a, T> {
 /// [`SystemParam`] for getting mutable access to a resource.
 ///
 /// Use [`ResMutInit`] if you want to automatically initialize the resource.
-pub struct ResMut<'a, T: HasSchema>(AtomicRefMut<'a, T>);
+pub struct ResMut<'a, T: HasSchema>(RefMut<'a, T>);
 impl<'a, T: HasSchema> std::ops::Deref for ResMut<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -181,7 +181,7 @@ impl<'a, T: HasSchema> std::ops::DerefMut for ResMut<'a, T> {
 /// already exist.
 ///
 /// Use [`ResMut`] if you don't want to automatically initialize the resource.
-pub struct ResMutInit<'a, T: HasSchema + FromWorld>(AtomicRefMut<'a, T>);
+pub struct ResMutInit<'a, T: HasSchema + FromWorld>(RefMut<'a, T>);
 impl<'a, T: HasSchema + FromWorld> std::ops::Deref for ResMutInit<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -279,12 +279,12 @@ impl<'a, T: HasSchema + FromWorld> SystemParam for ResMutInit<'a, T> {
 }
 
 /// [`SystemParam`] for getting read access to a [`ComponentStore`].
-pub type Comp<'a, T> = AtomicRef<'a, ComponentStore<T>>;
+pub type Comp<'a, T> = Ref<'a, ComponentStore<T>>;
 /// [`SystemParam`] for getting mutable access to a [`ComponentStore`].
-pub type CompMut<'a, T> = AtomicRefMut<'a, ComponentStore<T>>;
+pub type CompMut<'a, T> = RefMut<'a, ComponentStore<T>>;
 
 impl<'a, T: HasSchema> SystemParam for Comp<'a, T> {
-    type State = Arc<AtomicRefCell<ComponentStore<T>>>;
+    type State = Arc<AtomicCell<ComponentStore<T>>>;
     type Param<'p> = Comp<'p, T>;
 
     fn initialize(world: &mut World) {
@@ -301,7 +301,7 @@ impl<'a, T: HasSchema> SystemParam for Comp<'a, T> {
 }
 
 impl<'a, T: HasSchema> SystemParam for CompMut<'a, T> {
-    type State = Arc<AtomicRefCell<ComponentStore<T>>>;
+    type State = Arc<AtomicCell<ComponentStore<T>>>;
     type Param<'p> = CompMut<'p, T>;
 
     fn initialize(world: &mut World) {
@@ -436,8 +436,8 @@ mod tests {
     #[test]
     fn convert_system() {
         fn tmp(
-            _var1: AtomicRef<ComponentStore<u32>>,
-            _var2: AtomicRef<ComponentStore<u64>>,
+            _var1: Ref<ComponentStore<u32>>,
+            _var2: Ref<ComponentStore<u64>>,
             _var3: Res<i32>,
             _var4: ResMut<i64>,
         ) -> SystemResult {

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -113,7 +113,7 @@ impl World {
     /// # Panics
     /// Panics if the resource does not exist in the store.
     #[track_caller]
-    pub fn resource<T: HasSchema>(&self) -> AtomicRef<T> {
+    pub fn resource<T: HasSchema>(&self) -> Ref<T> {
         match self.resources.get::<T>() {
             Some(r) => r,
             None => panic!(
@@ -128,7 +128,7 @@ impl World {
     /// # Panics
     /// Panics if the resource does not exist in the store.
     #[track_caller]
-    pub fn resource_mut<T: HasSchema>(&mut self) -> AtomicRefMut<T> {
+    pub fn resource_mut<T: HasSchema>(&mut self) -> RefMut<T> {
         match self.resources.get_mut::<T>() {
             Some(r) => r,
             None => panic!(
@@ -140,12 +140,12 @@ impl World {
     }
 
     /// Borrow a resource from the world, if it exists.
-    pub fn get_resource<T: HasSchema>(&self) -> Option<AtomicRef<T>> {
+    pub fn get_resource<T: HasSchema>(&self) -> Option<Ref<T>> {
         self.resources.get()
     }
 
     /// Borrow a resource from the world, if it exists.
-    pub fn get_resource_mut<T: HasSchema>(&mut self) -> Option<AtomicRefMut<T>> {
+    pub fn get_resource_mut<T: HasSchema>(&mut self) -> Option<RefMut<T>> {
         self.resources.get_mut()
     }
 }

--- a/framework_crates/bones_framework/src/localization.rs
+++ b/framework_crates/bones_framework/src/localization.rs
@@ -91,7 +91,7 @@ impl LocalizationAsset {
 #[derive(Deref, DerefMut)]
 pub struct Localization<'a, T> {
     #[deref]
-    asset: AtomicRef<'a, LocalizationAsset>,
+    asset: Ref<'a, LocalizationAsset>,
     _phantom: PhantomData<T>,
 }
 
@@ -147,7 +147,7 @@ impl<T: HasSchema> SystemParam for Localization<'_, T> {
             idx.expect(ERR)
         });
 
-        let asset = AtomicRef::map(asset_server, |asset_server| {
+        let asset = Ref::map(asset_server, |asset_server| {
             let root = asset_server.root::<T>().as_schema_ref();
             let handle = root
                 .get_field(*field_idx)

--- a/framework_crates/bones_framework/src/params.rs
+++ b/framework_crates/bones_framework/src/params.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 /// Get the root asset of the core asset pack and cast it to type `T`.
-pub struct Root<'a, T: HasSchema>(AtomicRef<'a, T>);
+pub struct Root<'a, T: HasSchema>(Ref<'a, T>);
 impl<'a, T: HasSchema> std::ops::Deref for Root<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
@@ -19,8 +19,6 @@ impl<'a, T: HasSchema> SystemParam for Root<'a, T> {
         world.resources.get_cell::<AssetServer>().unwrap()
     }
     fn borrow(state: &mut Self::State) -> Self::Param<'_> {
-        Root(AtomicRef::map(state.borrow(), |asset_server| {
-            asset_server.root()
-        }))
+        Root(Ref::map(state.borrow(), |asset_server| asset_server.root()))
     }
 }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -156,7 +156,7 @@ impl Game {
     }
 
     /// Borrow the asset server.
-    pub fn asset_server(&self) -> AtomicRefMut<AssetServer> {
+    pub fn asset_server(&self) -> RefMut<AssetServer> {
         self.asset_server.borrow_mut()
     }
 


### PR DESCRIPTION
Previously it was possible to change the underlying `SchemaBox` for an `UntypedResource` through it's cell, which would allow de-syncing the schema ID of the box, which was relied on for the typed resources store. This would be unsound.

To fix it we prevent accessing the `SchemaBox` in an `UntypedResource` directly and only give out atomic wrappers around `SchemaRef` and `SchemaRefMut`.

This required switching from `atomic_refcell` to `atomicell`, which had the ability to do unsafe maps on the atomic borrows. Both libraries are fundamentally similar in idea and implementation, and I like the way that `atomicell` allows us to create our own borrowed types, so I think it's a benefit either way.