### PR TITLE
test: ignore doc tests for timers to reduce CI time.

### DIFF
--- a/framework_crates/bones_framework/src/time/stopwatch.rs
+++ b/framework_crates/bones_framework/src/time/stopwatch.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// # use bones_framework::prelude::*;
 /// use std::time::Duration;
 /// let mut stopwatch = Stopwatch::new();
@@ -32,7 +32,7 @@ impl Stopwatch {
     /// Create a new unpaused `Stopwatch` with no elapsed time.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let stopwatch = Stopwatch::new();
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
@@ -46,7 +46,7 @@ impl Stopwatch {
     /// of the stopwatch.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -67,7 +67,7 @@ impl Stopwatch {
     /// of the stopwatch, in seconds.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -99,7 +99,7 @@ impl Stopwatch {
     /// Sets the elapsed time of the stopwatch.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -116,7 +116,7 @@ impl Stopwatch {
     /// on elapsed time.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -134,7 +134,7 @@ impl Stopwatch {
     /// paused will not have any effect on the elapsed time.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -151,7 +151,7 @@ impl Stopwatch {
     /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
@@ -170,7 +170,7 @@ impl Stopwatch {
     /// Returns `true` if the stopwatch is paused.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let mut stopwatch = Stopwatch::new();
     /// assert!(!stopwatch.paused());
@@ -187,7 +187,7 @@ impl Stopwatch {
     /// Resets the stopwatch. The reset doesn't affect the paused state of the stopwatch.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut stopwatch = Stopwatch::new();

--- a/framework_crates/bones_framework/src/time/timer.rs
+++ b/framework_crates/bones_framework/src/time/timer.rs
@@ -35,7 +35,7 @@ impl Timer {
     /// Creates a new timer with a given duration in seconds.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// ```
@@ -51,7 +51,7 @@ impl Timer {
     /// See also [`Timer::just_finished`](Timer::just_finished).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -68,7 +68,7 @@ impl Timer {
     /// Returns `true` only on the tick the timer reached its duration.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -88,7 +88,7 @@ impl Timer {
     /// See also [`Stopwatch::elapsed`](Stopwatch::elapsed).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -110,7 +110,7 @@ impl Timer {
     /// Sets the elapsed time of the timer without any other considerations.
     ///
     /// # Example
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -127,7 +127,7 @@ impl Timer {
     /// Returns the duration of the timer.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let timer = Timer::new(Duration::from_secs(1), TimerMode::Once);
@@ -141,7 +141,7 @@ impl Timer {
     /// Sets the duration of the timer.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
@@ -156,7 +156,7 @@ impl Timer {
     /// Returns the mode of the timer.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// assert_eq!(timer.mode(), TimerMode::Repeating);
@@ -169,7 +169,7 @@ impl Timer {
     /// Sets the mode of the timer.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.set_mode(TimerMode::Once);
@@ -193,7 +193,7 @@ impl Timer {
     /// See also [`Stopwatch::tick`](Stopwatch::tick).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -242,7 +242,7 @@ impl Timer {
     /// See also [`Stopwatch::pause`](Stopwatch::pause).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -260,7 +260,7 @@ impl Timer {
     /// See also [`Stopwatch::unpause()`](Stopwatch::unpause).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -280,7 +280,7 @@ impl Timer {
     /// See also [`Stopwatch::paused`](Stopwatch::paused).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// assert!(!timer.paused());
@@ -299,7 +299,7 @@ impl Timer {
     /// See also [`Stopwatch::reset`](Stopwatch::reset).
     ///
     /// Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
@@ -318,7 +318,7 @@ impl Timer {
     /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
@@ -333,7 +333,7 @@ impl Timer {
     /// Returns the percentage of the timer remaining time (goes from 1.0 to 0.0).
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
@@ -348,7 +348,7 @@ impl Timer {
     /// Returns the remaining time in seconds
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::cmp::Ordering;
     /// use std::time::Duration;
@@ -365,7 +365,7 @@ impl Timer {
     /// Returns the remaining time using Duration
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
@@ -384,7 +384,7 @@ impl Timer {
     /// return 0 or 1.
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use bones_framework::prelude::*;
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
@@ -412,7 +412,8 @@ pub enum TimerMode {
     Repeating,
 }
 
-#[cfg(test)]
+// To speed up CI, only do these on miri, where they complete without waiting for time to pass.
+#[cfg(miri)]
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;


### PR DESCRIPTION
It isn't super critical that we test the timers and it is costing us lots of time in CI, so we disable the doc tests and we make some tests only run on miri, where time is faked and the tests complet quickly.