### PR TITLE
feat: make `HasSchema` assume `#[schema(opaque)]` if `#[repr(C)]` is not specified.

### DIFF
--- a/framework_crates/bones_asset/examples/tutorial.rs
+++ b/framework_crates/bones_asset/examples/tutorial.rs
@@ -91,7 +91,6 @@ struct PluginMeta {
 #[derive(HasSchema, Debug, Clone, Default)]
 // We specify the file extensions and the asset loader to use to load the asset.
 #[type_data(asset_loader(["png", "jpg"], ImageAssetLoader))]
-#[schema(opaque)]
 struct Image {
     data: Vec<u8>,
     width: u32,

--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -92,7 +92,6 @@ mod test {
     use super::*;
 
     #[derive(Clone, HasSchema, Default)]
-    #[schema(opaque)]
     struct A;
 
     #[test]

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -47,7 +47,6 @@ impl Entity {
 /// It also holds a list of entities that were recently killed, which allows to remove components of
 /// deleted entities at the end of a game frame.
 #[derive(Clone, HasSchema)]
-#[schema(opaque)]
 pub struct Entities {
     /// Bitset containing all living entities
     alive: BitSetVec,

--- a/framework_crates/bones_ecs/src/stage.rs
+++ b/framework_crates/bones_ecs/src/stage.rs
@@ -268,7 +268,6 @@ impl StageLabel for CoreStage {
 ///
 /// You can use [`Commands`] as a [`SystemParam`] as a shortcut to [`ResMut<CommandQueue>`].
 #[derive(Debug, HasSchema, Default)]
-#[schema(opaque)]
 pub struct CommandQueue {
     /// The system queue that will be run at the end of the stage
     pub queue: VecDeque<System>,

--- a/framework_crates/bones_ecs/src/system.rs
+++ b/framework_crates/bones_ecs/src/system.rs
@@ -494,10 +494,8 @@ mod tests {
     #[test]
     fn system_replace_resource() {
         #[derive(Default, HasSchema, Clone, PartialEq, Eq, Debug)]
-        #[schema(opaque)]
         pub struct A;
         #[derive(Default, HasSchema, Clone, Debug)]
-        #[schema(opaque)]
         pub struct B {
             x: u32,
         }

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -180,7 +180,6 @@ mod tests {
     struct Vel(i32, i32);
 
     #[derive(Clone, HasSchema, Debug, Eq, PartialEq, Default)]
-    #[schema(opaque)]
     struct Marker;
 
     // Sets up the world with a couple entities.
@@ -304,7 +303,6 @@ mod tests {
     // ============
 
     #[derive(Clone, HasSchema, Default)]
-    #[schema(opaque)]
     struct TestResource(u32);
 
     #[derive(Clone, HasSchema)]

--- a/framework_crates/bones_framework/src/animation.rs
+++ b/framework_crates/bones_framework/src/animation.rs
@@ -17,7 +17,6 @@ pub fn plugin(core: &mut Session) {
 
 /// Component that may be added to entities with an [`AtlasSprite`] to animate them.
 #[derive(Clone, HasSchema, Debug)]
-#[schema(opaque)]
 pub struct AnimatedSprite {
     /// The current frame in the animation.
     pub index: usize,
@@ -44,7 +43,6 @@ fn default_true() -> bool {
 /// This is great for players or other sprites that will change through different, named animations
 /// at different times.
 #[derive(Clone, HasSchema, Debug, Default)]
-#[schema(opaque)]
 pub struct AnimationBankSprite {
     /// The current animation.
     pub current: Key,

--- a/framework_crates/bones_framework/src/camera.rs
+++ b/framework_crates/bones_framework/src/camera.rs
@@ -16,7 +16,6 @@ pub fn plugin(core: &mut Session) {
 
 /// Resource providing a noise source for [`CameraShake`] entities to use.
 #[derive(Clone, HasSchema)]
-#[schema(opaque)]
 pub struct ShakeNoise(pub noise::permutationtable::PermutationTable);
 
 impl Default for ShakeNoise {
@@ -95,7 +94,6 @@ impl CameraShake {
 
 /// Queue that can be used to send camera trauma events.
 #[derive(Default, Clone, HasSchema)]
-#[schema(opaque)]
 pub struct CameraTraumaEvents {
     /// The event queue.
     pub queue: VecDeque<f32>,

--- a/framework_crates/bones_framework/src/input/keyboard.rs
+++ b/framework_crates/bones_framework/src/input/keyboard.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 
 /// Resource containing the keyboard input events detected on the current frame.
 #[derive(HasSchema, Clone, Debug, Default)]
-#[schema(opaque)]
 pub struct KeyboardInputs {
     /// The key events that have been detected this frame.
     pub keys: Vec<KeyboardInput>,

--- a/framework_crates/bones_framework/src/input/mouse.rs
+++ b/framework_crates/bones_framework/src/input/mouse.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 
 /// The mouse inputs made this frame.
 #[derive(HasSchema, Clone, Debug, Default)]
-#[schema(opaque)]
 pub struct MouseInputs {
     /// The movement of the mouse this frame.
     pub movement: Vec2,

--- a/framework_crates/bones_framework/src/input/time.rs
+++ b/framework_crates/bones_framework/src/input/time.rs
@@ -18,7 +18,6 @@ pub use timer::*;
 /// A clock that tracks how much it has advanced (and how much real time has elapsed) since
 /// its previous update and since its creation.
 #[derive(Clone, Copy, Debug, HasSchema)]
-#[schema(opaque)]
 pub struct Time {
     startup: Instant,
     last_update: Option<Instant>,

--- a/framework_crates/bones_framework/src/input/time/timer.rs
+++ b/framework_crates/bones_framework/src/input/time/timer.rs
@@ -12,7 +12,6 @@ use super::stopwatch::Stopwatch;
 ///
 /// Paused timers will not have elapsed time increased.
 #[derive(Clone, Debug, Default, HasSchema)]
-#[schema(opaque)]
 pub struct Timer {
     finished: bool,
     mode: TimerMode,

--- a/framework_crates/bones_framework/src/localization.rs
+++ b/framework_crates/bones_framework/src/localization.rs
@@ -98,7 +98,6 @@ pub struct Localization<'a, T> {
 /// Internal resource used to cache the field of the root asset containing the localization resource
 /// for the [`Localization`] parameter.
 #[derive(HasSchema, Default, Clone)]
-#[schema(opaque)]
 pub struct RootLocalizationFieldIdx(OnceLock<usize>);
 
 impl<T: HasSchema> SystemParam for Localization<'_, T> {

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -12,7 +12,6 @@ pub struct AudioSource;
 
 /// Resource containing the audio event queue.
 #[derive(Default, HasSchema, Clone, Debug)]
-#[schema(opaque)]
 pub struct AudioEvents {
     /// List of audio events that haven't been handled by the audio system yet.
     pub queue: VecDeque<AudioEvent>,

--- a/framework_crates/bones_framework/src/render/camera.rs
+++ b/framework_crates/bones_framework/src/render/camera.rs
@@ -6,7 +6,6 @@ use crate::prelude::*;
 ///
 /// The entity must also have a [`Transform`] component for the camera to render anything.
 #[derive(Clone, Copy, Debug, HasSchema)]
-#[schema(opaque)]
 // TODO: make repr(C) when `Option`s are supported.
 // We don't have `Option` support in `bones_schema` right now.
 // Once we do, we can make this type `#[repr(C)]` instead of `#[schema(opaque)]`.
@@ -56,7 +55,6 @@ impl Default for Camera {
 
 /// Resource for controlling the clear color.
 #[derive(Deref, DerefMut, Clone, Copy, HasSchema, Default)]
-#[schema(opaque)]
 pub struct ClearColor(pub Color);
 
 /// Utility function that spawns the camera in a default position.

--- a/framework_crates/bones_framework/src/render/color.rs
+++ b/framework_crates/bones_framework/src/render/color.rs
@@ -9,8 +9,6 @@ use crate::prelude::*;
 /// Color type.
 #[derive(Clone, Copy, Debug, HasSchema)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[schema(opaque)]
-#[repr(C)]
 pub enum Color {
     /// sRGBA color
     Rgba {

--- a/framework_crates/bones_framework/src/render/line.rs
+++ b/framework_crates/bones_framework/src/render/line.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 
 /// A component for rendering a 2D line path, made up of a list of straight line segments.
 #[derive(Clone, Debug, HasSchema)]
-#[schema(opaque)]
 pub struct Path2d {
     /// The color of the path.
     pub color: Color,

--- a/framework_crates/bones_framework/src/render/sprite.rs
+++ b/framework_crates/bones_framework/src/render/sprite.rs
@@ -41,7 +41,6 @@ pub struct Atlas {
 
 /// A 2D sprite component
 #[derive(Clone, HasSchema, Debug, Default)]
-#[repr(C)]
 pub struct Sprite {
     /// The sprite's color tint
     pub color: Color,
@@ -58,7 +57,6 @@ pub struct Sprite {
 /// Represents one or more [`Atlas`]s stacked on top of each other, and possibly animated through a
 /// range of frames out of the atlas.
 #[derive(Debug, Default, Clone, HasSchema)]
-#[repr(C)]
 pub struct AtlasSprite {
     /// The sprite's color tint
     pub color: Color,

--- a/framework_crates/bones_framework/src/render/tilemap.rs
+++ b/framework_crates/bones_framework/src/render/tilemap.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 
 /// A tilemap layer component.
 #[derive(Clone, Debug, HasSchema, Default)]
-#[schema(opaque)]
 pub struct TileLayer {
     /// The vector of tile slots in this layer.
     pub tiles: Vec<Option<Entity>>,

--- a/framework_crates/bones_framework/src/render/ui.rs
+++ b/framework_crates/bones_framework/src/render/ui.rs
@@ -6,12 +6,10 @@ pub use ::egui;
 
 /// Resource containing the [`egui::Context`] that can be used to render UI.
 #[derive(HasSchema, Clone, Debug, Default, Deref, DerefMut)]
-#[schema(opaque)]
 pub struct EguiCtx(pub egui::Context);
 
 /// Resource that maps image handles to their associated egui textures.
 #[derive(HasSchema, Clone, Debug, Default, Deref, DerefMut)]
-#[schema(opaque)]
 pub struct EguiTextures(pub HashMap<Handle<Image>, egui::TextureId>);
 
 /// Resource for configuring egui rendering.

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -256,7 +256,6 @@ impl Game {
 ///
 /// Each session shares the same [`Entities`].
 #[derive(HasSchema, Default, Debug)]
-#[schema(opaque)]
 pub struct Sessions {
     entities: AtomicResource<Entities>,
     map: HashMap<Key, Session>,

--- a/framework_crates/bones_schema/examples/custom_type_data.rs
+++ b/framework_crates/bones_schema/examples/custom_type_data.rs
@@ -6,7 +6,6 @@ use bones_schema::prelude::*;
 ///
 /// In this case we want to store the name of the type in our custom type data.
 #[derive(HasSchema, Clone, Default)]
-#[schema(opaque)]
 struct TypeName(String);
 
 /// In order to make [`TypeName`] derivable, we must implement [`FromType`] for it.

--- a/framework_crates/bones_schema/src/ptr.rs
+++ b/framework_crates/bones_schema/src/ptr.rs
@@ -160,6 +160,13 @@ impl<'pointer> SchemaRef<'pointer> {
 
 /// An untyped mutable reference that knows the [`Schema`] of the pointee and that can be cast to a matching
 /// type.
+// TODO: Re-evaluate whether or not it is necessary to have two lifetimes for `SchemaRefMut`.
+// I believe the current implementation is sound, and the extra liftime is not a huge annoyance, but
+// it would be good to simplify if possible. See the comment below on `parent_lifetime` for a
+// description of the purpose of the second lifetime. We need to maintain the effect of the
+// lifetime, but we might be able to do that by using the '`pointer` lifetime to represent the
+// `'parent` lifetime when necessary. **Note:** This is a little more advanced rust than "normal".
+// This is not a beginner issue.
 pub struct SchemaRefMut<'pointer, 'parent> {
     ptr: PtrMut<'pointer>,
     schema: &'static Schema,

--- a/framework_crates/bones_schema/src/schema.rs
+++ b/framework_crates/bones_schema/src/schema.rs
@@ -144,7 +144,6 @@ pub struct SchemaData {
     /// ```rust
     /// # use bones_schema::prelude::*;
     /// #[derive(HasSchema, Default, Clone)]
-    /// #[schema(opaque)]
     /// struct SomeTypeData;
     ///
     /// impl<T> FromType<T> for SomeTypeData {
@@ -155,7 +154,6 @@ pub struct SchemaData {
     ///
     /// #[derive(HasSchema, Default, Clone)]
     /// #[derive_type_data(SomeTypeData)]
-    /// #[schema(opaque)]
     /// struct MyData;
     /// ```
     pub type_data: SchemaTypeMap,

--- a/framework_crates/bones_schema/tests/tests.rs
+++ b/framework_crates/bones_schema/tests/tests.rs
@@ -26,7 +26,6 @@ struct DataC {
 struct Zst;
 
 #[derive(HasSchema, Debug, Clone, Default)]
-#[schema(opaque)]
 struct OpaqueZst;
 
 #[test]


### PR DESCRIPTION
This makes it much more convenient to derive HasSchema for types that don't need to support scripting or be `#[repr(C)]`.