### PR TITLE
fix: undefined behaviour with then_some

### DIFF
--- a/framework_crates/bones_schema/src/ptr.rs
+++ b/framework_crates/bones_schema/src/ptr.rs
@@ -115,21 +115,21 @@ impl<'pointer> SchemaRef<'pointer> {
     pub fn as_map(&self) -> Option<&'pointer SchemaMap> {
         matches!(self.schema.kind, SchemaKind::Map { .. })
             // SOUND: Schema asserts this is a schema map
-            .then_some(unsafe { self.cast_into_unchecked::<SchemaMap>() })
+            .then(|| unsafe { self.cast_into_unchecked::<SchemaMap>() })
     }
 
     /// Borrow the schema ref as a [`SchemaVec`] if it is one.
     pub fn as_vec(&self) -> Option<&'pointer SchemaVec> {
         matches!(self.schema.kind, SchemaKind::Vec(_))
             // SOUND: Schema asserts this is a schema map
-            .then_some(unsafe { self.cast_into_unchecked::<SchemaVec>() })
+            .then(|| unsafe { self.cast_into_unchecked::<SchemaVec>() })
     }
 
     /// Borrow the schema ref as a [`SchemaBox`] if it is one.
     pub fn as_box(&self) -> Option<SchemaRef<'pointer>> {
         matches!(self.schema.kind, SchemaKind::Vec(_))
             // SOUND: Schema asserts this is a schema box
-            .then_some(unsafe { self.cast_into_unchecked::<SchemaBox>().as_ref() })
+            .then(|| unsafe { self.cast_into_unchecked::<SchemaBox>().as_ref() })
     }
 
     /// Debug format the value stored in the schema box.
@@ -758,7 +758,7 @@ impl<'pointer> SchemaRefMut<'pointer> {
     pub fn into_map(self) -> Result<&'pointer mut SchemaMap, Self> {
         matches!(self.schema.kind, SchemaKind::Map { .. })
             // SOUND: Schema asserts this is a schema map
-            .then_some(unsafe { &mut *(self.ptr.as_ptr() as *mut SchemaMap) })
+            .then(|| unsafe { &mut *(self.ptr.as_ptr() as *mut SchemaMap) })
             .ok_or(self)
     }
 
@@ -766,7 +766,7 @@ impl<'pointer> SchemaRefMut<'pointer> {
     pub fn into_vec(self) -> Result<&'pointer mut SchemaVec, Self> {
         matches!(self.schema.kind, SchemaKind::Vec(_))
             // SOUND: Schema asserts this is a schema map
-            .then_some(unsafe { &mut *(self.ptr.as_ptr() as *mut SchemaVec) })
+            .then(|| unsafe { &mut *(self.ptr.as_ptr() as *mut SchemaVec) })
             .ok_or(self)
     }
 
@@ -774,7 +774,7 @@ impl<'pointer> SchemaRefMut<'pointer> {
     pub fn into_box(self) -> Result<SchemaRefMut<'pointer>, Self> {
         matches!(self.schema.kind, SchemaKind::Vec(_))
             // SOUND: Schema asserts this is a schema box
-            .then_some(unsafe { (*(self.ptr.as_ptr() as *mut SchemaBox)).as_mut() })
+            .then(|| unsafe { (*(self.ptr.as_ptr() as *mut SchemaBox)).as_mut() })
             .ok_or(self)
     }
 


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = matches!(self.schema.kind, SchemaKind::Vec(_));
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe { self.cast_into_unchecked::<SchemaMap>() };
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
