### PR TITLE
feat(networking): Port networking to bones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "parking_lot",
+ "parking_lot 0.12.1",
  "thiserror",
  "winapi",
  "x11rb",
@@ -356,6 +356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomicell"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +390,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -445,7 +460,7 @@ dependencies = [
  "downcast-rs",
  "fastrand 1.9.0",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -771,7 +786,7 @@ dependencies = [
  "erased-serde",
  "glam",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serde",
  "smallvec",
  "smol_str",
@@ -828,7 +843,7 @@ dependencies = [
  "js-sys",
  "naga",
  "naga_oil",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "serde",
  "smallvec",
@@ -1009,6 +1024,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1066,16 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitfield-rle"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8acc105b7bd3ed61e4bb7ad3e3b3f2a8da72205b2e0408cf71a499e8f57dd0"
+dependencies = [
+ "failure",
+ "varinteger",
+]
 
 [[package]]
 name = "bitflags"
@@ -1164,24 +1198,44 @@ dependencies = [
 name = "bones_framework"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
+ "async-channel",
+ "bevy_tasks",
  "bones_asset",
  "bones_lib",
+ "bones_matchmaker_proto",
  "bones_schema",
  "bones_scripting",
+ "bytemuck",
+ "bytes",
  "csscolorparser",
  "document-features",
  "egui",
+ "either",
  "fluent",
  "fluent-langneg",
+ "futures-lite 1.13.0",
+ "ggrs",
  "glam",
  "hex",
  "image",
  "instant",
  "intl-memoizer",
  "kira",
+ "mdns-sd",
  "noise",
+ "numquant",
+ "once_cell",
+ "ping-rs",
+ "postcard",
+ "quinn",
+ "quinn_runtime_bevy",
+ "rand 0.8.5",
+ "rcgen 0.10.0",
+ "rustls",
  "serde",
  "serde_yaml",
+ "smallvec",
  "sys-locale",
  "thiserror",
  "tracing",
@@ -1215,7 +1269,7 @@ dependencies = [
  "quinn",
  "quinn_runtime_bevy",
  "rand 0.8.5",
- "rcgen",
+ "rcgen 0.11.3",
  "rustls",
  "scc",
  "serde",
@@ -1285,7 +1339,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "instant",
  "maybe-owned",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serde",
  "smallvec",
  "turborand",
@@ -1615,7 +1669,7 @@ dependencies = [
  "ndk-context",
  "oboe",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1639,6 +1693,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1699,7 +1759,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -1935,7 +1995,7 @@ dependencies = [
  "ecolor",
  "emath",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -2018,6 +2078,28 @@ checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -2123,6 +2205,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2260,7 @@ checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2190,6 +2282,17 @@ name = "futures-core"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2294,7 +2397,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.42",
- "synstructure",
+ "synstructure 0.13.0",
 ]
 
 [[package]]
@@ -2339,6 +2442,22 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ggrs"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1419c3c38e579884b075b99a8ade2ca507e87a2bde81940c6fe4aea895696831"
+dependencies = [
+ "bincode",
+ "bitfield-rle",
+ "bytemuck",
+ "instant",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -2483,6 +2602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,6 +2640,20 @@ dependencies = [
  "thiserror",
  "widestring",
  "winapi",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2571,6 +2713,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2998,6 +3150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "mdns-sd"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0d8bca08bbe8a91cc4a865f682241468c32bac1fcbc63ceafa07f35d67549e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "polling",
+ "socket2 0.4.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,6 +3478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numquant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54809e43d79aa532432c0d03c6adf62fdd96f2e152b90cef6cd9a316c3da4d99"
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,7 +3594,7 @@ checksum = "eba3de7c2ff90d756ee0713daaae3a3547fa2424b3b9cca46bce0b4dcd1d7ef2"
 dependencies = [
  "ahash",
  "hashbrown 0.14.3",
- "parking_lot",
+ "parking_lot 0.12.1",
  "stable_deref_trait",
 ]
 
@@ -3472,12 +3642,37 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3525,11 +3720,20 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "serde",
 ]
 
@@ -3638,6 +3842,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ping-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d873f038f84371f9c7fa13f6afea4d5f1fbcd5070ba8eb7af2a6d41c768eff8b"
+dependencies = [
+ "futures",
+ "mio",
+ "paste",
+ "socket2 0.4.10",
+ "windows 0.43.0",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,6 +3897,7 @@ checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
  "embedded-io",
+ "heapless",
  "serde",
 ]
 
@@ -3900,11 +4118,23 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem 1.1.1",
+ "ring 0.16.20",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem",
+ "pem 3.0.3",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -3915,6 +4145,15 @@ name = "rectangle-pack"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4039,7 +4278,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "bitflags 2.4.1",
  "serde",
  "serde_derive",
@@ -4056,6 +4295,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -4101,7 +4349,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.5",
 ]
 
 [[package]]
@@ -4362,6 +4610,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spirv"
@@ -4559,6 +4810,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4933,7 +5196,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "flate2",
  "log",
  "once_cell",
@@ -4963,7 +5226,7 @@ dependencies = [
  "ahash",
  "byteorder",
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serde",
 ]
 
@@ -4988,6 +5251,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "varinteger"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea29db9f94ff08bb619656b8120878f280526f71dc88b5262c958a510181812"
 
 [[package]]
 name = "vec_map"
@@ -5166,7 +5435,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5191,7 +5460,7 @@ dependencies = [
  "codespan-reporting",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
@@ -5230,7 +5499,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -5300,6 +5569,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,6 @@ dependencies = [
  "postcard",
  "quinn",
  "quinn_runtime_bevy",
- "rand 0.8.5",
  "rcgen 0.10.0",
  "rustls",
  "serde",

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -73,12 +73,20 @@ bones_schema = { version = "0.3", path = "../bones_schema", features = ["humanti
 bones_scripting = { version = "0.3", path = "../bones_scripting", optional = true }
 
 # Other
+anyhow              = "1.0"
+async-channel       = "1.7"
+bevy_tasks = { version = "0.11"}
+bytemuck               = "1.12"
+either                 = "1.8"
+futures-lite           = "1.12"
 glam      = "0.24"
-thiserror = "1.0"
-instant   = { version = "0.1", features = ["wasm-bindgen"] }
 hex       = "0.4"
-tracing   = "0.1"
+instant   = { version = "0.1", features = ["wasm-bindgen"] }
 noise     = "0.8"
+once_cell              = "1.17"
+rand                   = "0.8"
+thiserror = "1.0"
+tracing   = "0.1"
 
 # Render
 csscolorparser = "0.6"
@@ -108,3 +116,18 @@ sys-locale     = { version = "0.3", optional = true }
 
 # API docs
 document-features = { version = "0.2", optional = true }
+
+# Networking
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ggrs                   = { version = "0.9", features = ["sync-send"] }
+bones_matchmaker_proto = { version = "0.2", path = "../../other_crates/bones_matchmaker_proto" }
+bytes                  = "1.4"
+mdns-sd                = { version = "0.7", default-features = false }
+numquant               = "0.2"
+ping-rs                = "0.1"
+postcard               = { version = "1.0", features = ["alloc"] }
+rcgen                  = "0.10"
+rustls                 = { version = "0.21", features = ["dangerous_configuration", "quic"] }
+smallvec               = "1.10"
+quinn                  = { version = "0.10", default-features = false, features = ["native-certs", "tls-rustls"] }
+quinn_runtime_bevy     = { version = "0.3", path = "../../other_crates/quinn_runtime_bevy" }

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -84,7 +84,6 @@ hex       = "0.4"
 instant   = { version = "0.1", features = ["wasm-bindgen"] }
 noise     = "0.8"
 once_cell              = "1.17"
-rand                   = "0.8"
 thiserror = "1.0"
 tracing   = "0.1"
 

--- a/framework_crates/bones_framework/src/input.rs
+++ b/framework_crates/bones_framework/src/input.rs
@@ -37,7 +37,7 @@ pub mod prelude {
 ///
 /// [`InputCollector::apply_inputs`] maps raw input to game controls and updates them.
 ///
-/// [`InputCollector::update_just_pressed`] computes any changes in pressed buttons that may bestored on [`PlayerControl`].
+/// [`InputCollector::update_just_pressed`] computes any changes in pressed buttons that may be stored on control.
 ///
 /// [`InputCollector::advance_frame`] is  used to mark that the input has been consumed, and update the prev frame inputs to current, to compute changes next frame.
 ///
@@ -47,7 +47,7 @@ pub trait InputCollector<'a, ControlMapping: HasSchema, ControlSource, Control>:
 {
     /// Update the internal state with new inputs. This must be called every render frame with the
     /// input events. This updates which buttons are pressed, but does not compute what buttons were "just_pressed".
-    /// use [`update_just_pressed`] to do this.
+    /// use [`InputCollector::update_just_pressed`] to do this.
     fn apply_inputs(
         &mut self,
         mapping: &ControlMapping,
@@ -67,7 +67,7 @@ pub trait InputCollector<'a, ControlMapping: HasSchema, ControlSource, Control>:
     /// This does not modify previous frame's input, to do this use [`InputCollector::advance_frame`].
     fn update_just_pressed(&mut self);
 
-    /// Get control for player based on provided [`ControlSource`].
+    /// Get control for player based on provided `ControlSource`.
     fn get_control(&self, player_idx: usize, control_source: ControlSource) -> &Control;
 }
 
@@ -76,7 +76,7 @@ pub trait PlayerControls<'a, Control> {
     /// InputCollector used to update controls.
     type InputCollector: InputCollector<'a, Self::ControlMapping, Self::ControlSource, Control>;
 
-    /// Control mapping from raw input, expected to be able to be retrieved as [`Resource`] from world.
+    /// Control mapping from raw input, expected to be able to be retrieved as `Resource` from world.
     type ControlMapping: HasSchema;
 
     /// Type used to map source of input to control.
@@ -85,7 +85,7 @@ pub trait PlayerControls<'a, Control> {
     /// Update control state from input collector.
     fn update_controls(&mut self, collector: &mut Self::InputCollector);
 
-    /// Get [`ControlSource`] for player, only present for local player.
+    /// Get `ControlSource` for player (only present for local player).
     fn get_control_source(&self, local_player_idx: usize) -> Option<Self::ControlSource>;
 
     /// Get control for player.

--- a/framework_crates/bones_framework/src/input.rs
+++ b/framework_crates/bones_framework/src/input.rs
@@ -2,6 +2,8 @@
 
 use bones_schema::HasSchema;
 
+use self::prelude::{GamepadInputs, KeyboardInputs};
+
 pub mod gamepad;
 pub mod keyboard;
 pub mod mouse;
@@ -28,4 +30,67 @@ impl ButtonState {
 /// Module prelude.
 pub mod prelude {
     pub use super::{gamepad::*, keyboard::*, mouse::*, window::*, ButtonState};
+    pub use crate::input::{InputCollector, PlayerControls};
+}
+
+/// Maps raw inputs to game controls and exposes controls for respective player and their control source.
+///
+/// [`InputCollector::apply_inputs`] maps raw input to game controls and updates them.
+///
+/// [`InputCollector::update_just_pressed`] computes any changes in pressed buttons that may bestored on [`PlayerControl`].
+///
+/// [`InputCollector::advance_frame`] is  used to mark that the input has been consumed, and update the prev frame inputs to current, to compute changes next frame.
+///
+/// Generic type param ControlMapping is HasSchema because it is expected to be a Resource retrievable on world.
+pub trait InputCollector<'a, ControlMapping: HasSchema, ControlSource, Control>:
+    Send + Sync
+{
+    /// Update the internal state with new inputs. This must be called every render frame with the
+    /// input events. This updates which buttons are pressed, but does not compute what buttons were "just_pressed".
+    /// use [`update_just_pressed`] to do this.
+    fn apply_inputs(
+        &mut self,
+        mapping: &ControlMapping,
+        keyboard: &KeyboardInputs,
+        gamepad: &GamepadInputs,
+    );
+
+    /// Indicate input for this frame has been consumed. An implementation of [`InputCollector`] that is
+    /// used with a fixed simulation step may track what keys are currently pressed, and what keys were "just pressed",
+    /// (changing from previous state).
+    ///
+    /// This saves current inputs as previous frame's inputs, allowing for determining what is "just pressed" next frame.
+    fn advance_frame(&mut self);
+
+    /// Update which buttons have been "just pressed", when input has changed from last frame and current input state.
+    ///
+    /// This does not modify previous frame's input, to do this use [`InputCollector::advance_frame`].
+    fn update_just_pressed(&mut self);
+
+    /// Get control for player based on provided [`ControlSource`].
+    fn get_control(&self, player_idx: usize, control_source: ControlSource) -> &Control;
+}
+
+/// Trait that tracks player control state. Provides associated types for other input trait implementations.
+pub trait PlayerControls<'a, Control> {
+    /// InputCollector used to update controls.
+    type InputCollector: InputCollector<'a, Self::ControlMapping, Self::ControlSource, Control>;
+
+    /// Control mapping from raw input, expected to be able to be retrieved as [`Resource`] from world.
+    type ControlMapping: HasSchema;
+
+    /// Type used to map source of input to control.
+    type ControlSource;
+
+    /// Update control state from input collector.
+    fn update_controls(&mut self, collector: &mut Self::InputCollector);
+
+    /// Get [`ControlSource`] for player, only present for local player.
+    fn get_control_source(&self, local_player_idx: usize) -> Option<Self::ControlSource>;
+
+    /// Get control for player.
+    fn get_control(&self, player_idx: usize) -> &Control;
+
+    /// Get mutable control for player.
+    fn get_control_mut(&mut self, player_idx: usize) -> &mut Control;
 }

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -32,6 +32,8 @@ pub mod prelude {
     pub use bones_lib::prelude::*;
     pub use glam::*;
 
+    pub use serde::{Deserialize, Serialize};
+
     #[cfg(feature = "scripting")]
     pub use bones_scripting::prelude::*;
 
@@ -55,6 +57,10 @@ pub use bones_scripting as scripting;
 
 #[cfg(feature = "localization")]
 pub mod localization;
+
+// TODO: make configurable
+/// Max players in networked game
+pub const MAX_PLAYERS: usize = 4;
 
 /// Default plugins for bones framework sessions.
 pub struct DefaultSessionPlugin;

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -58,10 +58,6 @@ pub use bones_scripting as scripting;
 #[cfg(feature = "localization")]
 pub mod localization;
 
-// TODO: make configurable
-/// Max players in networked game
-pub const MAX_PLAYERS: usize = 4;
-
 /// Default plugins for bones framework sessions.
 pub struct DefaultSessionPlugin;
 impl lib::SessionPlugin for DefaultSessionPlugin {

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -20,8 +20,8 @@ pub use glam;
 /// The prelude.
 pub mod prelude {
     pub use crate::{
-        animation::*, input::prelude::*, params::*, render::prelude::*,
-        storage::*, time::*, utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
+        animation::*, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
+        utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
     };
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -57,6 +57,19 @@ pub use bones_scripting as scripting;
 
 #[cfg(feature = "localization")]
 pub mod localization;
+
+/// External crate documentation.
+///
+/// This module only exists during docs builds and serves to make it eaiser to link to relevant
+/// documentation in external crates.
+#[cfg(doc)]
+pub mod external {
+    #[doc(inline)]
+    pub use ggrs;
+
+    #[doc(inline)]
+    pub use bones_matchmaker_proto;
+}
 
 /// Default plugins for bones framework sessions.
 pub struct DefaultSessionPlugin;

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -23,6 +23,10 @@ pub mod prelude {
         animation::*, input::prelude::*, params::*, render::prelude::*,
         storage::*, time::*, utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
     };
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use crate::networking::prelude::*;
+
     pub use bones_asset::anyhow::Context;
     pub use bones_asset::prelude::*;
     pub use bones_lib::prelude::*;
@@ -42,6 +46,9 @@ pub mod render;
 pub mod storage;
 pub mod time;
 pub mod utils;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod networking;
 
 #[cfg(feature = "scripting")]
 pub use bones_scripting as scripting;

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -20,8 +20,8 @@ pub use glam;
 /// The prelude.
 pub mod prelude {
     pub use crate::{
-        animation::*, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
-        AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
+        animation::*, input::prelude::*, params::*, render::prelude::*,
+        storage::*, time::*, utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
     };
     pub use bones_asset::anyhow::Context;
     pub use bones_asset::prelude::*;
@@ -41,6 +41,7 @@ pub mod params;
 pub mod render;
 pub mod storage;
 pub mod time;
+pub mod utils;
 
 #[cfg(feature = "scripting")]
 pub use bones_scripting as scripting;

--- a/framework_crates/bones_framework/src/networking.md
+++ b/framework_crates/bones_framework/src/networking.md
@@ -1,0 +1,74 @@
+Networked multi-player plugin.
+
+Jumpy uses a Peer-to-Peer, rollback networking model built on [GGRS].
+
+Messages are serialized/deserialized to a binary representation using [`serde`] and the [`postcard`]
+crate.
+
+The major facets of our networking are:
+
+- **[Matchmaking](#matchmaking):** How we connect clients to each-other and start an network match.
+- **[Synchronization](#synchronization):** How we synchronize a network game between multiple players.
+
+[ggrs]: https://github.com/gschup/ggrs
+[`serde`]: https://docs.rs/serde
+[`postcard`]: https://docs.rs/postcard
+
+## Matchmaking
+
+There are currently two different matchmaking strategies: [`online`] and [`lan`]. Both of those
+modules contain their own matchmaker with docs on how it works. Eventually we will probably have
+additional matchmakers for Steam and the browser.
+
+Regardless of the matchmaker, the goal is to find a match and establish a connection to the other
+players. Once a match is established, the matchmaker must provide an implementation of
+[`NetworkSocket`] that may be used to send [GGRS], reliable, and unreliable messages.
+
+Each matchmaker is free to implement this socket with whatever networking transport they wish,
+allowing the Steam matchmaker, for example, to use the steam networking library, and the browser
+matchmaker to use `WebTransport` or `WebRTC`.
+
+## Synchronization
+
+Match synchronization, as mentioned above, is accomplished with [GGRS], wich is a re-imagining of
+the [GGPO] network SDK.
+
+The [`NetworkSocket`] trait, which matchmakers are required to implement for their sockets, is
+required to return an implementation of GGRS's [`NonBlockingSocket`] trait, so that it can send it's
+unreliable messages. The exact method for sending these messages depends on the matchmaker.
+
+The key requirement for rollback networking is:
+
+- The synchronized game loop must be **deterministic**.
+- We must have the ability to **snapshot** and **restore** the game state.
+- We must be able to run up to 8 game simulation frames in 16ms ( to achieve a 60 FPS frame rate,
+  even in the case where we have to rollback and re-simulate ).
+
+The integration with GGRS is implemented by the [`GgrsSessionRunner`].
+
+## Input
+
+[`GgrsSessionRunner`] is generic over a couple of input traits, some of which have associated types with other trait bounds. This provides an API for game to define their input collection, control mapping, etc to be used by bones in networking.
+
+[`NonBlockingSocket`]: https://docs.rs/ggrs/0.9.2/ggrs/trait.NonBlockingSocket.html
+[ggpo]: https://github.com/pond3r/ggpo/tree/master
+[`bones_lib`]: https://fishfolk.github.io/bones/rustdoc/bones_lib/index.html
+
+## Development & Debugging
+
+Here are some tips for debugging networking features while developing.
+
+### Local Sync Test
+
+It can be cumbersome to start a new networked match every time you need to troubleshoot some part of
+the game that may not be rolling back or restoring properly. To help with this, you can run the game
+with the `--sync-test-check-distance 7` to make the game test rolling back and forward 8 times every
+frame as a test when starting a local game.
+
+This allows you to test the rollback without having to connect to a server. If things start popping
+around the map or having other weird behaviors that they don't have without the sync-test mode, then
+you know you have a rollback issue.
+
+> **ℹ️ Note:** Just because you **don't** have an issue in sync test mode, doesn't mean that there
+> is no determinism issues. You still have to test network games with multiple game instances. There
+> are some non-determinism issues that only exhibit themselves when restarting the game.

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -1,11 +1,476 @@
+#![doc = include_str!("./networking.md")]
+
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
+use ggrs::P2PSession;
+use instant::Duration;
+use once_cell::sync::Lazy;
+use rand::Rng;
+use tracing::{debug, error, info, warn};
+
 use crate::prelude::*;
 
+use self::input::{DenseInput, NetworkInputConfig, NetworkPlayerControl, NetworkPlayerControls};
+use crate::input::PlayerControls as PlayerControlsTrait;
+
 pub mod certs;
+pub mod input;
+// TODO: network debug features
+// pub mod debug;
 pub mod lan;
 pub mod online;
 pub mod proto;
 
+/// Indicates if input from networking is confirmed, predicted, or if player is disconnected.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NetworkInputStatus {
+    /// The input of this player for this frame is an actual received input.
+    Confirmed,
+    /// The input of this player for this frame is predicted.
+    Predicted,
+    /// The player has disconnected at or prior to this frame, so this input is a dummy.
+    Disconnected,
+}
+
+impl From<ggrs::InputStatus> for NetworkInputStatus {
+    fn from(value: ggrs::InputStatus) -> Self {
+        match value {
+            ggrs::InputStatus::Confirmed => NetworkInputStatus::Confirmed,
+            ggrs::InputStatus::Predicted => NetworkInputStatus::Predicted,
+            ggrs::InputStatus::Disconnected => NetworkInputStatus::Disconnected,
+        }
+    }
+}
+
 /// Module prelude.
 pub mod prelude {
-    pub use super::{certs, lan, online, proto};
+    pub use super::{certs, input, lan, online, proto};
+}
+
+/// The muliplier for the [`jumpy_core::FPS`] that will be used when playing an online match.
+///
+/// Lowering the frame rate a little for online matches reduces bandwidth and may help overall
+/// gameplay. This may not be necessary once we improve network performance.
+///
+/// Note that FPS is provided as an integer to ggrs, so network modified fps is rounded to nearest int,
+/// which is then used to compute timestep so ggrs and networking match.
+pub const NETWORK_FRAME_RATE_FACTOR: f32 = 0.9;
+
+/// Number of frames client may predict beyond confirmed frame before freezing and waiting
+/// for inputs from other players.
+pub const NETWORK_MAX_PREDICTION_WINDOW: usize = 10;
+
+// todo test as zero?
+
+/// Amount of frames GGRS will delay local input.
+pub const NETWORK_LOCAL_INPUT_DELAY: usize = 1;
+
+// TODO: Remove this limitation on max players, a variety of types use this for static arrays,
+// should either figure out how to make this a compile-time const value specified by game, or
+// use dynamic arrays.
+//
+/// Max players in networked game
+pub const MAX_PLAYERS: usize = 4;
+
+/// Possible errors returned by [`update_networking`].
+pub enum NetworkError {
+    /// The session was disconnected.
+    Disconnected,
+}
+
+/// The [`ggrs::Config`] implementation used by Jumpy.
+#[derive(Debug)]
+pub struct GgrsConfig<T: DenseInput + Debug> {
+    phantom: PhantomData<T>,
+}
+
+impl<T: DenseInput + Debug> ggrs::Config for GgrsConfig<T> {
+    type Input = T;
+    type State = World;
+    /// Addresses are the same as the player handle for our custom socket.
+    type Address = usize;
+}
+
+/// The network endpoint used for all QUIC network communications.
+pub static NETWORK_ENDPOINT: Lazy<quinn::Endpoint> = Lazy::new(|| {
+    // Generate certificate
+    let (cert, key) = certs::generate_self_signed_cert().unwrap();
+
+    let mut transport_config = quinn::TransportConfig::default();
+    transport_config.keep_alive_interval(Some(std::time::Duration::from_secs(5)));
+
+    let mut server_config = quinn::ServerConfig::with_single_cert([cert].to_vec(), key).unwrap();
+    server_config.transport = Arc::new(transport_config);
+
+    // Open Socket and create endpoint
+    let port = rand::thread_rng().gen_range(10000..=11000); // Bind a random port
+    info!(port, "Started network endpoint");
+    let socket = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap();
+
+    let client_config = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(certs::SkipServerVerification::new())
+        .with_no_client_auth();
+    let client_config = quinn::ClientConfig::new(Arc::new(client_config));
+
+    let mut endpoint = quinn::Endpoint::new(
+        quinn::EndpointConfig::default(),
+        Some(server_config),
+        socket,
+        Arc::new(quinn_runtime_bevy::BevyIoTaskPoolExecutor),
+    )
+    .unwrap();
+
+    endpoint.set_default_client_config(client_config);
+
+    endpoint
+});
+
+/// Resource containing the [`NetworkSocket`] implementation while there is a connection to a
+/// network game.
+///
+/// This is inserted into the world after a match has been established by a network matchmaker.
+#[derive(Clone, HasSchema, Deref, DerefMut)]
+#[schema(no_default)]
+pub struct NetworkMatchSocket(Arc<dyn NetworkSocket>);
+
+/// A type-erased [`ggrs::NonBlockingSocket`][crate::external::ggrs::NonBlockingSocket]
+/// implementation.
+#[derive(Deref, DerefMut)]
+pub struct BoxedNonBlockingSocket(Box<dyn ggrs::NonBlockingSocket<usize> + 'static>);
+
+impl ggrs::NonBlockingSocket<usize> for BoxedNonBlockingSocket {
+    fn send_to(&mut self, msg: &ggrs::Message, addr: &usize) {
+        self.0.send_to(msg, addr)
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(usize, ggrs::Message)> {
+        self.0.receive_all_messages()
+    }
+}
+
+/// Trait that must be implemented by socket connections establish by matchmakers.
+///
+/// The [`NetworkMatchSocket`] resource will contain an instance of this trait and will be used by
+/// the game to send network messages after a match has been established.
+pub trait NetworkSocket: Sync + Send {
+    /// Get a GGRS socket from this network socket.
+    fn ggrs_socket(&self) -> BoxedNonBlockingSocket;
+    /// Send a reliable message to the given [`SocketTarget`].
+    fn send_reliable(&self, target: SocketTarget, message: &[u8]);
+    /// Receive reliable messages from other players. The `usize` is the index of the player that
+    /// sent the message.
+    fn recv_reliable(&self) -> Vec<(usize, Vec<u8>)>;
+    /// Close the connection.
+    fn close(&self);
+    /// Get the player index of the local player.
+    fn player_idx(&self) -> usize;
+    /// Return, for every player index, whether the player is a local player.
+    fn player_is_local(&self) -> [bool; MAX_PLAYERS];
+    /// Get the player count for this network match.
+    fn player_count(&self) -> usize;
+}
+
+/// The destination for a reliable network message.
+pub enum SocketTarget {
+    /// Send to a specific player.
+    Player(usize),
+    /// Broadcast to all players.
+    All,
+}
+
+/// [`SessionRunner`] implementation that uses [`ggrs`][crate::external::ggrs] for network play.
+///
+/// This is where the whole `ggrs` integration is implemented.
+pub struct GgrsSessionRunner<'a, InputTypes: NetworkInputConfig<'a>> {
+    /// The last player input we detected.
+    pub last_player_input: InputTypes::Dense,
+
+    /// The GGRS peer-to-peer session.
+    pub session: P2PSession<GgrsConfig<InputTypes::Dense>>,
+
+    /// Array containing a flag indicating, for each player, whether they are a local player.
+    pub player_is_local: [bool; MAX_PLAYERS],
+
+    /// Index of local player, computed from player_is_local
+    pub local_player_idx: usize,
+
+    /// The frame time accumulator, used to produce a fixed refresh rate.
+    pub accumulator: f64,
+
+    /// Timestamp of last time session was run to compute delta time.
+    pub last_run: Option<Instant>,
+
+    /// FPS from game adjusted with constant network factor (may be slightly slower)
+    pub network_fps: f64,
+
+    /// Session runner's input collector.
+    pub input_collector: InputTypes::InputCollector,
+}
+
+/// The info required to create a [`GgrsSessionRunner`].
+pub struct GgrsSessionRunnerInfo {
+    /// The GGRS socket implementation to use.
+    pub socket: BoxedNonBlockingSocket,
+    /// The list of local players.
+    pub player_is_local: [bool; MAX_PLAYERS],
+    /// the player count.
+    pub player_count: usize,
+}
+
+impl From<&dyn NetworkSocket> for GgrsSessionRunnerInfo {
+    fn from(socket: &dyn NetworkSocket) -> Self {
+        Self {
+            socket: socket.ggrs_socket(),
+            player_is_local: socket.player_is_local(),
+            player_count: socket.player_count(),
+        }
+    }
+}
+
+impl<'a, InputTypes> GgrsSessionRunner<'a, InputTypes>
+where
+    InputTypes: NetworkInputConfig<'a>,
+{
+    /// Create a new sessino runner.
+    pub fn new(simulation_fps: f32, info: GgrsSessionRunnerInfo) -> Self
+    where
+        Self: Sized,
+    {
+        // Modified FPS may not be an integer, but ggrs requires integer fps, so we clamp and round
+        // to integer so our computed timestep will match  that of ggrs.
+        let network_fps = (simulation_fps * NETWORK_FRAME_RATE_FACTOR) as f64;
+        let network_fps = network_fps
+            .max(std::usize::MIN as f64)
+            .min(std::usize::MAX as f64)
+            .round() as usize;
+
+        let mut builder = ggrs::SessionBuilder::new()
+            .with_num_players(info.player_count)
+            .with_max_prediction_window(NETWORK_MAX_PREDICTION_WINDOW)
+            .with_input_delay(NETWORK_LOCAL_INPUT_DELAY)
+            .with_fps(network_fps)
+            .unwrap();
+
+        let mut local_player_idx: Option<usize> = None;
+        for i in 0..info.player_count {
+            if info.player_is_local[i] {
+                builder = builder.add_player(ggrs::PlayerType::Local, i).unwrap();
+                local_player_idx = Some(i);
+            } else {
+                builder = builder.add_player(ggrs::PlayerType::Remote(i), i).unwrap();
+            }
+        }
+        let local_player_idx =
+            local_player_idx.expect("Networking player_is_local array has no local players.");
+
+        let session = builder.start_p2p_session(info.socket).unwrap();
+
+        Self {
+            last_player_input: InputTypes::Dense::default(),
+            session,
+            player_is_local: info.player_is_local,
+            local_player_idx,
+            accumulator: default(),
+            last_run: None,
+            network_fps: network_fps as f64,
+            input_collector: InputTypes::InputCollector::default(),
+        }
+    }
+}
+
+/// Helper for accessing nested associated types on [`NetworkInputConfig`].
+#[allow(type_alias_bounds)]
+type ControlMapping<'a, C: NetworkInputConfig<'a>> =
+    <C::PlayerControls as PlayerControls<'a, C::Control>>::ControlMapping;
+
+impl<InputTypes> SessionRunner for GgrsSessionRunner<'static, InputTypes>
+where
+    InputTypes: NetworkInputConfig<'static> + 'static,
+{
+    fn step(&mut self, frame_start: Instant, world: &mut World, stages: &mut SystemStages) {
+        let step: f64 = 1.0 / self.network_fps;
+
+        let last_run = self.last_run.unwrap_or(frame_start);
+        let delta = (frame_start - last_run).as_secs_f64();
+        self.accumulator += delta;
+
+        let mut skip_frames: u32 = 0;
+
+        {
+            let keyboard = world.resource::<KeyboardInputs>();
+            let gamepad = world.resource::<GamepadInputs>();
+
+            let player_inputs = world.resource::<InputTypes::PlayerControls>();
+
+            // Collect inputs and update controls
+            self.input_collector.apply_inputs(
+                &world.resource::<ControlMapping<InputTypes>>(),
+                &keyboard,
+                &gamepad,
+            );
+            self.input_collector.update_just_pressed();
+
+            // save local players dense input for use with ggrs
+            match player_inputs.get_control_source(self.local_player_idx) {
+                Some(control_source) => {
+                    let control = self
+                        .input_collector
+                        .get_control(self.local_player_idx, control_source);
+
+                    self.last_player_input = control.get_dense_input();
+                },
+                None => warn!("GgrsSessionRunner local_player_idx {} has no control source, no local input provided.",
+                    self.local_player_idx)
+            };
+        }
+
+        // Current frame before we start network update loop
+        // let current_frame_original = self.session.current_frame();
+        for event in self.session.events() {
+            match event {
+                ggrs::GGRSEvent::Synchronizing { addr, total, count } => {
+                    info!(player=%addr, %total, progress=%count, "Syncing network player");
+                }
+                ggrs::GGRSEvent::Synchronized { addr } => {
+                    info!(player=%addr, "Syncrhonized network client");
+                }
+                // TODO
+                ggrs::GGRSEvent::Disconnected { .. } => {} //return Err(SessionError::Disconnected)},
+                ggrs::GGRSEvent::NetworkInterrupted { addr, .. } => {
+                    info!(player=%addr, "Network player interrupted");
+                }
+                ggrs::GGRSEvent::NetworkResumed { addr } => {
+                    info!(player=%addr, "Network player re-connected");
+                }
+                ggrs::GGRSEvent::WaitRecommendation {
+                    skip_frames: skip_count,
+                } => {
+                    info!(
+                        "Skipping {skip_count} frames to give network players a chance to catch up"
+                    );
+                    skip_frames = skip_count;
+
+                    // NETWORK_DEBUG_CHANNEL
+                    //     .sender
+                    //     .try_send(NetworkDebugMessage::SkipFrame {
+                    //         frame: current_frame_original,
+                    //         count: skip_count,
+                    //     })
+                    //     .unwrap();
+                }
+                ggrs::GGRSEvent::DesyncDetected {
+                    frame,
+                    local_checksum,
+                    remote_checksum,
+                    addr,
+                } => {
+                    error!(%frame, %local_checksum, %remote_checksum, player=%addr, "Network de-sync detected");
+                }
+            }
+        }
+
+        loop {
+            if self.accumulator >= step {
+                self.accumulator -= step;
+
+                self.session
+                    .add_local_input(self.local_player_idx, self.last_player_input)
+                    .unwrap();
+
+                // let current_frame = self.session.current_frame();
+                // let confirmed_frame = self.session.confirmed_frame();
+                // NETWORK_DEBUG_CHANNEL
+                //     .sender
+                //     .try_send(NetworkDebugMessage::FrameUpdate {
+                //         current: current_frame,
+                //         last_confirmed: confirmed_frame,
+                //     })
+                //     .unwrap();
+
+                if skip_frames > 0 {
+                    skip_frames = skip_frames.saturating_sub(1);
+                    continue;
+                }
+
+                match self.session.advance_frame() {
+                    Ok(requests) => {
+                        for request in requests {
+                            match request {
+                                ggrs::GGRSRequest::SaveGameState { cell, frame } => {
+                                    info!("ggrs request: Save frame: {frame}");
+                                    cell.save(frame, Some(world.clone()), None)
+                                }
+                                ggrs::GGRSRequest::LoadGameState { cell, .. } => {
+                                    info!("ggrs request: Load");
+                                    *world = cell.load().unwrap_or_default();
+                                }
+                                ggrs::GGRSRequest::AdvanceFrame {
+                                    inputs: network_inputs,
+                                } => {
+                                    // Input has been consumed, signal that we are in new input frame
+                                    self.input_collector.advance_frame();
+
+                                    {
+                                        world
+                                            .resource_mut::<Time>()
+                                            .advance_exact(Duration::from_secs_f64(step));
+
+                                        // update game controls from ggrs inputs
+                                        let mut player_inputs =
+                                            world.resource_mut::<InputTypes::PlayerControls>();
+                                        for (player_idx, (input, status)) in
+                                            network_inputs.into_iter().enumerate()
+                                        {
+                                            player_inputs.network_update(
+                                                player_idx,
+                                                &input,
+                                                status.into(),
+                                            );
+                                        }
+                                    }
+
+                                    // Run game session stages, advancing simulation
+                                    stages.run(world);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => match e {
+                        ggrs::GGRSError::NotSynchronized => {
+                            debug!("Waiting for network clients to sync")
+                        }
+                        ggrs::GGRSError::PredictionThreshold => {
+                            warn!("Freezing game while waiting for network to catch-up.");
+                            // NETWORK_DEBUG_CHANNEL
+                            //     .sender
+                            //     .try_send(NetworkDebugMessage::FrameFroze {
+                            //         frame: self.session.current_frame(),
+                            //     })
+                            //     .unwrap();
+                        }
+                        e => error!("Network protocol error: {e}"),
+                    },
+                }
+            } else {
+                break;
+            }
+        }
+
+        self.last_run = Some(frame_start);
+
+        // Fetch GGRS network stats of remote players and send to net debug tool
+        // let mut network_stats: Vec<(PlayerHandle, NetworkStats)> = vec![];
+        // for handle in self.session.remote_player_handles().iter() {
+        //     if let Ok(stats) = self.session.network_stats(*handle) {
+        //         network_stats.push((*handle, stats));
+        //     }
+        // }
+        // if !network_stats.is_empty() {
+        //     NETWORK_DEBUG_CHANNEL
+        //         .sender
+        //         .try_send(NetworkDebugMessage::NetworkStats { network_stats })
+        //         .unwrap();
+        // }
+    }
 }

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -5,7 +5,6 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 use ggrs::P2PSession;
 use instant::Duration;
 use once_cell::sync::Lazy;
-use rand::Rng;
 use tracing::{debug, error, info, warn};
 
 use crate::prelude::*;
@@ -103,7 +102,7 @@ pub static NETWORK_ENDPOINT: Lazy<quinn::Endpoint> = Lazy::new(|| {
     server_config.transport = Arc::new(transport_config);
 
     // Open Socket and create endpoint
-    let port = rand::thread_rng().gen_range(10000..=11000); // Bind a random port
+    let port = THREAD_RNG.with(|rng| rng.u16(10000..=11000));
     info!(port, "Started network endpoint");
     let socket = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap();
 

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -1,0 +1,11 @@
+use crate::prelude::*;
+
+pub mod certs;
+pub mod lan;
+pub mod online;
+pub mod proto;
+
+/// Module prelude.
+pub mod prelude {
+    pub use super::{certs, lan, online, proto};
+}

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -46,7 +46,7 @@ pub mod prelude {
     pub use super::{certs, input, lan, online, proto};
 }
 
-/// The muliplier for the [`jumpy_core::FPS`] that will be used when playing an online match.
+/// Muliplier for framerate that will be used when playing an online match.
 ///
 /// Lowering the frame rate a little for online matches reduces bandwidth and may help overall
 /// gameplay. This may not be necessary once we improve network performance.
@@ -71,7 +71,7 @@ pub const NETWORK_LOCAL_INPUT_DELAY: usize = 1;
 /// Max players in networked game
 pub const MAX_PLAYERS: usize = 4;
 
-/// Possible errors returned by [`update_networking`].
+/// Possible errors returned by network loop.
 pub enum NetworkError {
     /// The session was disconnected.
     Disconnected,
@@ -133,7 +133,7 @@ pub static NETWORK_ENDPOINT: Lazy<quinn::Endpoint> = Lazy::new(|| {
 #[schema(no_default)]
 pub struct NetworkMatchSocket(Arc<dyn NetworkSocket>);
 
-/// A type-erased [`ggrs::NonBlockingSocket`][crate::external::ggrs::NonBlockingSocket]
+/// A type-erased [`ggrs::NonBlockingSocket`]
 /// implementation.
 #[derive(Deref, DerefMut)]
 pub struct BoxedNonBlockingSocket(Box<dyn ggrs::NonBlockingSocket<usize> + 'static>);
@@ -178,7 +178,7 @@ pub enum SocketTarget {
     All,
 }
 
-/// [`SessionRunner`] implementation that uses [`ggrs`][crate::external::ggrs] for network play.
+/// [`SessionRunner`] implementation that uses [`ggrs`] for network play.
 ///
 /// This is where the whole `ggrs` integration is implemented.
 pub struct GgrsSessionRunner<'a, InputTypes: NetworkInputConfig<'a>> {

--- a/framework_crates/bones_framework/src/networking/certs.rs
+++ b/framework_crates/bones_framework/src/networking/certs.rs
@@ -1,0 +1,40 @@
+//! QUIC certificate utilities.
+//!
+//!
+
+use std::sync::Arc;
+
+/// Implementation of `ServerCertVerifier` that verifies everything as trustworthy.
+///
+/// This allows us to connect to servers without having to worry about domain verification.
+///
+/// TODO: In the future we may want to do domain verification, but allow opting out of it.
+pub struct SkipServerVerification;
+
+impl SkipServerVerification {
+    /// Make new [`SkipServerVerification`].
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::client::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}
+
+/// Generates a self-signed cert for use in QUIC connections.
+pub fn generate_self_signed_cert() -> anyhow::Result<(rustls::Certificate, rustls::PrivateKey)> {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])?;
+    let key = rustls::PrivateKey(cert.serialize_private_key_der());
+    Ok((rustls::Certificate(cert.serialize_der()?), key))
+}

--- a/framework_crates/bones_framework/src/networking/input.rs
+++ b/framework_crates/bones_framework/src/networking/input.rs
@@ -1,0 +1,123 @@
+//! Input traits required by networking. These traits are networking specific, either only used in networking,
+//! or extending other traits from [`crate::input`] for networking.
+
+use std::fmt::Debug;
+
+use bones_schema::HasSchema;
+
+use crate::input::{InputCollector, PlayerControls};
+
+use super::NetworkInputStatus;
+
+/// Define input types used by game for use in networking.
+///
+/// As long as types `PlayerControls` and `InputCollector` implement traits [`PlayerControls`] and [`InputCollector`],
+/// trait bounds [`NetworkPlayerControl`] and [`NetworkInputCollector`] are automatically implemented.
+#[allow(missing_docs)]
+pub trait NetworkInputConfig<'a> {
+    type Dense: DenseInput + Debug + Default;
+    type Control: NetworkPlayerControl<Self::Dense>;
+
+    // Must be HasSchema because expected to be retrieved from `World` as `Resource`.
+    type PlayerControls: PlayerControls<'a, Self::Control> + HasSchema;
+
+    // InputCollector type params must match that of PlayerControls, so using associated types.
+    type InputCollector: InputCollector<
+            'a,
+            <Self::PlayerControls as PlayerControls<'a, Self::Control>>::ControlMapping,
+            <Self::PlayerControls as PlayerControls<'a, Self::Control>>::ControlSource,
+            Self::Control,
+        > + Default;
+}
+
+/// Required for use of [`PlayerControls`] in networking.
+pub trait NetworkPlayerControls<'a, Dense: DenseInput, Control>:
+    PlayerControls<'a, Control>
+{
+    /// Update control of player from dense input.
+    ///
+    /// [`NetworkInputStatus`] communicates if input is confirmed, predicted, or from disconnected player.
+    fn network_update(
+        &mut self,
+        player_idx: usize,
+        dense_input: &Dense,
+        status: NetworkInputStatus,
+    );
+
+    /// Get dense control for player.
+    fn get_dense_control(&self, player_idx: usize) -> Dense;
+}
+
+impl<'a, T, Dense, Control> NetworkPlayerControls<'a, Dense, Control> for T
+where
+    Dense: DenseInput,
+    Control: NetworkPlayerControl<Dense>,
+    T: PlayerControls<'a, Control>,
+{
+    // type NetworkControl = PlayerControl;
+    fn network_update(
+        &mut self,
+        player_idx: usize,
+        dense_input: &Dense,
+        _status: NetworkInputStatus,
+    ) {
+        self.get_control_mut(player_idx)
+            .update_from_dense(dense_input);
+    }
+
+    fn get_dense_control(&self, player_idx: usize) -> Dense {
+        self.get_control(player_idx).get_dense_input()
+    }
+}
+
+/// Dense input for network replication.
+pub trait DenseInput:
+    bytemuck::Pod + bytemuck::Zeroable + Copy + Clone + PartialEq + Eq + Send + Sync
+{
+}
+
+/// Automatic implementation for `DenseInput`.
+impl<T> DenseInput for T where
+    T: bytemuck::Pod + bytemuck::Zeroable + Copy + Clone + PartialEq + Eq + Send + Sync
+{
+}
+
+///  Trait allowing for creating and applying [`DenseInput`] from control.
+pub trait NetworkPlayerControl<Dense: DenseInput>: Send + Sync + Default {
+    /// Get [`DenseInput`] for control.
+    fn get_dense_input(&self) -> Dense;
+
+    /// Update control from [`DenseInput`].
+    fn update_from_dense(&mut self, new_control: &Dense);
+}
+
+/// Extension of [`InputCollector`] exposing dense control for networking.
+///
+/// This trait is automatically implemented for [`InputCollector`]'s such that `Control`
+/// implements [`NetworkPlayerControl`] (i.e. implements dense input)
+pub trait NetworkInputCollector<'a, Dense, ControlMapping, ControlSource, Control>:
+    InputCollector<'a, ControlMapping, ControlSource, Control>
+where
+    Dense: DenseInput,
+    ControlMapping: HasSchema,
+    Control: NetworkPlayerControl<Dense>,
+{
+    /// Get dense control
+    fn get_dense_control(&self, player_idx: usize, control_soure: ControlSource) -> Dense;
+}
+
+/// Provide automatic [`NetworkInputCollector`] for [`InputCollector`] when type parameters
+/// meet required bounds for networking.
+impl<'a, T, Dense, ControlMapping, ControlSource, Control>
+    NetworkInputCollector<'a, Dense, ControlMapping, ControlSource, Control> for T
+where
+    Dense: DenseInput,
+    Control: NetworkPlayerControl<Dense>,
+    ControlMapping: HasSchema,
+    T: InputCollector<'a, ControlMapping, ControlSource, Control>,
+{
+    fn get_dense_control(&self, player_idx: usize, control_source: ControlSource) -> Dense {
+        self.get_control(player_idx, control_source)
+            .get_dense_input()
+    }
+}

--- a/framework_crates/bones_framework/src/networking/lan.rs
+++ b/framework_crates/bones_framework/src/networking/lan.rs
@@ -5,10 +5,6 @@
 //! The LAN matchmaker works by allowing the player to start a match and wait for people to join it,
 //! or to join player's started match.
 //!
-//! Players hosting matches are found using the MDNS protocol. Currently the MDNS logic resides in
-//! the [`ui::main_menu::network_game`] module, in the menu code. This probably isn't the best place
-//! for it, and it should be moved into here to be a part of the [`lan_matchmaker`] task.
-//!
 //! Communication happens directly between LAN peers over the QUIC protocol.
 
 // TODO
@@ -234,7 +230,7 @@ pub fn prepare_to_host<'a>(
 
 /// Implementation of the lan matchmaker task.
 ///
-/// This is a long-running tasks that listens for messages sent through the [`LAN_MATCHMAKER`]
+/// This is a long-running tasks that listens for messages sent through the `LAN_MATCHMAKER`
 /// channel.
 async fn lan_matchmaker(
     matchmaker_channel: BiChannelServer<LanMatchmakerRequest, LanMatchmakerResponse>,
@@ -473,11 +469,11 @@ async fn lan_matchmaker(
     }
 }
 
-/// The type of the [`LAN_MATCHMAKER`] channel.
+/// The type of the `LAN_MATCHMAKER` channel.
 #[derive(DerefMut, Deref)]
 pub struct LanMatchmaker(BiChannelClient<LanMatchmakerRequest, LanMatchmakerResponse>);
 
-/// A request that may be sent to the [`LAN_MATCHMAKER`].
+/// A request that may be sent to the `LAN_MATCHMAKER`.
 #[derive(Debug)]
 pub enum LanMatchmakerRequest {
     /// Start matchmaker server
@@ -498,7 +494,7 @@ pub enum LanMatchmakerRequest {
     StopJoin,
 }
 
-/// A response that may come from the [`LAN_MATCHMAKER`].
+/// A response that may come from the `LAN_MATCHMAKER`.
 pub enum LanMatchmakerResponse {
     /// Server started
     ServerStarted,

--- a/framework_crates/bones_framework/src/networking/lan.rs
+++ b/framework_crates/bones_framework/src/networking/lan.rs
@@ -1,0 +1,763 @@
+//! LAN matchmaking and socket implementation.
+//!
+//! ## Matchmaking
+//!
+//! The LAN matchmaker works by allowing the player to start a match and wait for people to join it,
+//! or to join player's started match.
+//!
+//! Players hosting matches are found using the MDNS protocol. Currently the MDNS logic resides in
+//! the [`ui::main_menu::network_game`] module, in the menu code. This probably isn't the best place
+//! for it, and it should be moved into here to be a part of the [`lan_matchmaker`] task.
+//!
+//! Communication happens directly between LAN peers over the QUIC protocol.
+
+// TODO
+#![allow(missing_docs)]
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    time::Duration,
+};
+
+use bevy_tasks::IoTaskPool;
+use bytes::Bytes;
+use futures_lite::{future, FutureExt};
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use smallvec::SmallVec;
+use tracing::warn;
+
+use crate::utils::BiChannelServer;
+
+use super::*;
+
+/// Service discover info and ping.
+#[derive(Clone)]
+pub struct ServerInfo {
+    /// mutli-cast dns service discover info.
+    pub service: ServiceInfo,
+    /// The ping in milliseconds
+    pub ping: Option<u16>,
+}
+
+/// Channel used to do matchmaking over LAN.
+///
+/// Spawns a task to handle the actual matchmaking.
+static LAN_MATCHMAKER: Lazy<LanMatchmaker> = Lazy::new(|| {
+    let (client, server) = bi_channel();
+
+    IoTaskPool::get().spawn(lan_matchmaker(server)).detach();
+
+    LanMatchmaker(client)
+});
+
+static MDNS: Lazy<ServiceDaemon> =
+    Lazy::new(|| ServiceDaemon::new().expect("Couldn't start MDNS service discovery thread."));
+
+const MDNS_SERVICE_TYPE: &str = "_jumpy._udp.local.";
+
+#[derive(DerefMut, Deref)]
+struct Pinger(BiChannelClient<PingerRequest, PingerResponse>);
+
+type PingerRequest = SmallVec<[Ipv4Addr; 10]>;
+type PingerResponse = SmallVec<[(Ipv4Addr, Option<u16>); 10]>;
+
+static PINGER: Lazy<Pinger> = Lazy::new(|| {
+    let (client, server) = bi_channel();
+
+    std::thread::spawn(move || pinger(server));
+
+    Pinger(client)
+});
+
+/// Host a server.
+pub fn start_server(service_info: ServiceInfo, player_count: usize) {
+    MDNS.register(service_info)
+        .expect("Could not register MDNS service.");
+    LAN_MATCHMAKER
+        .try_send(LanMatchmakerRequest::StartServer { player_count })
+        .unwrap();
+}
+
+/// Stop hosting a server.
+pub fn stop_server(service_info: &ServiceInfo) {
+    loop {
+        match MDNS.unregister(service_info.get_fullname()) {
+            Ok(_) => break,
+            Err(mdns_sd::Error::Again) => (),
+            Err(e) => {
+                panic!("Error unregistering MDNS service: {e}")
+            }
+        }
+    }
+}
+
+/// Wait for players to join a hosted server.
+pub fn wait_players(joined_players: &mut usize, service_info: &ServiceInfo) -> Option<LanSocket> {
+    while let Ok(response) = LAN_MATCHMAKER.try_recv() {
+        match response {
+            LanMatchmakerResponse::ServerStarted => {}
+            LanMatchmakerResponse::PlayerCount(count) => {
+                *joined_players = count;
+            }
+            LanMatchmakerResponse::GameStarting {
+                lan_socket,
+                player_idx,
+                player_count: _,
+            } => {
+                info!(?player_idx, "Starting network game");
+                loop {
+                    match MDNS.unregister(service_info.get_fullname()) {
+                        Ok(_) => break,
+                        Err(mdns_sd::Error::Again) => (),
+                        Err(e) => panic!("Error unregistering MDNS service: {e}"),
+                    }
+                }
+                return Some(lan_socket);
+            }
+        }
+    }
+    None
+}
+
+/// Join a server hosted by someone else.
+pub fn join_server(server: &ServerInfo) {
+    LAN_MATCHMAKER
+        .try_send(lan::LanMatchmakerRequest::JoinServer {
+            ip: *server.service.get_addresses().iter().next().unwrap(),
+            port: server.service.get_port(),
+        })
+        .unwrap();
+}
+
+/// Leave a joined server.
+pub fn leave_server() {
+    LAN_MATCHMAKER
+        .try_send(LanMatchmakerRequest::StopJoin)
+        .unwrap();
+}
+
+/// Wait for a joined game to start.
+pub fn wait_game_start() -> Option<LanSocket> {
+    while let Ok(message) = LAN_MATCHMAKER.try_recv() {
+        match message {
+            LanMatchmakerResponse::ServerStarted | LanMatchmakerResponse::PlayerCount(_) => {}
+            LanMatchmakerResponse::GameStarting {
+                lan_socket,
+                player_idx,
+                player_count: _,
+            } => {
+                info!(?player_idx, "Starting network game");
+                return Some(lan_socket);
+            }
+        }
+    }
+    None
+}
+
+/// Update server pings and turn on service discovery.
+pub fn prepare_to_join(
+    servers: &mut Vec<ServerInfo>,
+    service_discovery_recv: &mut Option<mdns_sd::Receiver<ServiceEvent>>,
+    ping_update_timer: &Timer,
+) {
+    // Update server pings
+    if ping_update_timer.finished() {
+        PINGER
+            .try_send(
+                servers
+                    .iter()
+                    .map(|x| *x.service.get_addresses().iter().next().unwrap())
+                    .collect(),
+            )
+            .ok();
+    }
+    if let Ok(pings) = PINGER.try_recv() {
+        for (server, ping) in pings {
+            for info in servers.iter_mut() {
+                if info.service.get_addresses().contains(&server) {
+                    info.ping = ping;
+                }
+            }
+        }
+    }
+
+    let events = service_discovery_recv.get_or_insert_with(|| {
+        MDNS.browse(MDNS_SERVICE_TYPE)
+            .expect("Couldn't start service discovery")
+    });
+
+    while let Ok(event) = events.try_recv() {
+        match event {
+            mdns_sd::ServiceEvent::ServiceResolved(info) => servers.push(lan::ServerInfo {
+                service: info,
+                ping: None,
+            }),
+            mdns_sd::ServiceEvent::ServiceRemoved(_, full_name) => {
+                servers.retain(|server| server.service.get_fullname() != full_name);
+            }
+            _ => (),
+        }
+    }
+}
+
+/// Get the current host info or create a new one. When there's an existing
+/// service but its `service_name` is different, the service is recreated and
+/// only then the returned `bool` is `true`.
+pub fn prepare_to_host<'a>(
+    host_info: &'a mut Option<ServiceInfo>,
+    service_name: &str,
+) -> (bool, &'a mut ServiceInfo) {
+    let create_service_info = || {
+        let port = NETWORK_ENDPOINT.local_addr().unwrap().port();
+        mdns_sd::ServiceInfo::new(
+            MDNS_SERVICE_TYPE,
+            service_name,
+            service_name,
+            "",
+            port,
+            None,
+        )
+        .unwrap()
+        .enable_addr_auto()
+    };
+
+    let service_info = host_info.get_or_insert_with(create_service_info);
+
+    let mut is_recreated = false;
+    if service_info.get_hostname() != service_name {
+        stop_server(service_info);
+        is_recreated = true;
+        *service_info = create_service_info();
+    }
+    (is_recreated, service_info)
+}
+
+/// Implementation of the lan matchmaker task.
+///
+/// This is a long-running tasks that listens for messages sent through the [`LAN_MATCHMAKER`]
+/// channel.
+async fn lan_matchmaker(
+    matchmaker_channel: BiChannelServer<LanMatchmakerRequest, LanMatchmakerResponse>,
+) {
+    #[derive(Serialize, Deserialize)]
+    enum MatchmakerNetMsg {
+        MatchReady {
+            /// The peers they have for the match, with the index in the array being the player index of the peer.
+            peers: [Option<SocketAddrV4>; MAX_PLAYERS],
+            /// The player index of the player getting the message.
+            player_idx: usize,
+            player_count: usize,
+        },
+    }
+
+    while let Ok(request) = matchmaker_channel.recv().await {
+        match request {
+            // Start server
+            LanMatchmakerRequest::StartServer { mut player_count } => {
+                info!("Starting LAN server");
+                matchmaker_channel
+                    .send(LanMatchmakerResponse::ServerStarted)
+                    .await
+                    .unwrap();
+
+                let mut connections = Vec::new();
+
+                loop {
+                    let next_request = async { either::Left(matchmaker_channel.recv().await) };
+                    let next_conn = async { either::Right(NETWORK_ENDPOINT.accept().await) };
+
+                    match next_request.or(next_conn).await {
+                        // Handle more matchmaker requests
+                        either::Either::Left(next_request) => {
+                            let Ok(next_request) = next_request else {
+                                break;
+                            };
+
+                            match next_request {
+                                LanMatchmakerRequest::StartServer {
+                                    player_count: new_player_count,
+                                } => {
+                                    connections.clear();
+                                    player_count = new_player_count;
+                                }
+                                LanMatchmakerRequest::StopServer => {
+                                    break;
+                                }
+                                LanMatchmakerRequest::StopJoin => {} // Not joining, so don't do anything
+                                LanMatchmakerRequest::JoinServer { .. } => {
+                                    error!("Cannot join server while hosting server");
+                                }
+                            }
+                        }
+
+                        // Handle new connections
+                        either::Either::Right(Some(new_connection)) => {
+                            let Some(conn) = new_connection.await.ok() else {
+                                continue;
+                            };
+                            connections.push(conn);
+                            let current_players = connections.len() + 1;
+                            info!(%current_players, "New player connection");
+                        }
+                        _ => (),
+                    }
+
+                    // Discard closed connections
+                    connections.retain(|conn| {
+                        if conn.close_reason().is_some() {
+                            info!("Player closed connection");
+                            false
+                        } else {
+                            true
+                        }
+                    });
+
+                    let current_players = connections.len();
+                    let target_players = player_count;
+                    info!(%current_players, %target_players);
+
+                    // If we're ready to start a match
+                    if connections.len() == player_count - 1 {
+                        info!("All players joined.");
+
+                        // Tell all clients we're ready
+                        for (i, conn) in connections.iter().enumerate() {
+                            let mut peers = [None; MAX_PLAYERS];
+                            connections
+                                .iter()
+                                .enumerate()
+                                .filter(|x| x.0 != i)
+                                .for_each(|(i, conn)| {
+                                    if let SocketAddr::V4(addr) = conn.remote_address() {
+                                        peers[i + 1] = Some(addr);
+                                    } else {
+                                        unreachable!("IPV6 not supported in LAN matchmaking");
+                                    };
+                                });
+
+                            let mut uni = conn.open_uni().await.unwrap();
+                            uni.write_all(
+                                &postcard::to_vec::<_, 20>(&MatchmakerNetMsg::MatchReady {
+                                    player_idx: i + 1,
+                                    peers,
+                                    player_count,
+                                })
+                                .unwrap(),
+                            )
+                            .await
+                            .unwrap();
+                            uni.finish().await.unwrap();
+                        }
+
+                        // Collect the list of client connections
+                        let connections = std::array::from_fn(|i| {
+                            if i == 0 {
+                                None
+                            } else {
+                                connections.get(i - 1).cloned()
+                            }
+                        });
+
+                        // Send the connections to the game so that it can start the network match.
+                        matchmaker_channel
+                            .try_send(LanMatchmakerResponse::GameStarting {
+                                lan_socket: LanSocket::new(0, connections),
+                                player_idx: 0,
+                                player_count,
+                            })
+                            .ok();
+                        info!(player_idx=0, %player_count, "Matchmaking finished");
+
+                        // Break out of the server loop
+                        break;
+
+                    // If we don't have enough players yet, send the updated player count to the game.
+                    } else if matchmaker_channel
+                        .try_send(LanMatchmakerResponse::PlayerCount(current_players))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+
+                // Once we are done with server matchmaking
+            }
+            // Server not running or joining so do nothing
+            LanMatchmakerRequest::StopServer => (),
+            LanMatchmakerRequest::StopJoin => (),
+
+            // Join a hosted match
+            LanMatchmakerRequest::JoinServer { ip, port } => {
+                let conn = NETWORK_ENDPOINT
+                    .connect((ip, port).into(), "jumpy-host")
+                    .unwrap()
+                    .await
+                    .expect("Could not connect to server");
+
+                // Wait for match to start
+                let mut uni = conn.accept_uni().await.unwrap();
+                let bytes = uni.read_to_end(20).await.unwrap();
+                let message: MatchmakerNetMsg = postcard::from_bytes(&bytes).unwrap();
+
+                match message {
+                    MatchmakerNetMsg::MatchReady {
+                        peers: peer_addrs,
+                        player_idx,
+                        player_count,
+                    } => {
+                        info!(%player_count, %player_idx, ?peer_addrs, "Matchmaking finished");
+                        let mut peer_connections = std::array::from_fn(|_| None);
+
+                        // Set the connection to the matchmaker for player 0
+                        peer_connections[0] = Some(conn.clone());
+
+                        // For every peer with a player index that is higher than ours, wait for
+                        // them to connect to us.
+                        let range = (player_idx + 1)..player_count;
+                        info!(players=?range, "Waiting for {} peer connections", range.len());
+                        for _ in range {
+                            // Wait for connection
+                            let conn = NETWORK_ENDPOINT
+                                .accept()
+                                .await
+                                .unwrap()
+                                .await
+                                .expect("Could not accept incomming connection");
+
+                            // Receive the player index
+                            let idx = {
+                                let mut buf = [0; 1];
+                                let mut channel = conn.accept_uni().await.unwrap();
+                                channel.read_exact(&mut buf).await.unwrap();
+
+                                buf[0] as usize
+                            };
+                            assert!(idx < MAX_PLAYERS, "Invalid player index");
+
+                            peer_connections[idx] = Some(conn);
+                        }
+
+                        // For every peer with a player index lower than ours, connect to them.
+                        let range = 1..player_idx;
+                        info!(players=?range, "Connecting to {} peers", range.len());
+                        for i in range {
+                            let addr = peer_addrs[i].unwrap();
+                            let conn = NETWORK_ENDPOINT
+                                .connect(addr.into(), "jumpy-peer")
+                                .unwrap()
+                                .await
+                                .expect("Could not connect to peer");
+
+                            // Send player index
+                            let mut channel = conn.open_uni().await.unwrap();
+                            channel.write(&[player_idx as u8]).await.unwrap();
+                            channel.finish().await.unwrap();
+
+                            peer_connections[i] = Some(conn);
+                        }
+
+                        let lan_socket = LanSocket::new(player_idx, peer_connections);
+                        info!("Connections established.");
+
+                        matchmaker_channel
+                            .try_send(LanMatchmakerResponse::GameStarting {
+                                lan_socket,
+                                player_idx,
+                                player_count,
+                            })
+                            .ok();
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The type of the [`LAN_MATCHMAKER`] channel.
+#[derive(DerefMut, Deref)]
+pub struct LanMatchmaker(BiChannelClient<LanMatchmakerRequest, LanMatchmakerResponse>);
+
+/// A request that may be sent to the [`LAN_MATCHMAKER`].
+#[derive(Debug)]
+pub enum LanMatchmakerRequest {
+    /// Start matchmaker server
+    StartServer {
+        /// match player count
+        player_count: usize,
+    },
+    /// Join server
+    JoinServer {
+        /// Server address
+        ip: Ipv4Addr,
+        /// Server port
+        port: u16,
+    },
+    /// Stop matchmaking server
+    StopServer,
+    /// Stop joining match
+    StopJoin,
+}
+
+/// A response that may come from the [`LAN_MATCHMAKER`].
+pub enum LanMatchmakerResponse {
+    /// Server started
+    ServerStarted,
+    /// Server player count
+    PlayerCount(usize),
+    /// Game is starting
+    GameStarting {
+        /// Lan socket to game
+        lan_socket: LanSocket,
+        /// Local player index
+        player_idx: usize,
+        /// Game player count
+        player_count: usize,
+    },
+}
+
+/// The LAN [`NetworkSocket`] implementation.
+#[derive(Debug, Clone)]
+pub struct LanSocket {
+    ///
+    pub connections: [Option<quinn::Connection>; MAX_PLAYERS],
+    pub ggrs_receiver: async_channel::Receiver<(usize, ggrs::Message)>,
+    pub reliable_receiver: async_channel::Receiver<(usize, Vec<u8>)>,
+    pub player_idx: usize,
+    pub player_count: usize,
+}
+
+impl LanSocket {
+    pub fn new(player_idx: usize, connections: [Option<quinn::Connection>; MAX_PLAYERS]) -> Self {
+        let (ggrs_sender, ggrs_receiver) = async_channel::unbounded();
+        let (reliable_sender, reliable_receiver) = async_channel::unbounded();
+
+        let pool = bevy_tasks::IoTaskPool::get();
+
+        // Spawn tasks to receive network messages from each peer
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..MAX_PLAYERS {
+            if let Some(conn) = connections[i].clone() {
+                let ggrs_sender = ggrs_sender.clone();
+
+                // Unreliable message receiver
+                let conn_ = conn.clone();
+                pool.spawn(async move {
+                    let conn = conn_;
+
+                    #[cfg(feature = "debug-network-slowdown")]
+                    use turborand::prelude::*;
+                    #[cfg(feature = "debug-network-slowdown")]
+                    let rng = AtomicRng::new();
+
+                    loop {
+                        let event =
+                            future::or(async { either::Left(conn.closed().await) }, async {
+                                either::Right(conn.read_datagram().await)
+                            })
+                            .await;
+
+                        match event {
+                            either::Either::Left(closed) => {
+                                warn!("Connection error: {closed}");
+                                break;
+                            }
+                            either::Either::Right(datagram_result) => match datagram_result {
+                                Ok(data) => {
+                                    let message: ggrs::Message = postcard::from_bytes(&data)
+                                        .expect("Could not deserialize net message");
+
+                                    // Debugging code to introduce artificial latency
+                                    #[cfg(feature = "debug-network-slowdown")]
+                                    {
+                                        use async_timer::Oneshot;
+                                        async_timer::oneshot::Timer::new(
+                                            std::time::Duration::from_millis(
+                                                (rng.f32_normalized() * 100.0) as u64 + 1,
+                                            ),
+                                        )
+                                        .await;
+                                    }
+                                    if ggrs_sender.send((i, message)).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!("Connection error: {e}");
+                                }
+                            },
+                        }
+                    }
+                })
+                .detach();
+
+                // Reliable message receiver
+                let reliable_sender = reliable_sender.clone();
+                pool.spawn(async move {
+                    #[cfg(feature = "debug-network-slowdown")]
+                    use turborand::prelude::*;
+                    #[cfg(feature = "debug-network-slowdown")]
+                    let rng = AtomicRng::new();
+
+                    loop {
+                        let event =
+                            future::or(async { either::Left(conn.closed().await) }, async {
+                                either::Right(conn.accept_uni().await)
+                            })
+                            .await;
+
+                        match event {
+                            either::Either::Left(closed) => {
+                                warn!("Connection error: {closed}");
+                                break;
+                            }
+                            either::Either::Right(result) => match result {
+                                Ok(mut stream) => {
+                                    let data =
+                                        stream.read_to_end(4096).await.expect("Network read error");
+
+                                    // Debugging code to introduce artificial latency
+                                    #[cfg(feature = "debug-network-slowdown")]
+                                    {
+                                        use async_timer::Oneshot;
+                                        async_timer::oneshot::Timer::new(
+                                            std::time::Duration::from_millis(
+                                                (rng.f32_normalized() * 100.0) as u64 + 1,
+                                            ),
+                                        )
+                                        .await;
+                                    }
+                                    if reliable_sender.send((i, data)).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!("Connection error: {e}");
+                                }
+                            },
+                        }
+                    }
+                })
+                .detach();
+            }
+        }
+
+        Self {
+            player_idx,
+            player_count: connections.iter().flatten().count() + 1,
+            connections,
+            ggrs_receiver,
+            reliable_receiver,
+        }
+    }
+}
+
+impl ggrs::NonBlockingSocket<usize> for LanSocket {
+    fn send_to(&mut self, msg: &ggrs::Message, addr: &usize) {
+        let conn = self.connections[*addr].as_ref().unwrap();
+
+        // TODO: determine a reasonable size for this buffer.
+        let msg_bytes = postcard::to_allocvec(msg).unwrap();
+        conn.send_datagram(Bytes::copy_from_slice(&msg_bytes[..]))
+            .ok();
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(usize, ggrs::Message)> {
+        let mut messages = Vec::new();
+        while let Ok(message) = self.ggrs_receiver.try_recv() {
+            messages.push(message);
+        }
+        messages
+    }
+}
+
+impl NetworkSocket for LanSocket {
+    fn send_reliable(&self, target: SocketTarget, message: &[u8]) {
+        let task_pool = IoTaskPool::get();
+        let message = Bytes::copy_from_slice(message);
+
+        match target {
+            SocketTarget::Player(i) => {
+                let conn = self.connections[i].as_ref().unwrap().clone();
+
+                task_pool
+                    .spawn(async move {
+                        let mut stream = conn.open_uni().await.unwrap();
+                        stream.write_chunk(message).await.unwrap();
+                        stream.finish().await.unwrap();
+                    })
+                    .detach();
+            }
+            SocketTarget::All => {
+                for conn in &self.connections {
+                    if let Some(conn) = conn.clone() {
+                        let message = message.clone();
+                        task_pool
+                            .spawn(async move {
+                                let mut stream = conn.open_uni().await.unwrap();
+                                stream.write_chunk(message).await.unwrap();
+                                stream.finish().await.unwrap();
+                            })
+                            .detach();
+                    }
+                }
+            }
+        }
+    }
+
+    fn recv_reliable(&self) -> Vec<(usize, Vec<u8>)> {
+        let mut messages = Vec::new();
+        while let Ok(message) = self.reliable_receiver.try_recv() {
+            messages.push(message);
+        }
+        messages
+    }
+
+    fn ggrs_socket(&self) -> BoxedNonBlockingSocket {
+        BoxedNonBlockingSocket(Box::new(self.clone()))
+    }
+
+    fn close(&self) {
+        for conn in self.connections.iter().flatten() {
+            conn.close(0u8.into(), &[]);
+        }
+    }
+
+    fn player_idx(&self) -> usize {
+        self.player_idx
+    }
+
+    fn player_count(&self) -> usize {
+        self.player_count
+    }
+
+    fn player_is_local(&self) -> [bool; MAX_PLAYERS] {
+        std::array::from_fn(|i| self.connections[i].is_none() && i < self.player_count)
+    }
+}
+
+fn pinger(server: BiChannelServer<PingerRequest, PingerResponse>) {
+    while let Ok(servers) = server.recv_blocking() {
+        let mut pings = SmallVec::new();
+        for server in servers {
+            let start = Instant::now();
+            let ping_result = ping_rs::send_ping(
+                &IpAddr::V4(server),
+                Duration::from_secs(2),
+                &[1, 2, 3, 4],
+                None,
+            );
+
+            let ping = if let Err(e) = ping_result {
+                warn!("Error pinging {server}: {e:?}");
+                None
+            } else {
+                Some((Instant::now() - start).as_millis() as u16)
+            };
+
+            pings.push((server, ping));
+        }
+        if server.send_blocking(pings).is_err() {
+            break;
+        }
+    }
+}

--- a/framework_crates/bones_framework/src/networking/online.md
+++ b/framework_crates/bones_framework/src/networking/online.md
@@ -1,0 +1,95 @@
+Contains the online matchmaker and the [`NetworkSocket`] implementation.
+
+## Matchmaking
+
+For online matchmaking, we use a centralized matchmaking server to connect peers to each-other and
+to forward the peers' network traffic. All connections utilize UDP and the QUIC protocol.
+
+In order to establish the peer connections we use a matchmaking server implemented in the
+[`bones_matchmaker`] crate. This server binds one UDP port and listens for client connections.
+Because QUIC supports mutliplexing connections, we are able to handle any number of clients on a
+single UDP port.
+
+All client traffic is proxied to other peers through the matchmaking server. In this way it is not
+true peer-to-peer networking, but logically, once the match starts, clients are sending messages to
+each-other, and the server doesn't take part in the match protocol.
+
+Having the matchmaker proxy client messages has the following pros and cons:
+
+**Cons:**
+
+- It uses up more of the matchmaking server's bandwidth
+- It adds an extra network hop between peers, increasing latency.
+
+**Pros:**
+
+- It reduces the number of connections each peer needs to make. Each peer only holds one
+  connection to the matchmaking server and nothing else.
+- It hides the IP addresses of clients from each-other. This is an important privacy feature.
+- It avoids a number of difficulties that you may run into while trying to establish true
+  peer-to-peer connections, and makes it much easier to bypass firewalls, NATs, etc.
+
+This doesn't prevent us from supporting true peer-to-peer connections in the future, though.
+Similarly, another scenario we will support in the future is LAN games that you can join without
+needing a matchmaking server.
+
+[`bones_matchmaker`]: https://github.com/fishfolk/bones/tree/main/crates/bones_matchmaker
+
+### Matchmaking Protocol
+
+> **ℹ️ Note:** This is meant as an overview and is not an exact specification of the matchmaking
+> protocol.
+
+#### Initial Connection
+
+When a client connects to the matchmaking server, the very first thing it will do is send a
+[`RequestMatch`][crate::external::bones_matchmaker_proto::MatchmakerRequest::RequestMatch] message
+to the server over a reliable channel.
+
+This message contains the [`MatchInfo`][crate::external::bones_matchmaker_proto::MatchInfo] that
+tells the server how many players the client wants to connect to for the match, along with an
+arbitrary byte sequence for the `match_data`.
+
+In order for players to end up in the same match as each-other, they must specify the _exact_ same
+`MatchInfo`, including the `match_data`. We use the `match_data` as a way to specify which game mode
+and parameters, etc. that the player wants to connect to, so that all the players that are connected
+to each-other are playing the same mode.
+
+The `match_data` also contains the game name and version. Because the matchmaker does not take part
+in the match protocol itself, just the matchmaking protocol, **this makes the matchmaking server
+game agnostic**. Different games can connect to the same matchmaking server, and they can make sure
+they are only connected to players playing the same game, by specifying a unique `match_data`.
+
+> **Note:** To be clear, the game implementation sets the `match_data` for players. Players are
+> never exposed directly to the concept of the `match_data`.
+
+#### Waiting For Players
+
+After the initial connection and match request, the server will send the client an
+[`Accepted`][crate::external::bones_matchmaker_proto::MatchmakerResponse::Accepted] message.
+
+If the waiting room for that match already has the desired number of players in it, the server will
+then respond immediately with a
+[`Success`][crate::external::bones_matchmaker_proto::MatchmakerResponse::Success] message. This
+message comes with:
+
+- a `random_seed` that can be used by all clients to generate deterministic random numbers, and
+- a `player_idx` that tells the client _which_ player in the match it is. This is used throughout
+    the game to keep track of the players, and is between `0` and `player_count - 1`.
+
+#### In the Match
+
+Immediately after the desired number of clients have joined and the `Success` message has been sent
+to all players, the matchmaker goes into proxy mode for all clients in the match.
+
+Once in proxy mode, the server listens for
+[`SendProxyMessage`][crate::external::bones_matchmaker_proto::SendProxyMessage]s from clients. Each
+message simply specifies a [`TargetClient`][crate::external::bones_matchmaker_proto::TargetClient] (
+either a specific client or all of them ), and a binary message data.
+
+Once it a `SendProxyMessage` it will send it to the target client, which will receive it in the form
+of a [`RecvProxyMessage`][crate::external::bones_matchmaker_proto::RecvProxyMessage], containing the
+message data, and the index of the client that sent the message.
+
+The matchmaking server supports forwarding both reliable and unreliable message in this way,
+allowing the game to chose any kind of protocol it sees fit to synchronize the match data.

--- a/framework_crates/bones_framework/src/networking/online.rs
+++ b/framework_crates/bones_framework/src/networking/online.rs
@@ -1,0 +1,416 @@
+#![doc = include_str!("./online.md")]
+// TODO
+#![allow(missing_docs)]
+
+use std::{
+    net::{SocketAddr, ToSocketAddrs},
+    sync::Arc,
+};
+
+use bevy_tasks::IoTaskPool;
+use bones_matchmaker_proto::{MatchInfo, MatchmakerRequest, MatchmakerResponse};
+use bytes::Bytes;
+use futures_lite::future;
+use once_cell::sync::Lazy;
+use quinn::Connection;
+use tracing::{info, warn};
+
+use crate::{networking::NetworkMatchSocket, prelude::*};
+
+use super::{BoxedNonBlockingSocket, NetworkSocket, SocketTarget, MAX_PLAYERS, NETWORK_ENDPOINT};
+
+#[derive(Default, PartialEq, Eq, Clone, Copy)]
+pub enum SearchState {
+    #[default]
+    Connecting,
+    Searching,
+    WaitingForPlayers(usize),
+}
+
+/// Online matchmaker channel
+pub static ONLINE_MATCHMAKER: Lazy<OnlineMatchmaker> = Lazy::new(|| {
+    let (client, server) = bi_channel();
+
+    IoTaskPool::get().spawn(online_matchmaker(server)).detach();
+
+    OnlineMatchmaker(client)
+});
+
+/// Channel to exchagne messages with matchmaking server
+#[derive(DerefMut, Deref)]
+pub struct OnlineMatchmaker(BiChannelClient<OnlineMatchmakerRequest, OnlineMatchmakerResponse>);
+
+/// Online matchmaker request
+#[derive(Debug)]
+pub enum OnlineMatchmakerRequest {
+    SearchForGame { addr: String, player_count: usize },
+    StopSearch,
+}
+
+/// Online matchmaker response
+#[derive(Debug)]
+pub enum OnlineMatchmakerResponse {
+    Searching,
+    PlayerCount(usize),
+    GameStarting {
+        online_socket: OnlineSocket,
+        player_idx: usize,
+        player_count: usize,
+    },
+}
+
+async fn online_matchmaker(
+    matchmaker_channel: BiChannelServer<OnlineMatchmakerRequest, OnlineMatchmakerResponse>,
+) {
+    while let Ok(message) = matchmaker_channel.recv().await {
+        match message {
+            OnlineMatchmakerRequest::SearchForGame { addr, player_count } => {
+                info!("Connecting to online matchmaker");
+                let addr = resolve_addr_blocking(&addr).unwrap();
+                let conn = NETWORK_ENDPOINT
+                    .connect(addr, "matchmaker")
+                    .unwrap()
+                    .await
+                    .unwrap();
+                info!("Connected to online matchmaker");
+
+                matchmaker_channel
+                    .try_send(OnlineMatchmakerResponse::Searching)
+                    .unwrap();
+
+                // Send a match request to the server
+                let (mut send, mut recv) = conn.open_bi().await.unwrap();
+
+                let message = MatchmakerRequest::RequestMatch(MatchInfo {
+                    client_count: player_count.try_into().unwrap(),
+                    match_data: b"jumpy_default_game".to_vec(),
+                });
+                info!(request=?message, "Sending match request");
+                let message = postcard::to_allocvec(&message).unwrap();
+                send.write_all(&message).await.unwrap();
+                send.finish().await.unwrap();
+
+                let response = recv.read_to_end(256).await.unwrap();
+                let message: MatchmakerResponse = postcard::from_bytes(&response).unwrap();
+
+                if let MatchmakerResponse::Accepted = message {
+                    info!("Waiting for match...");
+                } else {
+                    panic!("Invalid response from matchmaker");
+                }
+
+                loop {
+                    let recv_ui_message = matchmaker_channel.recv();
+                    let recv_online_matchmaker = conn.accept_uni();
+
+                    let next_message = futures_lite::future::or(
+                        async move { either::Left(recv_ui_message.await) },
+                        async move { either::Right(recv_online_matchmaker.await) },
+                    )
+                    .await;
+
+                    match next_message {
+                        // UI message
+                        either::Either::Left(message) => {
+                            let message = message.unwrap();
+
+                            match message {
+                                OnlineMatchmakerRequest::SearchForGame { .. } => {
+                                    panic!("Unexpected message from UI");
+                                }
+                                OnlineMatchmakerRequest::StopSearch => {
+                                    info!("Canceling online search");
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Matchmaker message
+                        either::Either::Right(recv) => {
+                            let mut recv = recv.unwrap();
+                            let message = recv.read_to_end(256).await.unwrap();
+                            let message: MatchmakerResponse =
+                                postcard::from_bytes(&message).unwrap();
+
+                            match message {
+                                MatchmakerResponse::ClientCount(count) => {
+                                    info!("Online match player count: {count}");
+                                    matchmaker_channel
+                                        .try_send(OnlineMatchmakerResponse::PlayerCount(count as _))
+                                        .unwrap();
+                                }
+                                MatchmakerResponse::Success {
+                                    random_seed,
+                                    player_idx,
+                                    client_count,
+                                } => {
+                                    info!(%random_seed, %player_idx, player_count=%client_count, "Online match complete");
+                                    let online_socket = OnlineSocket::new(
+                                        player_idx as usize,
+                                        client_count as usize,
+                                        conn,
+                                    );
+
+                                    matchmaker_channel
+                                        .try_send(OnlineMatchmakerResponse::GameStarting {
+                                            online_socket,
+                                            player_idx: player_idx as _,
+                                            player_count: client_count as _,
+                                        })
+                                        .unwrap();
+                                    break;
+                                }
+                                _ => panic!("Unexpected message from matchmaker"),
+                            }
+                        }
+                    }
+                }
+            }
+            OnlineMatchmakerRequest::StopSearch => (), // Not searching, don't do anything
+        }
+    }
+}
+
+/// Resolve a server address.
+///
+/// Note: This may block the thread
+fn resolve_addr_blocking(addr: &str) -> anyhow::Result<SocketAddr> {
+    let formatting_err =
+        || anyhow::format_err!("Matchmaking server must be in the format `host:port`");
+
+    let mut iter = addr.split(':');
+    let host = iter.next().ok_or_else(formatting_err)?;
+    let port = iter.next().ok_or_else(formatting_err)?;
+    let port: u16 = port.parse().context("Couldn't parse port number")?;
+    if iter.next().is_some() {
+        return Err(formatting_err());
+    }
+
+    let addr = (host, port)
+        .to_socket_addrs()
+        .context("Couldn't resolve matchmaker address")?
+        .find(|x| x.is_ipv4()) // For now, only support IpV4. I don't think IpV6 works right.
+        .ok_or_else(|| anyhow::format_err!("Couldn't resolve matchmaker address"))?;
+
+    Ok(addr)
+}
+
+#[derive(Debug, Clone)]
+pub struct OnlineSocket {
+    pub conn: Connection,
+    pub ggrs_receiver: async_channel::Receiver<(usize, ggrs::Message)>,
+    pub reliable_receiver: async_channel::Receiver<(usize, Vec<u8>)>,
+    pub player_idx: usize,
+    pub player_count: usize,
+}
+
+impl OnlineSocket {
+    pub fn new(player_idx: usize, player_count: usize, conn: Connection) -> Self {
+        let (ggrs_sender, ggrs_receiver) = async_channel::unbounded();
+        let (reliable_sender, reliable_receiver) = async_channel::unbounded();
+
+        let task_pool = IoTaskPool::get();
+
+        let conn_ = conn.clone();
+        task_pool
+            .spawn(async move {
+                let conn = conn_;
+                loop {
+                    let event = future::or(async { either::Left(conn.closed().await) }, async {
+                        either::Right(conn.read_datagram().await)
+                    })
+                    .await;
+
+                    match event {
+                        either::Either::Left(closed) => {
+                            warn!("Connection error: {closed}");
+                            break;
+                        }
+                        either::Either::Right(datagram_result) => match datagram_result {
+                            Ok(data) => {
+                                let message: bones_matchmaker_proto::RecvProxyMessage =
+                                    postcard::from_bytes(&data)
+                                        .expect("Could not deserialize net message");
+                                let player = message.from_client;
+                                let message = postcard::from_bytes(&message.message).unwrap();
+
+                                if ggrs_sender.send((player as _, message)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                warn!("Connection error: {e}");
+                            }
+                        },
+                    }
+                }
+            })
+            .detach();
+
+        let conn_ = conn.clone();
+        task_pool
+            .spawn(async move {
+                let conn = conn_;
+                loop {
+                    let event = future::or(async { either::Left(conn.closed().await) }, async {
+                        either::Right(conn.accept_uni().await)
+                    })
+                    .await;
+
+                    match event {
+                        either::Either::Left(closed) => {
+                            warn!("Connection error: {closed}");
+                            break;
+                        }
+                        either::Either::Right(result) => match result {
+                            Ok(mut stream) => {
+                                let data =
+                                    stream.read_to_end(4096).await.expect("Network read error");
+                                let message: bones_matchmaker_proto::RecvProxyMessage =
+                                    postcard::from_bytes(&data).unwrap();
+
+                                if reliable_sender
+                                    .send((message.from_client as usize, message.message))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                warn!("Connection error: {e}");
+                            }
+                        },
+                    }
+                }
+            })
+            .detach();
+
+        Self {
+            conn,
+            ggrs_receiver,
+            reliable_receiver,
+            player_idx,
+            player_count,
+        }
+    }
+}
+
+// TODO see zig's PR
+impl NetworkSocket for OnlineSocket {
+    fn ggrs_socket(&self) -> BoxedNonBlockingSocket {
+        BoxedNonBlockingSocket(Box::new(self.clone()))
+    }
+
+    fn send_reliable(&self, target: SocketTarget, message: &[u8]) {
+        let task_pool = IoTaskPool::get();
+        let target_client = match target {
+            SocketTarget::Player(player) => bones_matchmaker_proto::TargetClient::One(player as _),
+            SocketTarget::All => bones_matchmaker_proto::TargetClient::All,
+        };
+        let message = bones_matchmaker_proto::SendProxyMessage {
+            target_client,
+            message: message.into(),
+        };
+
+        let conn = self.conn.clone();
+        task_pool
+            .spawn(async move {
+                let mut send = conn.open_uni().await.unwrap();
+
+                send.write_all(&postcard::to_allocvec(&message).unwrap())
+                    .await
+                    .unwrap();
+                send.finish().await.unwrap();
+            })
+            .detach();
+    }
+
+    fn recv_reliable(&self) -> Vec<(usize, Vec<u8>)> {
+        let mut messages = Vec::new();
+        while let Ok(message) = self.reliable_receiver.try_recv() {
+            messages.push(message);
+        }
+        messages
+    }
+
+    fn close(&self) {
+        self.conn.close(0u8.into(), &[]);
+    }
+
+    fn player_idx(&self) -> usize {
+        self.player_idx
+    }
+
+    fn player_is_local(&self) -> [bool; MAX_PLAYERS] {
+        std::array::from_fn(|i| i == self.player_idx)
+    }
+
+    fn player_count(&self) -> usize {
+        self.player_count
+    }
+}
+
+impl ggrs::NonBlockingSocket<usize> for OnlineSocket {
+    fn send_to(&mut self, msg: &ggrs::Message, addr: &usize) {
+        let message = bones_matchmaker_proto::SendProxyMessage {
+            target_client: bones_matchmaker_proto::TargetClient::One(*addr as u8),
+            message: postcard::to_allocvec(msg).unwrap(),
+        };
+        let msg_bytes = postcard::to_allocvec(&message).unwrap();
+        self.conn
+            .send_datagram(Bytes::copy_from_slice(&msg_bytes[..]))
+            .ok();
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(usize, ggrs::Message)> {
+        let mut messages = Vec::new();
+        while let Ok(message) = self.ggrs_receiver.try_recv() {
+            messages.push(message);
+        }
+        messages
+    }
+}
+
+/// Search for game with `matchmaking_server` and `player_count`
+pub fn start_search_for_game(matchmaking_server: String, player_count: usize) {
+    // TODO remove
+    info!("Starting search for online game with player count {player_count}");
+    ONLINE_MATCHMAKER
+        .try_send(OnlineMatchmakerRequest::SearchForGame {
+            addr: matchmaking_server.clone(),
+            player_count,
+        })
+        .unwrap()
+}
+
+/// Stop searching for game
+pub fn stop_search_for_game() -> Result<(), async_channel::TrySendError<OnlineMatchmakerRequest>> {
+    ONLINE_MATCHMAKER.try_send(OnlineMatchmakerRequest::StopSearch)
+}
+
+/// Update state of game matchmaking, update `search_state`, return [`NetworkMatchSocket`] once connected.
+pub fn update_search_for_game(search_state: &mut SearchState) -> Option<NetworkMatchSocket> {
+    while let Ok(message) = ONLINE_MATCHMAKER.try_recv() {
+        match message {
+            OnlineMatchmakerResponse::Searching => *search_state = SearchState::Searching,
+            OnlineMatchmakerResponse::PlayerCount(count) => {
+                warn!("Waiting for players: {count}");
+                *search_state = SearchState::WaitingForPlayers(count)
+            }
+            OnlineMatchmakerResponse::GameStarting {
+                online_socket,
+                player_idx,
+                player_count: _,
+            } => {
+                info!(?player_idx, "Starting network game");
+
+                *search_state = default();
+
+                return Some(NetworkMatchSocket(Arc::new(online_socket)));
+            }
+        }
+    }
+
+    None
+}

--- a/framework_crates/bones_framework/src/networking/proto.rs
+++ b/framework_crates/bones_framework/src/networking/proto.rs
@@ -6,7 +6,7 @@ use numquant::{IntRange, Quantized};
 use crate::prelude::*;
 
 /// A newtype around [`Vec2`] that implements [`From<u16>`] and [`Into<u16>`] as a way to compress
-/// user stick input for use in [`DensePlayerControl`].
+/// user stick input for use in [`self::input::DenseInput`].
 #[derive(Debug, Deref, DerefMut, Default)]
 pub struct DenseMoveDirection(pub Vec2);
 

--- a/framework_crates/bones_framework/src/networking/proto.rs
+++ b/framework_crates/bones_framework/src/networking/proto.rs
@@ -1,0 +1,47 @@
+//! Serializable data types for network messages used by the game.
+
+// use bevy::reflect::Reflect;
+use numquant::{IntRange, Quantized};
+
+use crate::prelude::*;
+
+/// A newtype around [`Vec2`] that implements [`From<u16>`] and [`Into<u16>`] as a way to compress
+/// user stick input for use in [`DensePlayerControl`].
+#[derive(Debug, Deref, DerefMut, Default)]
+pub struct DenseMoveDirection(pub Vec2);
+
+/// This is the specific [`Quantized`] type that we use to represent movement directions in
+/// [`DenseMoveDirection`].
+type MoveDirQuant = Quantized<IntRange<u16, 0b111111, -1, 1>>;
+
+impl From<u16> for DenseMoveDirection {
+    fn from(bits: u16) -> Self {
+        // maximum movement value representable, we use 6 bits to represent each movement direction.
+        let max = 0b111111;
+        // The first six bits represent the x movement
+        let x_move_bits = bits & max;
+        // The second six bits represents the y movement
+        let y_move_bits = (bits >> 6) & max;
+
+        // Round near-zero values to zero
+        let mut x = MoveDirQuant::from_raw(x_move_bits).to_f32();
+        if x.abs() < 0.02 {
+            x = 0.0;
+        }
+        let mut y = MoveDirQuant::from_raw(y_move_bits).to_f32();
+        if y.abs() < 0.02 {
+            y = 0.0;
+        }
+
+        DenseMoveDirection(Vec2::new(x, y))
+    }
+}
+
+impl From<DenseMoveDirection> for u16 {
+    fn from(dir: DenseMoveDirection) -> Self {
+        let x_bits = MoveDirQuant::from_f32(dir.x).raw();
+        let y_bits = MoveDirQuant::from_f32(dir.y).raw();
+
+        x_bits | (y_bits << 6)
+    }
+}

--- a/framework_crates/bones_framework/src/utils.rs
+++ b/framework_crates/bones_framework/src/utils.rs
@@ -1,0 +1,88 @@
+//! Miscellaneous utilities.
+
+use async_channel::*;
+
+/// Create a bi-directional channel with a given request and response type.
+///
+/// This reduces the boilerplate required to implement patterns where you need to send data across a
+/// channel, but in both directions.
+pub fn bi_channel<Request, Response>() -> (
+    BiChannelClient<Request, Response>,
+    BiChannelServer<Request, Response>,
+) {
+    let (request_sender, request_receiver) = async_channel::unbounded();
+    let (response_sender, response_receiver) = async_channel::unbounded();
+
+    (
+        BiChannelClient {
+            request_sender,
+            response_receiver,
+        },
+        BiChannelServer {
+            request_receiver,
+            response_sender,
+        },
+    )
+}
+
+/// A [`bi_channel`] client.
+///
+/// See [`bi_channel`].
+#[allow(missing_docs)]
+pub struct BiChannelClient<Request, Response> {
+    pub request_sender: Sender<Request>,
+    pub response_receiver: Receiver<Response>,
+}
+
+#[allow(missing_docs)]
+impl<Req, Res> BiChannelClient<Req, Res> {
+    pub fn recv_blocking(&self) -> Result<Res, RecvError> {
+        self.response_receiver.recv_blocking()
+    }
+    pub fn send_blocking(&self, req: Req) -> Result<(), SendError<Req>> {
+        self.request_sender.send_blocking(req)
+    }
+    pub async fn send(&self, req: Req) -> Result<(), SendError<Req>> {
+        self.request_sender.send(req).await
+    }
+    pub async fn recv(&self) -> Result<Res, RecvError> {
+        self.response_receiver.recv().await
+    }
+    pub fn try_send(&self, req: Req) -> Result<(), TrySendError<Req>> {
+        self.request_sender.try_send(req)
+    }
+    pub fn try_recv(&self) -> Result<Res, TryRecvError> {
+        self.response_receiver.try_recv()
+    }
+}
+
+/// A [`bi_channel`] server.
+///
+/// See [`bi_channel`].
+#[allow(missing_docs)]
+pub struct BiChannelServer<Request, Response> {
+    pub request_receiver: Receiver<Request>,
+    pub response_sender: Sender<Response>,
+}
+
+#[allow(missing_docs)]
+impl<Req, Res> BiChannelServer<Req, Res> {
+    pub fn recv_blocking(&self) -> Result<Req, RecvError> {
+        self.request_receiver.recv_blocking()
+    }
+    pub fn send_blocking(&self, res: Res) -> Result<(), SendError<Res>> {
+        self.response_sender.send_blocking(res)
+    }
+    pub async fn send(&self, res: Res) -> Result<(), SendError<Res>> {
+        self.response_sender.send(res).await
+    }
+    pub async fn recv(&self) -> Result<Req, RecvError> {
+        self.request_receiver.recv().await
+    }
+    pub fn try_send(&self, res: Res) -> Result<(), TrySendError<Res>> {
+        self.response_sender.try_send(res)
+    }
+    pub fn try_recv(&self) -> Result<Req, TryRecvError> {
+        self.request_receiver.try_recv()
+    }
+}


### PR DESCRIPTION
This is the bones half of getting networking back in.

Most things haven't changed much here, though I did define a number of input traits, for collecting / managing input. I tried to not have a million generic type params everywhere, used a lot of associated types, but unsure if this ended up being better or worse, as got a little hairy in spots.

Handling player disconnects is TODO. (not sure how we used to handle this, will look).