### PR TITLE
fix(build): fix quinn compilation for matchmaker + quinn_runtime_bevy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3732,8 +3732,7 @@ checksum = "d135ede8821cf6376eb7a64148901e1690b788c11ae94dc297ae917dbc91dc0e"
 [[package]]
 name = "quinn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=0.10.2#023f10376dbfdda4dfab2d775c5af61a4a29a803"
 dependencies = [
  "bytes",
  "futures-io",
@@ -3749,9 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+version = "0.10.2"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=0.10.2#023f10376dbfdda4dfab2d775c5af61a4a29a803"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -3767,9 +3765,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+version = "0.4.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=0.10.2#023f10376dbfdda4dfab2d775c5af61a4a29a803"
 dependencies = [
  "bytes",
  "libc",

--- a/other_crates/bones_matchmaker/Cargo.toml
+++ b/other_crates/bones_matchmaker/Cargo.toml
@@ -22,7 +22,8 @@ bones_matchmaker_proto = { version = "0.2", path = "../bones_matchmaker_proto" }
 clap                   = { version = "4.0", features = ["derive", "env"] }
 futures                = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 postcard               = { version = "1.0", default-features = false, features = ["alloc"] }
-quinn                  = { version = "0.10", default-features = false, features = ["futures-io", "native-certs", "tls-rustls"] }
+# crates.io quinn release (0.10.2) not compiling, use 0.10.2 git branch instead (https://github.com/quinn-rs/quinn/issues/1735)
+quinn          = { git = "https://github.com/quinn-rs/quinn.git", rev = "0.10.2", default-features = false, features = ["futures-io", "native-certs", "tls-rustls"] }
 quinn_runtime_bevy     = { version = "0.3", path = "../quinn_runtime_bevy" }
 rustls                 = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 serde                  = { version = "1.0", features = ["derive"] }

--- a/other_crates/quinn_runtime_bevy/Cargo.toml
+++ b/other_crates/quinn_runtime_bevy/Cargo.toml
@@ -13,5 +13,6 @@ async-io       = "1.9"
 bevy_tasks     = "0.11"
 futures-lite   = "1.0"
 pin-project    = "1.0"
-quinn          = { version = "0.10", default-features = false, features = ["native-certs", "tls-rustls"] }
-quinn-udp      = { version = "0.4", default-features = false }
+# crates.io quinn release (0.10.2) not compiling, use 0.10.2 git branch instead (https://github.com/quinn-rs/quinn/issues/1735)
+quinn          = { git = "https://github.com/quinn-rs/quinn.git", rev = "0.10.2", default-features = false, features = ["native-certs", "tls-rustls"] }
+quinn-udp      = { git = "https://github.com/quinn-rs/quinn.git", rev = "0.10.2", default-features = false }


### PR DESCRIPTION
quinn 0.10.2 does not seem to be compiling when used from crates.io, but works from git tag 0.10.2.

Update quinn to git 0.10.2 for matchmaker + quinn_runtime_bevy.

Opened an issue here: https://github.com/quinn-rs/quinn/issues/1735