### PR TITLE
fix: preserve sessions when loading world snapshot in networking.

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -400,7 +400,20 @@ where
                                     cell.save(frame, Some(world.clone()), None)
                                 }
                                 ggrs::GGRSRequest::LoadGameState { cell, .. } => {
+                                    // Swap out sessions to preserve them after world save.
+                                    // Sessions clone makes empty copy, so saved snapshots do not include sessions.
+                                    // Sessions are borrowed from Game for execution of this session,
+                                    // they are not like other resources and should not be preserved.
+                                    let mut sessions = Sessions::default();
+                                    std::mem::swap(
+                                        &mut sessions,
+                                        &mut world.resource_mut::<Sessions>(),
+                                    );
                                     *world = cell.load().unwrap_or_default();
+                                    std::mem::swap(
+                                        &mut sessions,
+                                        &mut world.resource_mut::<Sessions>(),
+                                    );
                                 }
                                 ggrs::GGRSRequest::AdvanceFrame {
                                     inputs: network_inputs,


### PR DESCRIPTION
This fixes non-running sessions (borrowed from Game) being lost during net rollback, as they are cloned empty. Fixes #336 

