### PR TITLE
feat: add a new `register_schema()` type method to make intent more clear.

### DIFF
--- a/demos/assets_minimal/src/main.rs
+++ b/demos/assets_minimal/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     // We must register all of our asset types before they can be loaded by the asset server. This
     // may be done by calling schema() on each of our types, to register them with the schema
     // registry.
-    GameMeta::schema();
+    GameMeta::register_schema();
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.

--- a/demos/features/src/main.rs
+++ b/demos/features/src/main.rs
@@ -85,7 +85,7 @@ struct PersistedTextData(String);
 
 fn main() {
     // Register persistent data's schema so that it can be loaded by the storage loader.
-    PersistedTextData::schema();
+    PersistedTextData::register_schema();
 
     // Create a bones bevy renderer from our bones game
     BonesBevyRenderer::new(create_game())
@@ -109,9 +109,9 @@ pub fn create_game() -> Game {
         .register_default_assets();
 
     // Register our custom asset types
-    GameMeta::schema();
-    AtlasDemoMeta::schema();
-    TilemapDemoMeta::schema();
+    GameMeta::register_schema();
+    AtlasDemoMeta::register_schema();
+    TilemapDemoMeta::register_schema();
 
     // Create our menu session
     game.sessions.create("menu").install_plugin(menu_plugin);

--- a/framework_crates/bones_asset/examples/tutorial.rs
+++ b/framework_crates/bones_asset/examples/tutorial.rs
@@ -141,13 +141,11 @@ fn main() -> anyhow::Result<()> {
     // compatible with our game version.
     let asset_server = AssetServer::new(io, Version::new(0, 1, 3));
 
-    // Each asset type needs to have it's schema registered to be loaded from an asset file. Calling
-    // the schema() method accomplishes that.
-    GameMeta::schema();
-    PlayerMeta::schema();
-    AtlasMeta::schema();
-    PluginMeta::schema();
-    // Image::schema();
+    // Each asset type needs to have it's schema registered to be loaded from an asset file.
+    GameMeta::register_schema();
+    PlayerMeta::register_schema();
+    AtlasMeta::register_schema();
+    PluginMeta::register_schema();
 
     // Load assets
     let s = asset_server.clone();

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -70,18 +70,18 @@ impl AssetServerExt for &mut bones_asset::AssetServer {
         use crate::prelude::*;
 
         // Register asset schemas
-        Image::schema();
-        Atlas::schema();
+        Image::register_schema();
+        Atlas::register_schema();
 
         #[cfg(feature = "localization")]
         {
-            LocalizationAsset::schema();
-            FluentBundleAsset::schema();
-            FluentResourceAsset::schema();
+            LocalizationAsset::register_schema();
+            FluentBundleAsset::register_schema();
+            FluentResourceAsset::register_schema();
         }
 
         #[cfg(feature = "ui")]
-        Font::schema();
+        Font::register_schema();
 
         self
     }

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -15,7 +15,7 @@ use kira::{
 
 /// The game plugin for the audio system.
 pub fn game_plugin(game: &mut Game) {
-    AudioSource::schema();
+    AudioSource::register_schema();
     game.insert_shared_resource(AudioManager::default());
     game.init_shared_resource::<AssetServer>();
 }

--- a/framework_crates/bones_schema/src/schema.rs
+++ b/framework_crates/bones_schema/src/schema.rs
@@ -16,7 +16,18 @@ use crate::{alloc::TypeDatas, prelude::*};
 /// of the type, or else accessing the type according to the schema would be unsound.
 pub unsafe trait HasSchema: Sync + Send + 'static {
     /// Get this type's [`Schema`].
+    #[must_use = "If you are only calling schema() for it's side-effect of registering the
+        schema, it is more clear to use register_schema() instead."]
     fn schema() -> &'static Schema;
+
+    /// Register this schema with the global schema registry.
+    ///
+    /// This is automatically done by the framework in many cases, whenever
+    /// [`schema()`][HasSchema::schema] is called, but it may be necessary sometimes to
+    /// manually register it.
+    fn register_schema() {
+        let _ = Self::schema();
+    }
 
     /// Cast a reference of this type to a reference of another type with the same memory layout.
     ///


### PR DESCRIPTION
This adds a `#[must_use]` attribute to `schema()` and adds a new `register_schema()` method so that it is more apparent what is happening when you make a free-standing schema() call to force it to register the schema.