### PR TITLE
feat: add `SystemParam` derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,12 +1272,33 @@ dependencies = [
  "anyhow",
  "atomicell",
  "bitset-core",
+ "bones_ecs_macros",
  "bones_schema",
  "bones_utils",
  "glam 0.24.2",
  "once_map",
  "paste",
  "thiserror",
+]
+
+[[package]]
+name = "bones_ecs_macros"
+version = "0.3.0"
+dependencies = [
+ "bevy_ecs",
+ "bones_ecs",
+ "bones_ecs_macros_core",
+ "bones_schema",
+ "proc-macro2",
+]
+
+[[package]]
+name = "bones_ecs_macros_core"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
 name = "bones_ecs_macros_core"
 version = "0.3.0"
 dependencies = [
+ "pretty_assertions",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -1923,6 +1924,12 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -4103,6 +4110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6067,6 +6084,12 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -11,7 +11,8 @@ categories.workspace    = true
 keywords.workspace      = true
 
 [features]
-default = ["keysize16"]
+default = ["derive", "keysize16"]
+derive  = ["dep:bones_ecs_macros"]
 glam    = ["dep:glam", "dep:paste", "bones_schema/glam"]
 
 keysize16 = []
@@ -22,6 +23,9 @@ keysize32 = []
 [dependencies]
 bones_utils  = { version = "0.3", path = "../bones_utils" }
 bones_schema = { version = "0.3", path = "../bones_schema" }
+
+# Optional deps
+bones_ecs_macros = { version = "0.3", path = "./macros", optional = true }
 
 anyhow      = "1.0"
 atomicell   = "0.2"

--- a/framework_crates/bones_ecs/macros/Cargo.toml
+++ b/framework_crates/bones_ecs/macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                    = "bones_ecs_macros"
+description             = "Macros for the bones_ecs crate."
+version.workspace       = true
+authors.workspace       = true
+edition.workspace       = true
+license.workspace       = true
+repository.workspace    = true
+documentation.workspace = true
+categories.workspace    = true
+keywords.workspace      = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+bones_ecs_macros_core = { path = "./core" }
+proc-macro2           = "1"
+
+[dev-dependencies]
+bevy_ecs     = "0.12"
+bones_ecs    = { path = ".." }
+bones_schema = { path = "../../bones_schema", features = ["derive"] }

--- a/framework_crates/bones_ecs/macros/core/Cargo.toml
+++ b/framework_crates/bones_ecs/macros/core/Cargo.toml
@@ -14,3 +14,6 @@ keywords.workspace      = true
 proc-macro2       = "1"
 quote             = "1"
 syn               = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/framework_crates/bones_ecs/macros/core/Cargo.toml
+++ b/framework_crates/bones_ecs/macros/core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name                    = "bones_ecs_macros_core"
+description             = "The core of bones_ecs macros."
+version.workspace       = true
+authors.workspace       = true
+edition.workspace       = true
+license.workspace       = true
+repository.workspace    = true
+documentation.workspace = true
+categories.workspace    = true
+keywords.workspace      = true
+
+[dependencies]
+proc-macro2       = "1"
+quote             = "1"
+syn               = { version = "2", features = ["full"] }

--- a/framework_crates/bones_ecs/macros/core/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/core/src/lib.rs
@@ -1,0 +1,14 @@
+use proc_macro2::TokenStream;
+use syn::ItemStruct;
+
+pub fn generate_system_param_impl(input: TokenStream) -> TokenStream {
+    match _generate_system_param_impl(input) {
+        Ok(output) => output,
+        Err(err) => err.to_compile_error(),
+    }
+}
+
+fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
+    syn::parse2::<ItemStruct>(input)?;
+    Ok(TokenStream::default())
+}

--- a/framework_crates/bones_ecs/macros/core/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/core/src/lib.rs
@@ -1,12 +1,9 @@
-use proc_macro2::TokenStream;
-use syn::{Fields, ItemStruct};
-
-pub fn generate_system_param_impl(input: TokenStream) -> TokenStream {
-    match _generate_system_param_impl(input) {
-        Ok(output) => output,
-        Err(err) => err.to_compile_error(),
-    }
-}
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    parse2, punctuated::Punctuated, token::Paren, Expr, ExprCall, ExprField, ExprPath,
+    ExprReference, FieldValue, Fields, GenericParam, Ident, Index, ItemStruct, Member, Path, Token,
+};
 
 macro_rules! err {
     ($target:expr, $message:expr) => {
@@ -17,14 +14,166 @@ macro_rules! err {
     };
 }
 
-fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
-    let item_struct: ItemStruct = syn::parse2(input)?;
+macro_rules! expr_path {
+    ($ident:literal, $span:expr) => {
+        ExprPath {
+            attrs: vec![],
+            qself: None,
+            path: Path::from(Ident::new($ident, $span)),
+        }
+    };
+}
 
-    match item_struct.fields {
+pub fn generate_system_param_impl(input: TokenStream) -> TokenStream {
+    match _generate_system_param_impl(input) {
+        Ok(output) => output,
+        Err(err) => err.to_compile_error(),
+    }
+}
+
+fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
+    let item_struct: ItemStruct = parse2(input)?;
+    let span = Span::call_site();
+
+    let Some(GenericParam::Lifetime(lifetime)) =
+        get_single_punctuated(&item_struct.generics.params)
+    else {
+        err!(
+            item_struct,
+            "struct must have a single generic lifetime parameter"
+        );
+    };
+
+    let ident = &item_struct.ident;
+
+    let fields = match &item_struct.fields {
         Fields::Unit => err!(item_struct, "unit structs are not supported"),
         Fields::Unnamed(_) => err!(item_struct, "structs with unnamed fields are not supported"),
-        Fields::Named(_) => {}
+        Fields::Named(fields) => fields,
+    };
+
+    let state_types: Punctuated<TokenStream, Token![,]> =
+        Punctuated::from_iter(fields.named.iter().map(|field| {
+            let ty = &field.ty;
+            quote! { <#ty as ::bones_framework::prelude::SystemParam>::State }
+        }));
+
+    let get_state_items: Punctuated<TokenStream, Token![,]> =
+        Punctuated::from_iter(fields.named.iter().map(|field| {
+            let ty = &field.ty;
+            quote! { <#ty as ::bones_framework::prelude::SystemParam>::get_state(world) }
+        }));
+
+    let borrow_param_fields: Punctuated<FieldValue, Token![,]> = fields
+        .named
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let index = index as u32;
+            let ty = &field.ty;
+            let borrow_path: ExprPath = parse2(quote! {
+                <#ty as ::bones_framework::prelude::SystemParam>::borrow
+            })
+            .unwrap();
+            let world_arg = expr_path!("world", span);
+            let state_arg = ExprReference {
+                attrs: vec![],
+                and_token: Token![&](span),
+                mutability: Some(Token![mut](span)),
+                expr: Box::new(Expr::Field(ExprField {
+                    attrs: vec![],
+                    base: Box::new(Expr::Path(expr_path!("state", span))),
+                    dot_token: Token![.](span),
+                    member: Member::Unnamed(Index { index, span }),
+                })),
+            };
+            FieldValue {
+                attrs: vec![],
+                member: field.ident.clone().unwrap().into(),
+                colon_token: Some(Token![:](span)),
+                expr: Expr::Call(ExprCall {
+                    attrs: vec![],
+                    func: Box::new(Expr::Path(borrow_path)),
+                    paren_token: Paren::default(),
+                    args: Punctuated::from_iter([
+                        Expr::Path(world_arg),
+                        Expr::Reference(state_arg),
+                    ]),
+                }),
+            }
+        })
+        .collect();
+
+    Ok(quote! {
+        impl<#lifetime> ::bones_framework::prelude::SystemParam for #ident<#lifetime> {
+            type State = ( #state_types );
+            type Param<'p> = #ident<'p>;
+            fn get_state(world: &::bones_framework::prelude::World) -> Self::State {
+                ( #get_state_items )
+            }
+            fn borrow<'s>(
+                world: &'s ::bones_framework::prelude::World,
+                state: &'s mut Self::State,
+            ) -> Self::Param<'s> {
+                Self::Param { #borrow_param_fields }
+            }
+        }
+    })
+}
+
+fn get_single_punctuated<T, P>(punctuated: &Punctuated<T, P>) -> Option<&T> {
+    match punctuated.first() {
+        single @ Some(_) if punctuated.len() == 1 => single,
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use quote::quote;
+
+    use super::*;
+
+    fn assert_tokens_eq(expected: TokenStream, actual: TokenStream) {
+        let expected = expected.to_string();
+        let actual = actual.to_string();
+        assert_eq!(expected, actual);
     }
 
-    Ok(TokenStream::default())
+    #[test]
+    fn correct_system_param_impl() {
+        let expected = quote! {
+            impl<'a> ::bones_framework::prelude::SystemParam for MySystemParam<'a> {
+                type State = (
+                    <Commands<'a> as ::bones_framework::prelude::SystemParam>::State,
+                    <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::State
+                );
+                type Param<'p> = MySystemParam<'p>;
+                fn get_state(world: &::bones_framework::prelude::World) -> Self::State {
+                    (
+                        <Commands<'a> as ::bones_framework::prelude::SystemParam>::get_state(world),
+                        <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::get_state(world)
+                    )
+                }
+                fn borrow<'s>(
+                    world: &'s ::bones_framework::prelude::World,
+                    state: &'s mut Self::State,
+                ) -> Self::Param<'s> {
+                    Self::Param {
+                        commands: <Commands<'a> as ::bones_framework::prelude::SystemParam>::borrow(world, &mut state.0),
+                        entities: <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::borrow(world, &mut state.1)
+                    }
+                }
+            }
+        };
+        let input = quote! {
+            struct MySystemParam<'a> {
+                commands: Commands<'a>,
+                entities: ResMut<'a, Entities>,
+            }
+        };
+        let actual = generate_system_param_impl(input);
+        assert_tokens_eq(expected, actual);
+    }
 }

--- a/framework_crates/bones_ecs/macros/core/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/core/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use syn::ItemStruct;
+use syn::{Fields, ItemStruct};
 
 pub fn generate_system_param_impl(input: TokenStream) -> TokenStream {
     match _generate_system_param_impl(input) {
@@ -8,7 +8,23 @@ pub fn generate_system_param_impl(input: TokenStream) -> TokenStream {
     }
 }
 
+macro_rules! err {
+    ($target:expr, $message:expr) => {
+        return Err(::syn::Error::new(
+            ::syn::spanned::Spanned::span(&$target),
+            $message,
+        ))
+    };
+}
+
 fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
-    syn::parse2::<ItemStruct>(input)?;
+    let item_struct: ItemStruct = syn::parse2(input)?;
+
+    match item_struct.fields {
+        Fields::Unit => err!(item_struct, "unit structs are not supported"),
+        Fields::Unnamed(_) => err!(item_struct, "structs with unnamed fields are not supported"),
+        Fields::Named(_) => {}
+    }
+
     Ok(TokenStream::default())
 }

--- a/framework_crates/bones_ecs/macros/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/src/lib.rs
@@ -1,0 +1,7 @@
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(SystemParam)]
+pub fn system_param_derive_macro(input: TokenStream) -> TokenStream {
+    let input = input.into();
+    bones_ecs_macros_core::generate_system_param_impl(input).into()
+}

--- a/framework_crates/bones_ecs/src/lib.rs
+++ b/framework_crates/bones_ecs/src/lib.rs
@@ -40,6 +40,9 @@ pub mod prelude {
         FromWorld, UnwrapMany, World,
     };
 
+    #[cfg(feature = "derive")]
+    pub use bones_ecs_macros::*;
+
     // Make bones_schema available for derive macros
     pub use bones_schema;
 }


### PR DESCRIPTION
Closes #16 

Add a procedural derive macro to generate an `impl SystemParam` for structs.

Allows jumpy to replace this:

```rust
impl_system_param! {
    struct MySystemParam<'a> {
        commands: Commands<'a>,
        entities: ResMut<'a, Entities>,
    }
}
```

with this:

```rust
#[derive(SystemParam)]
struct MySystemParam<'a> {
    commands: Commands<'a>,
    entities: ResMut<'a, Entities>,
}
```