### PR TITLE
feat: allow asset packs to load assets from other asset packs.

### DIFF
--- a/framework_crates/bones_asset/examples/tutorial.rs
+++ b/framework_crates/bones_asset/examples/tutorial.rs
@@ -234,7 +234,7 @@ fn main() -> anyhow::Result<()> {
         let (folder_name, pack_meta) = (entry.key(), entry.value());
         let id = pack_meta.id;
         let version = &pack_meta.version;
-        let actual_game_version = &asset_server.game_version;
+        let actual_game_version = &asset_server.game_version();
         let compatible_game_version = &pack_meta.game_version;
         println!(
             "{id}@{version} in folder `{folder_name}` is not compatible with game version \

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -238,6 +238,7 @@ impl BonesBevyRenderer {
             else {
                 break 'asset_load;
             };
+            asset_server.set_game_version(self.game_version);
 
             // Configure the AssetIO implementation
             #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
This allows you to prefix `core:` or `assetpack_id:` to an asset path to load the asset from another asset pack.