### PR TITLE
fix: make sure input resources are always present.

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -279,6 +279,11 @@ impl BonesBevyRenderer {
             .insert_shared_resource(bones::EguiTextures::default());
         app.insert_resource(BonesImageIds::default());
 
+        // Insert empty inputs that will be updated by the `insert_bones_input` system later.
+        self.game.init_shared_resource::<bones::KeyboardInputs>();
+        self.game.init_shared_resource::<bones::MouseInputs>();
+        self.game.init_shared_resource::<bones::GamepadInputs>();
+
         // Insert the bones data
         app.insert_resource(BonesData {
             asset_server: self


### PR DESCRIPTION
In https://github.com/fishfolk/jumpy/issues/861 it appears that the assets may have finished loading after the input system, but before the update system, leading to the game being ticked without the keyboard inputs.

This initializes all of the input resources to their defaults so that the game will never be ticked without them.