### PR TITLE
feat(frame-time-diagnostisc): Re-add frame time diagnostics window to bones

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/debug.rs
+++ b/framework_crates/bones_bevy_renderer/src/debug.rs
@@ -1,0 +1,48 @@
+//! Debug module for data that hooks into Bevy. Bevy frame diagnostics are synchronized into [`bones_framework::debug::FrameDiagState`]
+//! which may be displayed using [`bones_framework::debug`] module.
+use bevy::{
+    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
+    prelude::*,
+};
+use bones_framework::debug::FrameDiagState;
+
+use crate::BonesData;
+
+/// Plugin for debug tools that hook into Bevy, such as [`bevy::diagnostic::FrameTimeDiagnosticsPlugin`].
+pub struct BevyDebugPlugin;
+
+impl Plugin for BevyDebugPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin);
+        app.add_systems(Last, sync_frame_time);
+    }
+}
+
+fn sync_frame_time(mut bones_data: ResMut<BonesData>, diagnostics: Res<DiagnosticsStore>) {
+    let game = &mut bones_data.game;
+    let mut state = game.init_shared_resource::<FrameDiagState>();
+
+    let fps = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS).unwrap();
+    state.fps = fps.value().unwrap_or(0.0);
+    state.fps_avg = fps.average().unwrap_or(0.0);
+
+    if state.fps < state.min_fps {
+        state.min_fps = state.fps;
+    }
+    if state.fps > state.max_fps {
+        state.max_fps = state.fps;
+    }
+
+    let frame_time = diagnostics
+        .get(FrameTimeDiagnosticsPlugin::FRAME_TIME)
+        .unwrap();
+    state.frame_time = frame_time.value().unwrap_or(0.0);
+    state.frame_time_avg = frame_time.average().unwrap_or(0.0);
+
+    if state.frame_time < state.min_frame_time {
+        state.min_frame_time = state.frame_time;
+    }
+    if state.frame_time > state.max_frame_time {
+        state.max_frame_time = state.frame_time;
+    }
+}

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -39,6 +39,7 @@ pub mod prelude {
 }
 
 mod convert;
+mod debug;
 
 /// Marker component for entities that are rendered in Bevy for bones.
 #[derive(Component)]
@@ -226,7 +227,11 @@ impl BonesBevyRenderer {
         }
 
         app.add_plugins(plugins)
-            .add_plugins((bevy_egui::EguiPlugin, lyon::ShapePlugin))
+            .add_plugins((
+                bevy_egui::EguiPlugin,
+                lyon::ShapePlugin,
+                debug::BevyDebugPlugin,
+            ))
             .insert_resource({
                 let mut egui_settings = bevy_egui::EguiSettings::default();
                 if self.pixel_art {

--- a/framework_crates/bones_framework/src/debug.rs
+++ b/framework_crates/bones_framework/src/debug.rs
@@ -1,0 +1,106 @@
+//! Implements bones egui debug windows and tools.
+
+use crate::prelude::*;
+
+/// Track frame time state synced from bevy frame time diagnostics for bones app.
+#[derive(HasSchema, Clone)]
+#[allow(missing_docs)]
+pub struct FrameDiagState {
+    pub fps: f64,
+    pub fps_avg: f64,
+    pub min_fps: f64,
+    pub max_fps: f64,
+    pub frame_time: f64,
+    pub frame_time_avg: f64,
+    pub min_frame_time: f64,
+    pub max_frame_time: f64,
+}
+
+impl Default for FrameDiagState {
+    fn default() -> Self {
+        Self {
+            fps: 0.0,
+            fps_avg: 0.0,
+            min_fps: f64::MAX,
+            max_fps: 0.0,
+            frame_time: 0.0,
+            frame_time_avg: 0.0,
+            min_frame_time: f64::MAX,
+            max_frame_time: 0.0,
+        }
+    }
+}
+
+impl FrameDiagState {
+    /// Reset min/max values to default
+    pub fn reset(&mut self) {
+        self.min_fps = f64::MAX;
+        self.max_fps = 0.0;
+        self.min_frame_time = f64::MAX;
+        self.max_frame_time = 0.0;
+    }
+}
+
+/// State of frame time diagnostic window. Stored in [`EguiCtx`] state,
+/// setting open = true will open window if plugin installed.
+#[derive(Clone, Default)]
+pub struct FrameTimeWindowState {
+    /// Is window open?
+    pub open: bool,
+}
+
+/// If installed, allows opening egui window with [`FrameTimeWindowState`] in [`EguiCtx`] state
+/// to get frame time information.
+pub fn frame_time_diagnostics_plugin(core: &mut Session) {
+    core.stages
+        .add_system_to_stage(CoreStage::Last, frame_diagnostic_window);
+}
+
+/// Renders frame time diagnostic window in Egui if window is set to open in [`FrameTimeWindowState`]
+/// stored in [`EguiCtx`] state.
+pub fn frame_diagnostic_window(
+    mut state: ResMut<FrameDiagState>,
+    // localization: Res<Localization>,
+    egui_ctx: ResMut<EguiCtx>,
+) {
+    let mut window_state = egui_ctx.get_state::<FrameTimeWindowState>();
+    let window_open = &mut window_state.open;
+
+    if *window_open {
+        // egui::Window::new(&localization.get("frame-diagnostics"))
+        egui::Window::new("Frame Diagnostics")
+            .id(egui::Id::new("frame_diagnostics"))
+            .default_width(500.0)
+            .open(window_open)
+            .show(&egui_ctx, |ui| {
+                // if ui.button(&localization.get("reset-min-max")).clicked() {
+                if ui.button("Reset Min/Max").clicked() {
+                    state.reset();
+                }
+
+                ui.monospace(&format!(
+                    "{label:20}: {fps:4.0}{suffix:3} ( {min:4.0}{suffix:3}, {avg:4.0}{suffix:3}, {max:4.0}{suffix:3} )",
+                    // label = localization.get("frames-per-second"),
+                    label = "Frames Per Second",
+                    fps = state.fps,
+                    // suffix = fps.suffix,
+                    suffix = "fps",
+                    min = state.min_fps,
+                    avg = state.fps_avg,
+                    max = state.max_fps,
+                ));
+                ui.monospace(&format!(
+                    "{label:20}: {fps:4.1}{suffix:3} ( {min:4.1}{suffix:3}, {avg:4.0}{suffix:3}, {max:4.1}{suffix:3} )",
+                    // label = localization.get("frame-time"),
+                    label = "Frame Time",
+                    fps = state.frame_time,
+                    suffix = "ms",
+                    min = state.min_frame_time,
+                    avg = state.frame_time_avg,
+                    max = state.max_frame_time,
+                ));
+            });
+    }
+
+    egui_ctx.set_state(window_state);
+}

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -20,7 +20,7 @@ pub use glam;
 /// The prelude.
 pub mod prelude {
     pub use crate::{
-        animation::*, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
+        animation::*, debug, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
         utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin,
     };
 
@@ -42,6 +42,7 @@ pub mod prelude {
 }
 
 pub mod animation;
+pub mod debug;
 pub mod input;
 pub mod params;
 pub mod render;


### PR DESCRIPTION
If session plugin is installed, egui state may be used to display window.

Decided to continue using Bevy frame diagnostics plugin instead of measuring in bones, as wanted to make sure data is accurate / representative of full frame and not just the execution of bevy bones app.