### PR TITLE
fix: compiling with all features

### DIFF
--- a/framework_crates/bones_ecs/src/bitset.rs
+++ b/framework_crates/bones_ecs/src/bitset.rs
@@ -14,11 +14,26 @@ use crate::prelude::*;
 // SIMD processes 256 bits/entities (32 bytes) at once when comparing bitsets.
 #[cfg(feature = "keysize16")]
 const BITSET_EXP: u32 = 16;
-#[cfg(feature = "keysize20")]
+#[cfg(all(
+    feature = "keysize20",
+    not(feature = "keysize16"),
+    not(feature = "keysize24"),
+    not(feature = "keysize32")
+))]
 const BITSET_EXP: u32 = 20;
-#[cfg(feature = "keysize24")]
+#[cfg(all(
+    feature = "keysize24",
+    not(feature = "keysize16"),
+    not(feature = "keysize20"),
+    not(feature = "keysize32")
+))]
 const BITSET_EXP: u32 = 24;
-#[cfg(feature = "keysize32")]
+#[cfg(all(
+    feature = "keysize32",
+    not(feature = "keysize16"),
+    not(feature = "keysize20"),
+    not(feature = "keysize24")
+))]
 const BITSET_EXP: u32 = 32;
 
 pub use bitset_core::*;


### PR DESCRIPTION
Fix an error cause by compiling with all features: `cargo build --all-features`.

Make the conditional compilation on the `const BITSET_EXP` declarations mutually exclusive so that any combination of the `keysize*` features only ever results in a single instance.

Note that the `keysize16` declaration does not exclude all other keysizes since it is the default. If multiple keysize features are enabled, including 16, then the declaration for `keysize16` will be the only one. If multiple keysize features are enabled, not including 16, then there will be no declarations, causing a compile error. This is fine since users should only enable one of these features at a time.

```
error[E0428]: the name `BITSET_EXP` is defined multiple times
  --> framework_crates/bones_ecs/src/bitset.rs:18:1
   |
16 | const BITSET_EXP: u32 = 16;
   | --------------------------- previous definition of the value `BITSET_EXP` here
17 | #[cfg(feature = "keysize20")]
18 | const BITSET_EXP: u32 = 20;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `BITSET_EXP` redefined here
   |
   = note: `BITSET_EXP` must be defined only once in the value namespace of this module

error[E0428]: the name `BITSET_EXP` is defined multiple times
  --> framework_crates/bones_ecs/src/bitset.rs:20:1
   |
16 | const BITSET_EXP: u32 = 16;
   | --------------------------- previous definition of the value `BITSET_EXP` here
...
20 | const BITSET_EXP: u32 = 24;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `BITSET_EXP` redefined here
   |
   = note: `BITSET_EXP` must be defined only once in the value namespace of this module

error[E0428]: the name `BITSET_EXP` is defined multiple times
  --> framework_crates/bones_ecs/src/bitset.rs:22:1
   |
16 | const BITSET_EXP: u32 = 16;
   | --------------------------- previous definition of the value `BITSET_EXP` here
...
22 | const BITSET_EXP: u32 = 32;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `BITSET_EXP` redefined here
   |
   = note: `BITSET_EXP` must be defined only once in the value namespace of this module
```