### PR TITLE
fix: add missing PartialEq/Eq/Hash derive for MouseButton

### DIFF
--- a/framework_crates/bones_framework/src/input/mouse.rs
+++ b/framework_crates/bones_framework/src/input/mouse.rs
@@ -42,7 +42,7 @@ pub struct MouseButtonEvent {
 }
 
 /// A button on the mouse.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum MouseButton {
     #[default]


### PR DESCRIPTION
Just adds a couple missing derives on `MouseButton` to make it a bit easier to work with (`KeyCode` already has them)