### PR TITLE
fix: fix asset mixup when two asset files have the same contents in different locations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
  "csscolorparser",
  "document-features",
  "egui",
- "fluent-bundle",
+ "fluent",
  "fluent-langneg",
  "glam",
  "hex",
@@ -1263,9 +1263,9 @@ dependencies = [
  "instant",
  "maybe-owned",
  "parking_lot",
- "rand 0.8.5",
  "serde",
  "smallvec",
+ "turborand",
  "ulid",
  "ustr",
 ]
@@ -2032,6 +2032,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4d7142005e2066e4844caf9f271b93fc79836ee96ec85057b8c109687e629a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
 ]
 
 [[package]]
@@ -4587,6 +4597,16 @@ name = "ttf-parser"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
+
+[[package]]
+name = "turborand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28d61f1c96db8c016037a77961fa5da84fc3a57fe69a15283ace0ab1647bac0"
+dependencies = [
+ "getrandom 0.2.10",
+ "instant",
+]
 
 [[package]]
 name = "type-map"

--- a/framework_crates/bones_asset/src/asset.rs
+++ b/framework_crates/bones_asset/src/asset.rs
@@ -269,7 +269,7 @@ pub struct LoadedAsset {
     /// The pack and path the asset was loaded from.
     pub loc: AssetLoc,
     /// The content IDs of any assets needed by this asset as a dependency.
-    pub dependencies: Arc<AppendOnlyVec<UntypedHandle>>,
+    pub dependencies: Vec<UntypedHandle>,
     /// The loaded data of the asset.
     #[deref]
     pub data: SchemaBox,

--- a/framework_crates/bones_asset/src/handle.rs
+++ b/framework_crates/bones_asset/src/handle.rs
@@ -59,7 +59,7 @@ impl<T> Handle<T> {
 }
 
 /// An untyped handle to an asset.
-#[derive(Default, Clone, Debug, Hash, PartialEq, Eq, Copy)]
+#[derive(Default, Clone, Debug, Hash, PartialEq, Eq, Copy, PartialOrd, Ord)]
 #[repr(C)]
 pub struct UntypedHandle {
     /// The runtime ID of the handle

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -502,10 +502,10 @@ mod storage {
                 else {
                     error!(
                         "\n\nCannot find schema registration for `{}` while loading persisted \
-                    storage. This means you that you need to call \
-                    `{}::schema()` to register your persisted storage type before \
-                    creating the `BonesBevyRenderer` or that there is data from an old \
-                    version of the app inside of the persistent storage file.\n\n",
+                        storage. This means you that you need to call \
+                        `{}::schema()` to register your persisted storage type before \
+                        creating the `BonesBevyRenderer` or that there is data from an old \
+                        version of the app inside of the persistent storage file.\n\n",
                         type_name, type_name,
                     );
                     continue;


### PR DESCRIPTION


Previously assets would get mixed up if they had the same file contents, because the Cid that was used to index them in asset storage would be the same. Now se update the Cid to include the contents of the file, the full name of the schema used to load it, and the Cids of the dependencies.