### PR TITLE
feat(optional_queries): Allow entities.iter_with to optionally retrieve components without filtering on them. (#340)

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -27,7 +27,9 @@ use bevy_egui::EguiContext;
 use glam::*;
 
 use bevy_prototype_lyon::prelude as lyon;
-use bones_framework::prelude::{self as bones, BitSet, SchemaBox, SCHEMA_REGISTRY};
+use bones_framework::prelude::{
+    self as bones, BitSet, ComponentIterBitset, SchemaBox, SCHEMA_REGISTRY,
+};
 use prelude::convert::{IntoBevy, IntoBones};
 use serde::{de::Visitor, Deserialize, Serialize};
 

--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -213,7 +213,7 @@ mod test {
             let comp_a = Ref::new(&components_a);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, a) in entities.iter_with(&Optional(comp_a)) {
+            for (_, a) in entities.iter_with(&Optional(&comp_a)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -224,10 +224,10 @@ mod test {
         }
         // Mutably Iterate over all entities, optionally retrieve A
         {
-            let comp_a_mut = RefMut::new(&mut components_a);
+            let mut comp_a_mut = RefMut::new(&mut components_a);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, a) in entities.iter_with(&mut Optional(comp_a_mut)) {
+            for (_, a) in entities.iter_with(&mut OptionalMut(&mut comp_a_mut)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -243,7 +243,7 @@ mod test {
             let comp_b = Ref::new(&components_b);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, (a, _b)) in entities.iter_with((&Optional(comp_a), &comp_b)) {
+            for (_, (a, _b)) in entities.iter_with((&Optional(&comp_a), &comp_b)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -258,7 +258,7 @@ mod test {
             let comp_a = Ref::new(&components_a);
             let comp_b = Ref::new(&components_b);
             let mut count = 0;
-            for (_, (_a, b)) in entities.iter_with((&comp_a, &Optional(comp_b))) {
+            for (_, (_a, b)) in entities.iter_with((&comp_a, &Optional(&comp_b))) {
                 count += 1;
                 assert!(b.is_some());
             }
@@ -280,7 +280,7 @@ mod test {
             let comp_c = Ref::new(&components_c);
 
             let mut count = 0;
-            for (_, (_, c)) in entities.iter_with((&comp_a, &Optional(comp_c))) {
+            for (_, (_, c)) in entities.iter_with((&comp_a, &Optional(&comp_c))) {
                 count += 1;
                 // Should not iterate over entity with C, as it does not have A.
                 assert!(c.is_none());

--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -213,7 +213,7 @@ mod test {
             let comp_a = Ref::new(&components_a);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, a) in entities.iter_with(&Optional::from(comp_a)) {
+            for (_, a) in entities.iter_with(&Optional(comp_a)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -227,7 +227,7 @@ mod test {
             let comp_a_mut = RefMut::new(&mut components_a);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, a) in entities.iter_with(&mut Optional::from(comp_a_mut)) {
+            for (_, a) in entities.iter_with(&mut Optional(comp_a_mut)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -243,7 +243,7 @@ mod test {
             let comp_b = Ref::new(&components_b);
             let mut count_a = 0;
             let mut count = 0;
-            for (_, (a, _b)) in entities.iter_with((&Optional::from(comp_a), &comp_b)) {
+            for (_, (a, _b)) in entities.iter_with((&Optional(comp_a), &comp_b)) {
                 count += 1;
                 if a.is_some() {
                     count_a += 1;
@@ -258,7 +258,7 @@ mod test {
             let comp_a = Ref::new(&components_a);
             let comp_b = Ref::new(&components_b);
             let mut count = 0;
-            for (_, (_a, b)) in entities.iter_with((&comp_a, &Optional::from(comp_b))) {
+            for (_, (_a, b)) in entities.iter_with((&comp_a, &Optional(comp_b))) {
                 count += 1;
                 assert!(b.is_some());
             }

--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -264,5 +264,29 @@ mod test {
             }
             assert_eq!(count, 1);
         }
+
+        // Make sure that entities with only optional components are still filtered by others,
+        // and not included in query.
+        //
+        // Case: 4 entities, we query over A and Optionally C, where entities have comps: 0:[AB],1:[B],2:[C],3:[A]
+        // Filtered by A, should iterate over entities 0 and 3. Verify that entitiy 2 with C is not included.
+        {
+            let e3 = entities.create();
+            let e4 = entities.create();
+            let mut components_c = ComponentStore::<A>::default();
+            components_c.insert(e3, A);
+            components_a.insert(e4, A);
+            let comp_a = Ref::new(&components_a);
+            let comp_c = Ref::new(&components_c);
+
+            let mut count = 0;
+            for (_, (_, c)) in entities.iter_with((&comp_a, &Optional(comp_c))) {
+                count += 1;
+                // Should not iterate over entity with C, as it does not have A.
+                assert!(c.is_none());
+            }
+            // Expected two entities with A
+            assert_eq!(count, 2);
+        }
     }
 }

--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -6,10 +6,24 @@ use crate::prelude::*;
 pub type ComponentBitsetIterator<'a, T> =
     std::iter::Map<UntypedComponentBitsetIterator<'a>, for<'b> fn(SchemaRef<'b>) -> &'b T>;
 
+/// Read-only iterator over components matching a given bitset.
+/// Returns None for entities matching bitset but not in this ComponentStore.
+pub type ComponentBitsetOptionalIterator<'a, T> = std::iter::Map<
+    UntypedComponentOptionalBitsetIterator<'a>,
+    for<'b> fn(Option<SchemaRef<'b>>) -> Option<&'b T>,
+>;
+
 /// Mutable iterator over components matching a given bitset
 pub type ComponentBitsetIteratorMut<'a, T> = std::iter::Map<
     UntypedComponentBitsetIteratorMut<'a>,
     for<'b> fn(SchemaRefMut<'b>) -> &'b mut T,
+>;
+
+/// Mutable iterator over components matching a given bitset.
+/// Returns None for entities matching bitset but not in this ComponentStore.
+pub type ComponentBitsetOptionalIteratorMut<'a, T> = std::iter::Map<
+    UntypedComponentOptionalBitsetIteratorMut<'a>,
+    for<'b> fn(Option<SchemaRefMut<'b>>) -> Option<&'b mut T>,
 >;
 
 /// Iterates over components using a provided bitset. Each time the bitset has a 1 in index i, the
@@ -39,6 +53,44 @@ impl<'a> Iterator for UntypedComponentBitsetIterator<'a> {
                 )
             })
         } else {
+            None
+        };
+        self.current_id += 1;
+        ret
+    }
+}
+
+/// Iterate over component store returning `Option<SchemaRef<'a>>`,
+/// filtered by bitset of iterator, but not bitset of own ComponentStore. Returns None on
+/// bitset entries that do not have this Component.
+#[derive(Deref, DerefMut)]
+pub struct UntypedComponentOptionalBitsetIterator<'a>(pub UntypedComponentBitsetIterator<'a>);
+
+impl<'a> Iterator for UntypedComponentOptionalBitsetIterator<'a> {
+    type Item = Option<SchemaRef<'a>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        // We stop iterating at bitset length, not component store length, as we want to iterate over
+        // whole bitset and return None for entities that don't have this optional component.
+        let max_id = self.bitset.bit_len() - 1;
+        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+            self.current_id += 1;
+        }
+        let ret = if self.current_id <= max_id {
+            // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
+            if self.components.bitset.bit_test(self.current_id) {
+                Some(Some(unsafe {
+                    SchemaRef::from_ptr_schema(
+                        self.components.storage.unchecked_idx(self.current_id),
+                        self.components.schema,
+                    )
+                }))
+            } else {
+                // Component at current_id is not in store, however we are still iterating,
+                // later ids in self.bitset may have components in store.
+                Some(None)
+            }
+        } else {
+            // Iterated through whole bitset
             None
         };
         self.current_id += 1;
@@ -81,12 +133,53 @@ impl<'a> Iterator for UntypedComponentBitsetIteratorMut<'a> {
     }
 }
 
+/// Iterate mutably over component store returning `Option<SchemaRef<'a>>`,
+/// filtered by bitset of iterator, but not bitset of own ComponentStore. Returns None on
+/// bitset entries that do not have this Component.
+#[derive(Deref, DerefMut)]
+pub struct UntypedComponentOptionalBitsetIteratorMut<'a>(pub UntypedComponentBitsetIteratorMut<'a>);
+
+impl<'a> Iterator for UntypedComponentOptionalBitsetIteratorMut<'a> {
+    type Item = Option<SchemaRefMut<'a>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        // We do not stop iterating at component store length, as we want to iterate over
+        // whole bitset and return None for entities that don't have this optional component.
+        let max_id = self.bitset.bit_len() - 1;
+        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+            self.current_id += 1;
+        }
+        let ret = if self.current_id <= max_id {
+            // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
+            if self.components.bitset.bit_test(self.current_id) {
+                Some(Some(unsafe {
+                    SchemaRefMut::from_ptr_schema(
+                        self.components.storage.unchecked_idx(self.current_id),
+                        self.components.schema,
+                    )
+                }))
+            } else {
+                // Component at current_id is not in store, however we are still iterating,
+                // later ids in self.bitset may have components in store.
+                Some(None)
+            }
+        } else {
+            // Iterated through whole bitset
+            None
+        };
+        self.current_id += 1;
+        ret
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[derive(Clone, HasSchema, Default)]
     struct A;
+
+    #[derive(Clone, HasSchema, Default)]
+    struct B;
 
     #[test]
     fn iter_with_empty_bitset() {
@@ -99,5 +192,77 @@ mod test {
         let bitset = Rc::new(BitSetVec::default());
         assert_eq!(components.iter_with_bitset(bitset.clone()).count(), 0);
         assert_eq!(components.iter_mut_with_bitset(bitset).count(), 0);
+    }
+
+    #[test]
+    /// Test that iterating with optional components does not filter entities.
+    fn iter_with_optional() {
+        // Initialize two total entities, both with B, one with A.
+        let mut entities = Entities::default();
+        let e1 = entities.create();
+        let e2 = entities.create();
+        let mut components_a = ComponentStore::<A>::default();
+        components_a.insert(e1, A);
+
+        let mut components_b = ComponentStore::<B>::default();
+        components_b.insert(e1, B);
+        components_b.insert(e2, B);
+
+        // Iterate over all entities, optionally retrieve A
+        {
+            let comp_a = Ref::new(&components_a);
+            let mut count_a = 0;
+            let mut count = 0;
+            for (_, a) in entities.iter_with(&Optional::from(comp_a)) {
+                count += 1;
+                if a.is_some() {
+                    count_a += 1;
+                }
+            }
+            assert_eq!(count_a, 1);
+            assert_eq!(count, 2);
+        }
+        // Mutably Iterate over all entities, optionally retrieve A
+        {
+            let comp_a_mut = RefMut::new(&mut components_a);
+            let mut count_a = 0;
+            let mut count = 0;
+            for (_, a) in entities.iter_with(&mut Optional::from(comp_a_mut)) {
+                count += 1;
+                if a.is_some() {
+                    count_a += 1;
+                }
+            }
+            assert_eq!(count_a, 1);
+            assert_eq!(count, 2);
+        }
+
+        // Iterate over entities with B and optionaly retrieve A
+        {
+            let comp_a = Ref::new(&components_a);
+            let comp_b = Ref::new(&components_b);
+            let mut count_a = 0;
+            let mut count = 0;
+            for (_, (a, _b)) in entities.iter_with((&Optional::from(comp_a), &comp_b)) {
+                count += 1;
+                if a.is_some() {
+                    count_a += 1;
+                }
+            }
+            assert_eq!(count_a, 1);
+            assert_eq!(count, 2);
+        }
+
+        // Iterate over entities with A, and optionally retrieve B
+        {
+            let comp_a = Ref::new(&components_a);
+            let comp_b = Ref::new(&components_b);
+            let mut count = 0;
+            for (_, (_a, b)) in entities.iter_with((&comp_a, &Optional::from(comp_b))) {
+                count += 1;
+                assert!(b.is_some());
+            }
+            assert_eq!(count, 1);
+        }
     }
 }

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -509,6 +509,19 @@ impl UntypedComponentStore {
         }
     }
 
+    /// Iterates immutably over the components of this type where `bitset` indicates the indices of
+    /// entities. Iterator provides Option, returning None if there is no component for entity in bitset.
+    pub fn iter_with_bitset_optional(
+        &self,
+        bitset: Rc<BitSetVec>,
+    ) -> UntypedComponentOptionalBitsetIterator {
+        UntypedComponentOptionalBitsetIterator(UntypedComponentBitsetIterator {
+            current_id: 0,
+            components: self,
+            bitset,
+        })
+    }
+
     /// Iterates mutable over the components of this type where `bitset` indicates the indices of
     /// entities.
     ///
@@ -522,6 +535,19 @@ impl UntypedComponentStore {
             components: self,
             bitset,
         }
+    }
+
+    /// Iterates mutably over the components of this type where `bitset` indicates the indices of
+    /// entities. Iterator provides Option, returning None if there is no component for entity in bitset.
+    pub fn iter_mut_with_bitset_optional(
+        &mut self,
+        bitset: Rc<BitSetVec>,
+    ) -> UntypedComponentOptionalBitsetIteratorMut {
+        UntypedComponentOptionalBitsetIteratorMut(UntypedComponentBitsetIteratorMut {
+            current_id: 0,
+            components: self,
+            bitset,
+        })
     }
 
     /// Returns the bitset indicating which entity indices have a component associated to them.

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -163,11 +163,7 @@ where
     S: std::ops::Deref<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIterator<'a, T>;
-    fn apply_bitset(&self, _bitset: &mut BitSetVec) {
-        // Use bit_or as we want to grow bitset if needed, but not
-        // modifiy, as this component is optional.
-        // bitset.bit_or(self.0.bitset());
-    }
+    fn apply_bitset(&self, _bitset: &mut BitSetVec) {}
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
         self.0.iter_with_bitset_optional(bitset)
@@ -181,11 +177,7 @@ where
     S: std::ops::DerefMut<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIteratorMut<'a, T>;
-    fn apply_bitset(&self, _bitset: &mut BitSetVec) {
-        // Use bit_or as we want to grow bitset if needed, but not
-        // modifiy, as this component is optional.
-        // bitset.bit_or(self.0.bitset());
-    }
+    fn apply_bitset(&self, _bitset: &mut BitSetVec) {}
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
         self.0.iter_mut_with_bitset_optional(bitset)

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -1,6 +1,6 @@
 //! [`Entity`] implementation, storage, and interation.
 
-use std::rc::Rc;
+use std::{marker::PhantomData, rc::Rc};
 
 use crate::prelude::*;
 
@@ -94,10 +94,32 @@ pub trait QueryItem {
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter;
 }
 
-// TODO: Implement optional component query iterators.
-// We don't have the ability to do `entities.iter_with(Option<&my_comp>)`, but we should
-// be able to implement a `QueryItem` for that so that you can iterate over entities that
-// _might_ have a component.
+/// Wrapper for the [`Comp`] [`SystemParam`] used as [`QueryItem`] to iterate
+/// over enities optionally retrieving components from [`ComponentStore`].
+/// Entities iterated over will not be filtered by [`Optional`] [`QueryItem`].
+///
+/// This example filters entities by `compC`, optionally retrieves `compA` as mutable, and
+/// `compB` as immutable.
+///
+/// `entities.iter_with(&mut Optional::from(compA), &Optional::from(compB), &compC)`
+///
+/// This will implement [`QueryItem`] as long as generic type implements [`std::ops::Deref`] for
+/// [`ComponentStore`], such as [`Comp`] and [`CompMut`]. Mutable reference to [`Optional`] works
+/// if type implements [`std::ops::DerefMut`].
+pub struct Optional<'a, T: HasSchema, S>(pub S, pub PhantomData<&'a T>);
+
+impl<'a, T: HasSchema> From<Comp<'a, T>> for Optional<'a, T, Comp<'a, T>> {
+    fn from(comp: Comp<'a, T>) -> Self {
+        Optional(comp, PhantomData::<&'a T>)
+    }
+}
+
+impl<'a, T: HasSchema> From<CompMut<'a, T>> for Optional<'a, T, CompMut<'a, T>> {
+    fn from(comp: CompMut<'a, T>) -> Self {
+        Optional(comp, PhantomData::<&'a T>)
+    }
+}
+
 impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
     type Iter = ComponentBitsetIterator<'a, T>;
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
@@ -108,6 +130,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
         ComponentStore::iter_with_bitset(&**self, bitset)
     }
 }
+
 impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
     type Iter = ComponentBitsetIterator<'a, T>;
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
@@ -118,6 +141,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
         ComponentStore::iter_with_bitset(&**self, bitset)
     }
 }
+
 impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
     type Iter = ComponentBitsetIteratorMut<'a, T>;
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
@@ -126,6 +150,43 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
         ComponentStore::iter_mut_with_bitset(self, bitset)
+    }
+}
+
+/// Immutably iterate over optional component with syntax: `&Optional::from(Comp<T>)` / `&Optional::from(CompMut<T>)`.
+/// (For mutable optional iteration we require `&mut Optional::from(CompMut<T>)`)
+impl<'a: 'b, 'b, T: HasSchema, S, C> QueryItem for &'a Optional<'a, T, S>
+where
+    C: ComponentIterBitset<'a, T> + 'a,
+    S: std::ops::Deref<Target = C> + 'a,
+{
+    type Iter = ComponentBitsetOptionalIterator<'a, T>;
+    fn apply_bitset(&self, bitset: &mut BitSetVec) {
+        // Use bit_or as we want to grow bitset if needed, but not
+        // modifiy, as this component is optional.
+        bitset.bit_or(self.0.bitset());
+    }
+
+    fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
+        self.0.iter_with_bitset_optional(bitset)
+    }
+}
+
+/// Mutably iterate over optional component with syntax: `&mut Optional::from(RefMut<ComponentStore<T>>)`
+impl<'a: 'b, 'b, T: HasSchema, S, C> QueryItem for &'a mut Optional<'a, T, S>
+where
+    C: ComponentIterBitset<'a, T> + 'a,
+    S: std::ops::DerefMut<Target = C> + 'a,
+{
+    type Iter = ComponentBitsetOptionalIteratorMut<'a, T>;
+    fn apply_bitset(&self, bitset: &mut BitSetVec) {
+        // Use bit_or as we want to grow bitset if needed, but not
+        // modifiy, as this component is optional.
+        bitset.bit_or(self.0.bitset());
+    }
+
+    fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
+        self.0.iter_mut_with_bitset_optional(bitset)
     }
 }
 
@@ -292,6 +353,43 @@ impl Entities {
     ///     for (entity, (pos, vel)) in entities.iter_with((&mut pos, &vel)) {
     ///         pos.x += vel.x;
     ///         pos.y += vel.y;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// You may optionally iterate over components with `&Optional::from(comp)` or mutably with
+    /// `&mut Optional::from(comp_mut)`. This will not filter entities using [`Optional`] [`QueryItem`].
+    /// None is returned for these. If done with single Optional query item, all entities are iterated over.
+    ///
+    /// Syntax is `&Optional::from(comp)`, or `&mut Optional::from(comp)`, for now using a reference inside like
+    /// `&Optional::from(&comp)` will NOT work. See example below for usage.
+    ///
+    /// # [`Optional`] Example
+    ///
+    /// ```
+    /// /// # use bones_ecs::prelude::*;
+    /// # #[derive(HasSchema, Clone, Default)]
+    /// # #[repr(C)]
+    /// # struct Pos { x: f32, y: f32 };
+    /// # #[derive(HasSchema, Clone, Default)]
+    /// # #[repr(C)]
+    /// # struct Vel { x: f32, y: f32 };
+    /// # #[derive(HasSchema, Clone, Default)]
+    /// # #[repr(C)]
+    /// # struct PosMax { x: f32, y: f32 }
+    ///
+    /// fn my_system(entities: Res<Entities>, mut pos: CompMut<Pos>, vel: Comp<Vel>, pos_max: Comp<PosMax>) {
+    ///     for (entity, (pos, vel, pos_max)) in entities.iter_with((&mut pos, &vel, &Optional::from(pos_max))) {
+    ///         // Update pos from vel on all entities that have pos and vel components
+    ///         pos.x += vel.x;
+    ///         pos.y += vel.y;
+    ///
+    ///         // limit pos.x by pos_max.x if entity has PosMax component
+    ///         if let Some(pos_max) = pos_max {
+    ///             if pos.x > pos_max.x {
+    ///                 pos.x = pos_max.x
+    ///             }
+    ///         }
     ///     }
     /// }
     /// ```

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -367,7 +367,7 @@ impl Entities {
     /// # [`Optional`] Example
     ///
     /// ```
-    /// /// # use bones_ecs::prelude::*;
+    /// # use bones_ecs::prelude::*;
     /// # #[derive(HasSchema, Clone, Default)]
     /// # #[repr(C)]
     /// # struct Pos { x: f32, y: f32 };

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -157,7 +157,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
 
 /// Immutably iterate over optional component with syntax: `&Optional(Comp<T>)` / `&Optional(CompMut<T>)`.
 /// (For mutable optional iteration we require `&mut Optional(CompMut<T>)`)
-impl<'a: 'b, 'b, T: HasSchema, S, C> QueryItem for &'a OptionalQueryItem<'a, T, S>
+impl<'a, T: HasSchema, S, C> QueryItem for &'a OptionalQueryItem<'a, T, S>
 where
     C: ComponentIterBitset<'a, T> + 'a,
     S: std::ops::Deref<Target = C> + 'a,
@@ -175,7 +175,7 @@ where
 }
 
 /// Mutably iterate over optional component with syntax: `&mut Optional(RefMut<ComponentStore<T>>)`
-impl<'a: 'b, 'b, T: HasSchema, S, C> QueryItem for &'a mut OptionalQueryItem<'a, T, S>
+impl<'a, T: HasSchema, S, C> QueryItem for &'a mut OptionalQueryItem<'a, T, S>
 where
     C: ComponentIterBitset<'a, T> + 'a,
     S: std::ops::DerefMut<Target = C> + 'a,

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -359,12 +359,12 @@ impl Entities {
     /// }
     /// ```
     ///
-    /// You may optionally iterate over components with `&Optional::from(comp)` or mutably with
-    /// `&mut Optional::from(comp_mut)`. This will not filter entities using [`Optional`] [`QueryItem`].
+    /// You may optionally iterate over components with `&Optional(comp)` or mutably with
+    /// `&mut Optional(comp_mut)`. Entities are not filtered by component in [`OptionalQueryItem`].
     /// None is returned for these. If done with single Optional query item, all entities are iterated over.
     ///
-    /// Syntax is `&Optional::from(comp)`, or `&mut Optional::from(comp)`, for now using a reference inside like
-    /// `&Optional::from(&comp)` will NOT work. See example below for usage.
+    /// Syntax is `&Optional(comp)`, or `&mut Optional(comp)`, for now using a reference inside like
+    /// `&Optional(&comp)` will NOT work. See example below for usage.
     ///
     /// # [`Optional`] Example
     ///
@@ -381,7 +381,7 @@ impl Entities {
     /// # struct PosMax { x: f32, y: f32 }
     ///
     /// fn my_system(entities: Res<Entities>, mut pos: CompMut<Pos>, vel: Comp<Vel>, pos_max: Comp<PosMax>) {
-    ///     for (entity, (pos, vel, pos_max)) in entities.iter_with((&mut pos, &vel, &Optional::from(pos_max))) {
+    ///     for (entity, (pos, vel, pos_max)) in entities.iter_with((&mut pos, &vel, &Optional(pos_max))) {
     ///         // Update pos from vel on all entities that have pos and vel components
     ///         pos.x += vel.x;
     ///         pos.y += vel.y;

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -163,10 +163,10 @@ where
     S: std::ops::Deref<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIterator<'a, T>;
-    fn apply_bitset(&self, bitset: &mut BitSetVec) {
+    fn apply_bitset(&self, _bitset: &mut BitSetVec) {
         // Use bit_or as we want to grow bitset if needed, but not
         // modifiy, as this component is optional.
-        bitset.bit_or(self.0.bitset());
+        // bitset.bit_or(self.0.bitset());
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -181,10 +181,10 @@ where
     S: std::ops::DerefMut<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIteratorMut<'a, T>;
-    fn apply_bitset(&self, bitset: &mut BitSetVec) {
+    fn apply_bitset(&self, _bitset: &mut BitSetVec) {
         // Use bit_or as we want to grow bitset if needed, but not
         // modifiy, as this component is optional.
-        bitset.bit_or(self.0.bitset());
+        // bitset.bit_or(self.0.bitset());
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {


### PR DESCRIPTION
Adds an Optional type that can be built from Comp / CompMut to optionally retrieve components in entities.iter_with without filtering by them.

I split some of the iter bitset functions out of ComponentStore into ComponentIterBitset Trait, so that generic type in Optional can implement trait bounds and expose these for its QueryItems implementations. See doc comment or test for usage.

Resolves #340 