### PR TITLE
fix: fix conversion of bones `Color` to `egui::Color32`.

### DIFF
--- a/framework_crates/bones_framework/src/render/color.rs
+++ b/framework_crates/bones_framework/src/render/color.rs
@@ -32,7 +32,13 @@ impl From<Color> for egui::Color32 {
                 green,
                 blue,
                 alpha,
-            } => egui::Rgba::from_rgba_unmultiplied(red, green, blue, alpha).into(),
+            } => egui::Rgba::from_srgba_unmultiplied(
+                (red * 255.0) as u8,
+                (green * 255.0) as u8,
+                (blue * 255.0) as u8,
+                (alpha * 255.0) as u8,
+            )
+            .into(),
         }
     }
 }


### PR DESCRIPTION
Uses sRGB conversion instead of linear conversion.

This fixes the display of UI colors specified in Jumpy style assets.