### PR TITLE
fix(input): Support DenseMoveDirection from u32

### DIFF
--- a/framework_crates/bones_framework/src/networking/proto.rs
+++ b/framework_crates/bones_framework/src/networking/proto.rs
@@ -45,3 +45,17 @@ impl From<DenseMoveDirection> for u16 {
         x_bits | (y_bits << 6)
     }
 }
+
+impl From<u32> for DenseMoveDirection {
+    fn from(bits: u32) -> Self {
+        let bits_16 = bits as u16;
+        bits_16.into()
+    }
+}
+
+impl From<DenseMoveDirection> for u32 {
+    fn from(dir: DenseMoveDirection) -> Self {
+        let bits_16 = u16::from(dir);
+        bits_16 as u32
+    }
+}


### PR DESCRIPTION
In Jumpy am adding an additional input for ragdoll'ing self and this pushed us over 16 bits in input bitfield.

This change allows us to build `DenseMoveDirection` from a u32, otherwise the bitfield `DensePlayerControl` (in Jumpy) fails to compile.

Only the 12 least significant bits are used in DenseMoveDirection, so casting u32 -> u16 should not impact anything here.