### PR TITLE
feat: make audio manager easier to to access and remove extra atomic cell.

### DIFF
--- a/demos/features/src/main.rs
+++ b/demos/features/src/main.rs
@@ -427,7 +427,7 @@ fn audio_demo_plugin(session: &mut Session) {
 fn audio_demo_ui(
     ctx: Res<EguiCtx>,
     localization: Localization<GameMeta>,
-    audio: Res<AudioManager>,
+    mut audio: ResMut<AudioManager>,
     meta: Root<GameMeta>,
     assets: Res<AssetServer>,
 ) {
@@ -437,10 +437,7 @@ fn audio_demo_ui(
             ui.vertical_centered(|ui| {
                 ui.add_space(50.0);
                 if ui.button(localization.get("play-sound")).clicked() {
-                    audio
-                        .borrow_mut()
-                        .play(&*assets.get(meta.audio_demo))
-                        .unwrap();
+                    audio.play(&*assets.get(meta.audio_demo)).unwrap();
                 }
             })
         });

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -1,6 +1,6 @@
 //! Audio components.
 
-use std::{io::Cursor, sync::Arc};
+use std::io::Cursor;
 
 use crate::prelude::*;
 
@@ -18,19 +18,18 @@ pub fn game_plugin(game: &mut Game) {
 }
 
 /// The audio manager resource which can be used to play sounds.
-#[derive(HasSchema, Clone, Deref, DerefMut)]
-pub struct AudioManager(Arc<AtomicCell<KiraAudioManager>>);
+#[derive(HasSchema, Deref, DerefMut)]
+#[schema(no_clone)]
+pub struct AudioManager(KiraAudioManager);
 impl Default for AudioManager {
     fn default() -> Self {
-        Self(Arc::new(AtomicCell::new(
-            KiraAudioManager::<CpalBackend>::new(default()).unwrap(),
-        )))
+        Self(KiraAudioManager::<CpalBackend>::new(default()).unwrap())
     }
 }
 
 /// The audio source asset type, contains no data, but [`Handle<AudioSource>`] is still useful
 /// because it uniquely represents a sound/music that may be played outside of bones.
-#[derive(Clone, HasSchema, Debug)]
+#[derive(Clone, HasSchema, Debug, Deref, DerefMut)]
 #[schema(no_default)]
 #[type_data(asset_loader(["ogg", "mp3", "flac", "wav"], AudioLoader))]
 pub struct AudioSource(pub StaticSoundData);


### PR DESCRIPTION
We had put the audio manager in an `Arc<AtomicCell<T>>` so that it could be `Clone`, but that was unnecessary when it is a shared resource that will not be duplicated in network play.