### PR TITLE
feat(assets): Add NetworkHandle type to replicate asset handles

### DIFF
--- a/framework_crates/bones_asset/src/cid.rs
+++ b/framework_crates/bones_asset/src/cid.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 /// A unique content ID.
 ///
 /// Represents the Sha-256 hash of the contents of a [`LoadedAsset`][crate::LoadedAsset].
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Default, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Default, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Cid(pub [u8; 32]);
 

--- a/framework_crates/bones_asset/src/lib.rs
+++ b/framework_crates/bones_asset/src/lib.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeSeed, Deserializer};
 /// Helper to export the same types in the crate root and in the prelude.
 macro_rules! pub_use {
     () => {
-        pub use crate::{asset::*, cid::*, handle::*, io::*, server::*};
+        pub use crate::{asset::*, cid::*, handle::*, io::*, network_handle::*, server::*};
         pub use anyhow;
         pub use bones_schema::prelude::*;
         pub use dashmap;
@@ -30,6 +30,7 @@ mod asset;
 mod cid;
 mod handle;
 mod io;
+mod network_handle;
 mod parse;
 mod server;
 

--- a/framework_crates/bones_asset/src/network_handle.rs
+++ b/framework_crates/bones_asset/src/network_handle.rs
@@ -1,0 +1,39 @@
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
+
+/// Asset handle that may be replicated over network and converted back into [`Handle`] or [`UntypedHandle`].
+#[derive(Serialize, Deserialize)]
+pub struct NetworkHandle<T> {
+    /// Content id of the asset, used to lookup asset from [`AssetServer`].
+    pub cid: Cid,
+    phantom: PhantomData<T>,
+}
+
+impl<T> NetworkHandle<T> {
+    /// Create [`NetworkHandle`] from content id ([`Cid`]).
+    pub fn from_cid(cid: Cid) -> Self {
+        Self {
+            cid,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create asset [`Handle`] by looking up [`NetworkHandle`]'s [`Cid`] in [`AssetServer`].
+    /// Panics if Cid not found in asset server.
+    pub fn into_handle(&self, asset_server: &AssetServer) -> Handle<T> {
+        asset_server
+            .try_get_handle_from_cid(&self.cid)
+            .expect("Failed to lookup NetworkHandle content id in AssetServer. Is asset loaded? Invalid Cid?")
+    }
+
+    /// Convert into [`UntypedHandle`].
+    /// Panics if [`AssetServer`] fails to find handle of asset loaded with [`Cid`].
+    pub fn into_untyped_handle(&self, asset_server: &AssetServer) -> UntypedHandle {
+        asset_server
+            .try_get_untyped_handle_from_cid(&self.cid)
+            .expect("Failed to lookup NetworkHandle content id in AssetServer. Is asset loaded? Invalid Cid?")
+    }
+}

--- a/framework_crates/bones_asset/src/server.rs
+++ b/framework_crates/bones_asset/src/server.rs
@@ -874,6 +874,27 @@ impl AssetServer {
         ))
     }
 
+    /// Get handle of loaded asset from content id [`Cid`].
+    pub fn get_handle_from_cid<T>(&self, cid: &Cid) -> Handle<T> {
+        self.get_untyped_handle_from_cid(cid).typed()
+    }
+
+    /// Get untyped handle of loaded asset from content id [`Cid`].
+    pub fn get_untyped_handle_from_cid(&self, cid: &Cid) -> UntypedHandle {
+        self.try_get_untyped_handle_from_cid(cid).unwrap()
+    }
+
+    /// Try to get handle of loaded asset from content id [`Cid`].
+    pub fn try_get_handle_from_cid<T>(&self, cid: &Cid) -> Option<Handle<T>> {
+        Some(self.try_get_untyped_handle_from_cid(cid)?.typed())
+    }
+
+    /// Try to get untyped handle of loaded asset from content id [`Cid`].
+    pub fn try_get_untyped_handle_from_cid(&self, cid: &Cid) -> Option<UntypedHandle> {
+        let loaded_asset = self.store.assets.get(cid)?;
+        Some(*self.store.path_handles.get(&loaded_asset.loc)?)
+    }
+
     /// Mutably borrow a loaded asset.
     ///
     /// # Panics


### PR DESCRIPTION
Add NetworkHandle to replicate asset handles using content id.