### PR TITLE
fix: downgrade bevy to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,24 +20,24 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.12.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
+checksum = "76eb1adf08c5bcaa8490b9851fd53cca27fa9880076f178ea9d29f05196728a8"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.16.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c17cca53c09fbd7288667b22a201274b9becaa27f0b91bf52a526db95de45e6"
+checksum = "04bb4d9e4772fe0d47df57d0d5dbe5d85dd05e2f37ae1ddb6b105e76be58fb00"
 dependencies = [
  "accesskit",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.10.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
+checksum = "134d0acf6acb667c89d3332999b1a5df4edbc8d6113910f392ebb73f2b03bb56"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -47,23 +47,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.15.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcae27ec0974fc7c3b0b318783be89fd1b2e66dd702179fe600166a38ff4a0b"
+checksum = "9eac0a7f2d7cd7a93b938af401d3d8e8b7094217989a7c25c55a953023436e31"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
+ "arrayvec",
  "once_cell",
  "paste",
- "static_assertions",
  "windows 0.48.0",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.15.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e39fcec2e10971e188730b7a76bab60647dacc973d4591855ebebcadfaa738"
+checksum = "825d23acee1bd6d25cbaa3ca6ed6e73faf24122a774ec33d52c5c86c6ab423c0"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -264,12 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,16 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
-dependencies = [
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,25 +290,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
-dependencies = [
- "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.0",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
@@ -333,24 +304,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
 name = "async-io"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -365,21 +324,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -403,12 +353,6 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomicell"
@@ -445,36 +389,36 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bevy"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bc7e09282a82a48d70ade0c4c1154b0fd7882a735a39c66766a5d0f4718ea9"
+checksum = "91c6d3ec4f89e85294dc97334c5b271ddc301fdf67ac9bb994fe44d9273e6ed7"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68080288c932634f6563d3a8299efe0ddc9ea6787539c4c771ba250d089a94f0"
+checksum = "132c9e35a77c5395951f6d25fa2c52ee92296353426df4f961e60f3ff47e2e42"
 dependencies = [
  "accesskit",
  "bevy_app",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41731817993f92e4363dd3335558e779e290bc71eefc0b5547052b85810907e"
+checksum = "f557a7d59e1e16892d7544fc37316506ee598cb5310ef0365125a30783c11531"
 dependencies = [
  "bevy_derive",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_ecs 0.11.3",
+ "bevy_reflect 0.11.3",
+ "bevy_tasks 0.11.3",
+ "bevy_utils 0.11.3",
  "downcast-rs",
  "wasm-bindgen",
  "web-sys",
@@ -482,29 +426,25 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935984568f75867dd7357133b06f4b1502cd2be55e4642d483ce597e46e63bff"
+checksum = "9714af523da4cdf58c42a317e5ed40349708ad954a18533991fd64c8ae0a6f68"
 dependencies = [
- "async-broadcast",
- "async-fs",
- "async-lock 2.8.0",
+ "anyhow",
+ "async-channel",
  "bevy_app",
- "bevy_asset_macros",
- "bevy_ecs",
+ "bevy_diagnostic",
+ "bevy_ecs 0.11.3",
  "bevy_log",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_reflect 0.11.3",
+ "bevy_tasks 0.11.3",
+ "bevy_utils 0.11.3",
  "bevy_winit",
- "blake3",
  "crossbeam-channel",
  "downcast-rs",
- "futures-io",
- "futures-lite 1.13.0",
+ "fastrand 1.9.0",
  "js-sys",
  "parking_lot 0.12.1",
- "ron",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -513,49 +453,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_asset_macros"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f48b9bbe4ec605e4910b5cd1e1a0acbfbe0b80af5f3bcc4489a9fdd1e80058c"
-dependencies = [
- "bevy_macro_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "bevy_core"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3daa24502a14839509f02407bc7e48299fe84d260877de23b60662de0f4f4b6c"
+checksum = "3d5272321be5fcf5ce2fb16023bc825bb10dfcb71611117296537181ce950f48"
 dependencies = [
  "bevy_app",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_math",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_reflect 0.11.3",
+ "bevy_tasks 0.11.3",
+ "bevy_utils 0.11.3",
  "bytemuck",
 ]
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b77c4fca6e90edbe2e72da7bc9aa7aed7dfdfded0920ae0a0c845f5e11084a"
+checksum = "67382fa9c96ce4f4e5833ed7cedd9886844a8f3284b4a717bd4ac738dcdea0c3"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_derive",
- "bevy_ecs",
- "bevy_log",
+ "bevy_ecs 0.11.3",
  "bevy_math",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "bitflags 2.4.1",
  "radsort",
  "serde",
@@ -563,28 +490,49 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
+checksum = "a44e4e2784a81430199e4157e02903a987a32127c773985506f020e7d501b62e"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.11.3",
  "quote",
  "syn 2.0.48",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa38ca5967d335cc1006a0e0f1a86c350e2f15fd1878449f61d04cd57a7c4060"
+checksum = "6babb230dc383c98fdfc9603e3a7a2a49e1e2879dbe8291059ef37dca897932e"
 dependencies = [
  "bevy_app",
  "bevy_core",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_log",
  "bevy_time",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "sysinfo",
+]
+
+[[package]]
+name = "bevy_ecs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266144b36df7e834d5198049e037ecdf2a2310a76ce39ed937d1b0a6a2c4e8c6"
+dependencies = [
+ "async-channel",
+ "bevy_ecs_macros 0.11.3",
+ "bevy_ptr 0.11.3",
+ "bevy_reflect 0.11.3",
+ "bevy_tasks 0.11.3",
+ "bevy_utils 0.11.3",
+ "downcast-rs",
+ "event-listener 2.5.3",
+ "fixedbitset",
+ "rustc-hash",
+ "serde",
+ "thiserror",
+ "thread_local",
 ]
 
 [[package]]
@@ -593,12 +541,12 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709fbd22f81fb681534cd913c41e1cd18b17143368743281195d7f024b61aea"
 dependencies = [
- "async-channel 1.9.0",
- "bevy_ecs_macros",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "async-channel",
+ "bevy_ecs_macros 0.12.1",
+ "bevy_ptr 0.12.1",
+ "bevy_reflect 0.12.1",
+ "bevy_tasks 0.12.1",
+ "bevy_utils 0.12.1",
  "downcast-rs",
  "event-listener 2.5.3",
  "fixedbitset",
@@ -610,11 +558,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7157a9c3be038d5008ee3f114feb6cf6b39c1d3d32ee21a7cacb8f81fccdfa80"
+dependencies = [
+ "bevy_macro_utils 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "bevy_ecs_macros"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8843aa489f159f25cdcd9fee75cd7d221a7098a71eaa72cb2d6b40ac4e3f1ba"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -622,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_egui"
-version = "0.24.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90c01202dbcebc03315a01ea71553b35e1f20b0da6b1cc8c2605344032a3d96"
+checksum = "fb1c1f6ad293c60fd8559c4502cda5e832e92b0e0f3d994929b33f24d4352d70"
 dependencies = [
  "arboard",
  "bevy",
@@ -635,83 +595,83 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5328a3715e933ebbff07d0e99528dc423c4f7a53590ed1ac19a120348b028990"
+checksum = "d0ac0f55ad6bca1be7b0f35bbd5fc95ed3d31e4e9db158fee8e5327f59006001"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.11.3",
  "encase_derive_impl",
 ]
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b81ca2ebf66cbc7f998f1f142b15038ffe3c4ae1d51f70adda26dcf51b0c4ca"
+checksum = "65f4d79c55829f8016014593a42453f61a564ffb06ef79460d25696ccdfac67b"
 dependencies = [
  "bevy_app",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_input",
  "bevy_log",
  "bevy_time",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "gilrs",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db232274ddca2ae452eb2731b98267b795d133ddd14013121bc7daddde1c7491"
+checksum = "e286a3e7276431963f4aa29165ea5429fa7dbbc6d5c5ba0c531e7dd44ecc88a2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_core_pipeline",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_math",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_sprite",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
 ]
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bd477152ce2ae1430f5e0a4f19216e5785c22fee1ab23788b5982dc59d1a55"
+checksum = "103f8f58416ac6799b8c7f0b418f1fac9eba44fa924df3b0e16b09256b897e3d"
 dependencies = [
  "bevy_app",
  "bevy_core",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_log",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_reflect 0.11.3",
+ "bevy_utils 0.11.3",
  "smallvec",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab9a599189b2a694c182d60cd52219dd9364f9892ff542d87799b8e45d9e6dc"
+checksum = "ffbd935401101ac8003f3c3aea70788c65ad03f7a32716a10608bedda7a648bc"
 dependencies = [
  "bevy_app",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_math",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_reflect 0.11.3",
+ "bevy_utils 0.11.3",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f124bece9831afd80897815231072d51bfe3ac58c6bb58eca8880963b6d0487c"
+checksum = "e0e35a9b2bd29aa784b3cc416bcbf2a298f69f00ca51fd042ea39d9af7fad37e"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -720,7 +680,7 @@ dependencies = [
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_diagnostic",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_gilrs",
  "bevy_gizmos",
  "bevy_hierarchy",
@@ -728,33 +688,45 @@ dependencies = [
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
- "bevy_ptr",
- "bevy_reflect",
+ "bevy_ptr 0.11.3",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_scene",
  "bevy_sprite",
- "bevy_tasks",
+ "bevy_tasks 0.11.3",
  "bevy_time",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "bevy_window",
  "bevy_winit",
 ]
 
 [[package]]
 name = "bevy_log"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc10ba1d225a8477b9e80a1bf797d8a8b8274e83c9b24fb4d9351aec9229755"
+checksum = "07dcc615ff4f617b06c3f9522fca3c55d56f9644db293318f8ab68fcdea5d4fe"
 dependencies = [
  "android_log-sys",
  "bevy_app",
- "bevy_ecs",
- "bevy_utils",
+ "bevy_ecs 0.11.3",
+ "bevy_utils 0.11.3",
  "console_error_panic_hook",
  "tracing-log 0.1.4",
  "tracing-subscriber",
  "tracing-wasm",
+]
+
+[[package]]
+name = "bevy_macro_utils"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ddc18d489b4e57832d4958cde7cd2f349f0ad91e5892ac9e2f2ee16546b981"
+dependencies = [
+ "quote",
+ "rustc-hash",
+ "syn 2.0.48",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -772,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ddc2b76783939c530178f88e5711a1b01044d7b02db4033e2eb8b43b6cf4ec"
+checksum = "78286a81fead796dc4b45ab14f4f02fe29a94423d3587bcfef872b2a8e0a474b"
 dependencies = [
  "glam 0.24.2",
  "serde",
@@ -782,44 +754,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec4962977a746d870170532fc92759e04d3dbcae8b7b82e7ca3bb83b1d75277"
+checksum = "6cfc2a21ea47970a9b1f0f4735af3256a8f204815bd756110051d10f9d909497"
 dependencies = [
  "glam 0.24.2",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520bfd2a898c74f84ea52cfb8eb061f37373ad15e623489d5f75d27ebd6138fe"
+checksum = "63ca796a619e61cd43a0a3b11fde54644f7f0732a1fba1eef5d406248c6eba85"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core_pipeline",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_math",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "bevy_window",
  "bitflags 2.4.1",
  "bytemuck",
- "fixedbitset",
  "naga_oil",
  "radsort",
- "smallvec",
- "thread_local",
 ]
 
 [[package]]
 name = "bevy_prototype_lyon"
-version = "0.10.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc916d5bbde0109007068727331c154eeea0d06ac38a44747e430f6e72370fc"
+checksum = "9e347c16caede05dc5f774ba388cefeef0ab558a5601fc6b5ffd6606bef77308"
 dependencies = [
  "bevy",
  "lyon_algorithms",
@@ -829,9 +798,36 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c7586401a46f7d8e436028225c1df5288f2e0082d066b247a82466fea155c6"
+
+[[package]]
+name = "bevy_ptr"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
+
+[[package]]
+name = "bevy_reflect"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0778197a1eb3e095a71417c74b7152ede02975cdc95b5ea4ddc5251ed00a2eb5"
+dependencies = [
+ "bevy_math",
+ "bevy_ptr 0.11.3",
+ "bevy_reflect_derive 0.11.3",
+ "bevy_utils 0.11.3",
+ "downcast-rs",
+ "erased-serde 0.3.31",
+ "glam 0.24.2",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "thiserror",
+]
 
 [[package]]
 name = "bevy_reflect"
@@ -839,17 +835,27 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7921f15fc944c9c8ad01d7dbcea6505b8909c6655cd9382bab1407181556038"
 dependencies = [
- "bevy_math",
- "bevy_ptr",
- "bevy_reflect_derive",
- "bevy_utils",
+ "bevy_ptr 0.12.1",
+ "bevy_reflect_derive 0.12.1",
+ "bevy_utils 0.12.1",
  "downcast-rs",
  "erased-serde 0.3.31",
- "glam 0.24.2",
  "serde",
- "smallvec",
- "smol_str",
  "thiserror",
+]
+
+[[package]]
+name = "bevy_reflect_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342a4b2d09db22c48607d23ad59a056aff1ee004549050a51d490d375ba29528"
+dependencies = [
+ "bevy_macro_utils 0.11.3",
+ "bit-set",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "uuid",
 ]
 
 [[package]]
@@ -858,7 +864,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a8c5475f216e751ef4452a1306b00711f33d2d04d9f149e4c845dfeb6753a0"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -867,27 +873,28 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdefdd3737125b0d94a6ff20bb70fa8cfe9d7d5dcd72ba4dfe6c5f1d30d9f6e4"
+checksum = "39df4824b760928c27afc7b00fb649c7a63c9d76661ab014ff5c86537ee906cb"
 dependencies = [
- "async-channel 1.9.0",
+ "anyhow",
+ "async-channel",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_encase_derive",
  "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
  "bevy_mikktspace",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render_macros",
- "bevy_tasks",
+ "bevy_tasks 0.11.3",
  "bevy_time",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "bevy_window",
  "bitflags 2.4.1",
  "bytemuck",
@@ -900,6 +907,8 @@ dependencies = [
  "js-sys",
  "naga",
  "naga_oil",
+ "parking_lot 0.12.1",
+ "regex",
  "serde",
  "smallvec",
  "thiserror",
@@ -907,15 +916,16 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu",
+ "wgpu-hal",
 ]
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d86bfc5a1e7fbeeaec0c4ceab18155530f5506624670965db3415f75826bea"
+checksum = "0bd08c740aac73363e32fb45af869b10cec65bcb76fe3e6cd0f8f7eebf4c36c9"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -923,19 +933,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7df078b5e406e37c8a1c6ba0d652bf105fde713ce3c3efda7263fe27467eee5"
+checksum = "bd47e1263506153bef3a8be97fe2d856f206d315668c4f97510ca6cc181d9681"
 dependencies = [
+ "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_hierarchy",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "ron",
  "serde",
  "thiserror",
@@ -944,28 +955,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cc0c9d946e17e3e0aaa202f182837bc796c4f862b2e5a805134f873f21cf7f"
+checksum = "68a8ca824fad75c6ef74cfbbba0a4ce3ccc435fa23d6bf3f003f260548813397"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core_pipeline",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_log",
  "bevy_math",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
  "bevy_render",
  "bevy_transform",
- "bevy_utils",
+ "bevy_utils 0.11.3",
  "bitflags 2.4.1",
  "bytemuck",
  "fixedbitset",
  "guillotiere",
- "radsort",
  "rectangle-pack",
  "thiserror",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73bbb847c83990d3927005090df52f8ac49332e1643d2ad9aac3cd2974e66bf"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -974,7 +998,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fefa7fe0da8923525f7500e274f1bd60dbd79918a25cf7d0dfa0a6ba15c1cf"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "async-executor",
  "async-task",
  "concurrent-queue",
@@ -984,30 +1008,46 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6250d76eed3077128b6a3d004f9f198b01107800b9824051e32bb658054e837"
+checksum = "3d58d6dbae9c8225d8c0e0f04d2c5dbb71d22adc01ecd5ab3cebc364139e4a6d"
 dependencies = [
  "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_ecs 0.11.3",
+ "bevy_reflect 0.11.3",
+ "bevy_utils 0.11.3",
  "crossbeam-channel",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d541e0c292edbd96afae816ee680e02247422423ccd5dc635c1e211a20ed64be"
+checksum = "3b9b0ac0149a57cd846cb357a35fc99286f9848e53d4481954608ac9552ed2d4"
 dependencies = [
  "bevy_app",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_hierarchy",
  "bevy_math",
- "bevy_reflect",
+ "bevy_reflect 0.11.3",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d9484e32434ea84dc548cff246ce0c6f756c1336f5ea03f24ac120a48595c7"
+dependencies = [
+ "ahash",
+ "bevy_utils_proc_macros 0.11.3",
+ "getrandom",
+ "hashbrown 0.14.3",
+ "instant",
+ "petgraph",
  "thiserror",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1017,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7915222f4a08ccc782e08d10b751b42e5f9d786e697d0cb3fd09333cb7e8b6ea"
 dependencies = [
  "ahash",
- "bevy_utils_proc_macros",
+ "bevy_utils_proc_macros 0.12.1",
  "getrandom",
  "hashbrown 0.14.3",
  "instant",
@@ -1026,6 +1066,17 @@ dependencies = [
  "thiserror",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "bevy_utils_proc_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5391b242c36f556db01d5891444730c83aa9dd648b6a8fd2b755d22cb3bddb57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1041,37 +1092,36 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ee72bf7f974000e9b31bb971a89387f1432ba9413f35c4fef59fef49767260"
+checksum = "bd584c0da7c4ada6557b09f57f30fb7cff21ccedc641473fc391574b4c9b7944"
 dependencies = [
- "bevy_a11y",
  "bevy_app",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_input",
  "bevy_math",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_reflect 0.11.3",
+ "bevy_utils 0.11.3",
  "raw-window-handle",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.12.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb71f287eca9006dda998784c7b931e400ae2cc4c505da315882a8b082f21ad"
+checksum = "bfdc044abdb95790c20053e6326760f0a2985f0dcd78613d397bf35f16039d53"
 dependencies = [
  "accesskit_winit",
  "approx",
  "bevy_a11y",
  "bevy_app",
  "bevy_derive",
- "bevy_ecs",
+ "bevy_ecs 0.11.3",
  "bevy_hierarchy",
  "bevy_input",
  "bevy_math",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_tasks 0.11.3",
+ "bevy_utils 0.11.3",
  "bevy_window",
  "crossbeam-channel",
  "raw-window-handle",
@@ -1126,11 +1176,11 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitfield-rle"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8acc105b7bd3ed61e4bb7ad3e3b3f2a8da72205b2e0408cf71a499e8f57dd0"
+checksum = "215d5574bfd0d6d9243a9c741690f0b7ee8a0f39d3195283779793ed46d984e1"
 dependencies = [
- "failure",
+ "anyhow",
  "varinteger",
 ]
 
@@ -1154,19 +1204,6 @@ name = "bitset-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f421f1bcb30aa9d851a03c2920ab5d96ca920d5786645a597b5fc37922f8b89e"
-
-[[package]]
-name = "blake3"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block"
@@ -1203,29 +1240,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
-dependencies = [
- "async-channel 2.2.0",
- "async-lock 3.3.0",
- "async-task",
- "fastrand 2.0.1",
- "futures-io",
- "futures-lite 2.3.0",
- "piper",
- "tracing",
-]
-
-[[package]]
 name = "bones_asset"
 version = "0.3.0"
 dependencies = [
  "anyhow",
  "append-only-vec",
- "async-channel 1.9.0",
- "bevy_tasks",
+ "async-channel",
+ "bevy_tasks 0.11.3",
  "bones_schema",
  "bones_utils",
  "bs58",
@@ -1285,7 +1306,7 @@ dependencies = [
 name = "bones_ecs_macros"
 version = "0.3.0"
 dependencies = [
- "bevy_ecs",
+ "bevy_ecs 0.12.1",
  "bones_ecs",
  "bones_ecs_macros_core",
  "bones_schema",
@@ -1307,8 +1328,8 @@ name = "bones_framework"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "async-channel 1.9.0",
- "bevy_tasks",
+ "async-channel",
+ "bevy_tasks 0.11.3",
  "bones_asset",
  "bones_lib",
  "bones_matchmaker_proto",
@@ -1365,7 +1386,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-io",
- "bevy_tasks",
+ "bevy_tasks 0.11.3",
  "bones_matchmaker_proto",
  "bytes",
  "clap",
@@ -1423,8 +1444,8 @@ dependencies = [
 name = "bones_scripting"
 version = "0.3.0"
 dependencies = [
- "async-channel 1.9.0",
- "bevy_tasks",
+ "async-channel",
+ "bevy_tasks 0.11.3",
  "bones_asset",
  "bones_lib",
  "gc-arena",
@@ -1691,12 +1712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ca1caa64ef4ed453e68bb3db612e51cf1b2f5b871337f0fcab1c8f87cc3dff"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
 name = "constgebra"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,7 +1745,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
 ]
 
@@ -1850,12 +1865,12 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
- "bitflags 2.4.1",
- "libloading 0.8.1",
+ "bitflags 1.3.2",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -1996,18 +2011,18 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7637fc2e74d17e52931bac90ff4fc061ac776ada9c7fa272f24cdca5991972"
+checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "egui"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55bcb864b764eb889515a38b8924757657a250738ad15126637ee2df291ee6b"
+checksum = "8bd69fed5fcf4fbb8225b24e80ea6193b61e17a625db105ef0c4d71dde6eb8b7"
 dependencies = [
  "ahash",
  "epaint",
@@ -2016,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.24.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b484821a5b336af40a34151a940f52bef0f1ab56ec0d8cf80f74783eaae412"
+checksum = "c7f33a00fe8eb1ba56535b3dbacdecc7a1365a328908a97c5f3c81bb466be72b"
 dependencies = [
  "egui",
 ]
@@ -2054,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a045c6c0b44b35e98513fc1e9d183ab42881ac27caccb9fa345465601f56cce4"
+checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
 dependencies = [
  "bytemuck",
 ]
@@ -2110,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1b9e000d21bab9b535ce78f9f7745be28b3f777f6c7223936561c5c7fefab8"
+checksum = "58067b840d009143934d91d8dcb8ded054d8301d7c11a517ace0a99bb1e1595e"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2194,17 +2209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "event-listener-strategy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,38 +2216,6 @@ checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
  "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
-dependencies = [
- "event-listener 5.2.0",
- "pin-project-lite",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -2369,28 +2341,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2398,12 +2349,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2570,7 +2515,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
- "synstructure 0.13.0",
+ "synstructure",
 ]
 
 [[package]]
@@ -2711,21 +2656,21 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.6.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3125,15 +3070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kurbo"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,17 +3277,16 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
- "paste",
 ]
 
 [[package]]
@@ -3390,12 +3325,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.13.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
+checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
 dependencies = [
  "bit-set",
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "hexf-parse",
  "indexmap 1.9.3",
@@ -3411,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.10.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac54c77b3529887f9668d3dd81e955e58f252b31a333f836e3548c06460b958"
+checksum = "8be942a5c21c58b9b0bf4d9b99db3634ddb7a916f8e1d1d0b71820cc4150e56b"
 dependencies = [
  "bit-set",
  "codespan-reporting",
@@ -3422,7 +3357,7 @@ dependencies = [
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.6.29",
  "rustc-hash",
  "thiserror",
  "tracing",
@@ -4017,17 +3952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "piper"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
-dependencies = [
- "atomic-waker",
- "fastrand 2.0.1",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,7 +4123,7 @@ version = "0.3.0"
 dependencies = [
  "async-executor",
  "async-io",
- "bevy_tasks",
+ "bevy_tasks 0.11.3",
  "futures-lite 2.3.0",
  "pin-project",
  "quinn",
@@ -4365,12 +4289,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -4811,11 +4729,10 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "svgtypes"
-version = "0.12.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71499ff2d42f59d26edb21369a308ede691421f79ebc0f001e2b1fd3a7c9e52"
+checksum = "22975e8a2bac6a76bb54f898a6b18764633b00e780330f0b689f65afb3975564"
 dependencies = [
- "kurbo",
  "siphasher",
 ]
 
@@ -4960,18 +4877,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
 ]
 
 [[package]]
@@ -5581,16 +5486,16 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.17.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752e44d3998ef35f71830dd1ad3da513e628e2e4d4aedb0ab580f850827a0b41"
+checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5605,9 +5510,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7"
+checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5615,7 +5520,7 @@ dependencies = [
  "codespan-reporting",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
@@ -5628,9 +5533,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.17.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a80bf0e3c77399bb52850cb0830af9bad073d5cfcb9dd8253bef8125c42db17"
+checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5640,6 +5545,7 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
+ "foreign-types",
  "glow",
  "gpu-alloc",
  "gpu-allocator",
@@ -5653,7 +5559,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -5669,9 +5575,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
+checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,15 +2554,14 @@ dependencies = [
 [[package]]
 name = "ggrs"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ab0bdf8c0046f369eba7011233f614b9f1d8646f86fdb5c0acfe039ab15836"
+source = "git+https://github.com/gschup/ggrs.git?rev=0af1a044b96465bd10398947b7fb5e0a34a75f70#0af1a044b96465bd10398947b7fb5e0a34a75f70"
 dependencies = [
  "bincode",
  "bitfield-rle",
  "bytemuck",
  "instant",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "rand",
  "serde",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,7 @@ allow = [
 ]
 
 [sources.allow-org]
-github = ["fishfolk"]
+github = ["gschup"]
 
 [[licenses.clarify]]
 name          = "ring"

--- a/framework_crates/bones_asset/Cargo.toml
+++ b/framework_crates/bones_asset/Cargo.toml
@@ -32,7 +32,7 @@ once_cell       = "1.18"
 path-absolutize = { version = "3.1", features = ["use_unix_paths_on_wasm"] }
 ehttp           = "0.3"
 tracing         = "0.1"
-bevy_tasks      = "0.12"
+bevy_tasks      = "0.11"
 dashmap         = "5.5"
 event-listener  = "4.0"
 elsa            = "1.9"
@@ -47,4 +47,4 @@ web-sys = { version = "0.3", features = ["console"] }
 [dev-dependencies]
 bones_schema = { version = "0.3", path = "../bones_schema", features = ["glam"] }
 glam         = "0.24"
-bevy_tasks   = "0.12"
+bevy_tasks   = "0.11"

--- a/framework_crates/bones_asset/examples/tutorial.rs
+++ b/framework_crates/bones_asset/examples/tutorial.rs
@@ -149,7 +149,7 @@ fn main() -> anyhow::Result<()> {
 
     // Load assets
     let s = asset_server.clone();
-    IoTaskPool::get_or_init(TaskPool::default);
+    IoTaskPool::init(TaskPool::default);
     println!("Loading Assets...");
 
     // Spawn a task to load the assets

--- a/framework_crates/bones_bevy_renderer/Cargo.toml
+++ b/framework_crates/bones_bevy_renderer/Cargo.toml
@@ -17,9 +17,9 @@ webgl2  = ["bevy/webgl2"]
 [dependencies]
 bones_framework = { version = "0.3", path = "../bones_framework" }
 
-bevy_egui           = "0.24"
+bevy_egui           = "0.22"
 glam                = { version = "0.24", features = ["serde"] }
-bevy_prototype_lyon = "0.10"
+bevy_prototype_lyon = "0.9"
 serde_yaml          = "0.9"
 serde               = "1.0.188"
 anyhow              = "1.0"
@@ -27,7 +27,7 @@ anyhow              = "1.0"
 [dependencies.bevy]
 default-features = false
 features         = ["bevy_render", "bevy_core_pipeline", "bevy_sprite", "x11", "bevy_gilrs"]
-version          = "0.12"
+version          = "0.11"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 directories = "5.0"

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -661,7 +661,7 @@ fn setup_egui(world: &mut World) {
             // Insert the bones egui textures
             ctx.data_mut(|map| {
                 map.insert_temp(
-                    bevy_egui::egui::Id::NULL,
+                    bevy_egui::egui::Id::null(),
                     bones_data.bones_egui_textures.clone(),
                 );
             });
@@ -695,19 +695,19 @@ fn get_bones_input(
     (
         bones::MouseInputs {
             movement: mouse_motion_events
-                .read()
+                .iter()
                 .last()
                 .map(|x| x.delta)
                 .unwrap_or_default(),
             wheel_events: mouse_wheel_events
-                .read()
+                .iter()
                 .map(|event| bones::MouseScrollEvent {
                     unit: event.unit.into_bones(),
                     movement: Vec2::new(event.x, event.y),
                 })
                 .collect(),
             button_events: mouse_button_input_events
-                .read()
+                .iter()
                 .map(|event| bones::MouseButtonEvent {
                     button: event.button.into_bones(),
                     state: event.state.into_bones(),
@@ -716,7 +716,7 @@ fn get_bones_input(
         },
         bones::KeyboardInputs {
             key_events: keyboard_events
-                .read()
+                .iter()
                 .map(|event| bones::KeyboardEvent {
                     scan_code: event.scan_code,
                     key_code: event.key_code.map(|x| x.into_bones()).into(),
@@ -726,7 +726,7 @@ fn get_bones_input(
         },
         bones::GamepadInputs {
             gamepad_events: gamepad_events
-                .read()
+                .iter()
                 .map(|event| match event {
                     GamepadEvent::Connection(c) => {
                         bones::GamepadEvent::Connection(bones::GamepadConnectionEvent {
@@ -805,7 +805,7 @@ fn step_bones_game(world: &mut World) {
 
     let BonesData { game, .. } = &mut data;
 
-    let bevy_time = world.resource::<Time<Real>>();
+    let bevy_time = world.resource::<Time>();
 
     // Reload assets if necessary
     if let Some(mut asset_server) = game.shared_resource_mut::<bones::AssetServer>() {
@@ -1023,26 +1023,23 @@ fn extract_bones_sprites(
                 please open an issue."
                 );
             };
-            extracted_sprites.sprites.insert(
-                bones_renderable_entity.0,
-                ExtractedSprite {
-                    original_entity: Some(bones_renderable_entity.0),
-                    transform: {
-                        let mut t: Transform = transform.into_bevy();
-                        // Add tiny z offset to enforce a consistent z-sort
-                        t.translation.z += z_offset;
-                        z_offset += 0.00001;
-                        t.into()
-                    },
-                    color: sprite.color.into_bevy(),
-                    rect: None,
-                    custom_size: None,
-                    image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
-                    flip_x: sprite.flip_x,
-                    flip_y: sprite.flip_y,
-                    anchor: Anchor::Center.as_vec(),
+            extracted_sprites.sprites.push(ExtractedSprite {
+                entity: bones_renderable_entity.0,
+                transform: {
+                    let mut t: Transform = transform.into_bevy();
+                    // Add tiny z offset to enforce a consistent z-sort
+                    t.translation.z += z_offset;
+                    z_offset += 0.00001;
+                    t.into()
                 },
-            );
+                color: sprite.color.into_bevy(),
+                rect: None,
+                custom_size: None,
+                image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
+                flip_x: sprite.flip_x,
+                flip_y: sprite.flip_y,
+                anchor: Anchor::Center.as_vec(),
+            });
         }
 
         // Extract atlas sprites
@@ -1068,20 +1065,17 @@ fn extract_bones_sprites(
                 min,
                 max: min + atlas.tile_size,
             };
-            extracted_sprites.sprites.insert(
-                bones_renderable_entity.0,
-                ExtractedSprite {
-                    original_entity: Some(bones_renderable_entity.0),
-                    transform: transform.into_bevy().into(),
-                    color: atlas_sprite.color.into_bevy(),
-                    rect: Some(rect),
-                    custom_size: None,
-                    image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
-                    flip_x: atlas_sprite.flip_x,
-                    flip_y: atlas_sprite.flip_y,
-                    anchor: Anchor::Center.as_vec(),
-                },
-            );
+            extracted_sprites.sprites.push(ExtractedSprite {
+                entity: bones_renderable_entity.0,
+                transform: transform.into_bevy().into(),
+                color: atlas_sprite.color.into_bevy(),
+                rect: Some(rect),
+                custom_size: None,
+                image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
+                flip_x: atlas_sprite.flip_x,
+                flip_y: atlas_sprite.flip_y,
+                anchor: Anchor::Center.as_vec(),
+            });
         }
     }
 }
@@ -1173,20 +1167,17 @@ fn extract_bones_tilemaps(
                 // create a proper tile renderer. That can render multiple tiles on one quad instead
                 // of using a separate quad for each tile.
                 transform.scale += Vec3::new(0.01, 0.01, 0.0);
-                extracted_sprites.sprites.insert(
-                    bones_renderable_entity.0,
-                    ExtractedSprite {
-                        original_entity: Some(bones_renderable_entity.0),
-                        transform: transform.into(),
-                        color: Color::WHITE,
-                        rect: Some(rect),
-                        custom_size: None,
-                        image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
-                        flip_x: tile.flip_x,
-                        flip_y: tile.flip_y,
-                        anchor: Anchor::BottomLeft.as_vec(),
-                    },
-                );
+                extracted_sprites.sprites.push(ExtractedSprite {
+                    entity: bones_renderable_entity.0,
+                    transform: transform.into(),
+                    color: Color::WHITE,
+                    rect: Some(rect),
+                    custom_size: None,
+                    image_handle_id: bones_image_ids.get(&image_id).unwrap().id(),
+                    flip_x: tile.flip_x,
+                    flip_y: tile.flip_y,
+                    anchor: Anchor::BottomLeft.as_vec(),
+                });
             }
         }
     }

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -117,7 +117,7 @@ document-features = { version = "0.2", optional = true }
 
 # Networking
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ggrs                   = { version = "0.10", features = ["sync-send"] }
+ggrs                   = { git = "https://github.com/gschup/ggrs.git", rev = "0af1a044b96465bd10398947b7fb5e0a34a75f70", features = ["sync-send"] }
 bones_matchmaker_proto = { version = "0.2", path = "../../other_crates/bones_matchmaker_proto" }
 bytes                  = "1.4"
 mdns-sd                = { version = "0.10", default-features = false }

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -75,7 +75,7 @@ bones_scripting = { version = "0.3", path = "../bones_scripting", optional = tru
 # Other
 anyhow        = "1.0"
 async-channel = "1.9"
-bevy_tasks    = { version = "0.12" }
+bevy_tasks    = "0.11"
 bytemuck      = "1.12"
 either        = "1.8"
 futures-lite  = "2.3"
@@ -98,8 +98,8 @@ serde      = { version = "1.0", features = ["derive"] }
 image = { version = "0.24", default-features = false }
 
 # Gui
-egui       = { version = "0.24", optional = true }
-egui_plot  = "0.24"
+egui       = { version = "0.23", optional = true }
+egui_plot  = "0.23"
 ttf-parser = { version = "0.20", default-features = false, optional = true }
 
 # Audio

--- a/framework_crates/bones_framework/src/render/sprite.rs
+++ b/framework_crates/bones_framework/src/render/sprite.rs
@@ -26,6 +26,7 @@ impl AssetLoader for ImageAssetLoader {
         _ctx: AssetLoadCtx,
         bytes: &[u8],
     ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+        tracing::info!(loc = %_ctx.loc.path.display(), size = bytes.len(), "load asset");
         let bytes = bytes.to_vec();
         Box::pin(async move {
             Ok(SchemaBox::new(Image::Data(image::load_from_memory(

--- a/framework_crates/bones_framework/src/render/sprite.rs
+++ b/framework_crates/bones_framework/src/render/sprite.rs
@@ -26,7 +26,6 @@ impl AssetLoader for ImageAssetLoader {
         _ctx: AssetLoadCtx,
         bytes: &[u8],
     ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
-        tracing::info!(loc = %_ctx.loc.path.display(), size = bytes.len(), "load asset");
         let bytes = bytes.to_vec();
         Box::pin(async move {
             Ok(SchemaBox::new(Image::Data(image::load_from_memory(

--- a/framework_crates/bones_framework/src/render/ui.rs
+++ b/framework_crates/bones_framework/src/render/ui.rs
@@ -184,13 +184,13 @@ pub trait EguiContextExt {
 
 impl EguiContextExt for &egui::Context {
     fn clear_focus(self) {
-        self.memory_mut(|r| r.request_focus(egui::Id::NULL));
+        self.memory_mut(|r| r.request_focus(egui::Id::null()));
     }
     fn get_state<T: Clone + Default + Sync + Send + 'static>(self) -> T {
-        self.data_mut(|data| data.get_temp_mut_or_default::<T>(egui::Id::NULL).clone())
+        self.data_mut(|data| data.get_temp_mut_or_default::<T>(egui::Id::null()).clone())
     }
     fn set_state<T: Clone + Default + Sync + Send + 'static>(self, value: T) {
-        self.data_mut(|data| *data.get_temp_mut_or_default::<T>(egui::Id::NULL) = value);
+        self.data_mut(|data| *data.get_temp_mut_or_default::<T>(egui::Id::null()) = value);
     }
 }
 

--- a/framework_crates/bones_framework/src/render/ui/widgets/bordered_button.rs
+++ b/framework_crates/bones_framework/src/render/ui/widgets/bordered_button.rs
@@ -199,7 +199,7 @@ impl<'a> Widget for BorderedButton<'a> {
 
             if let Some(border) = border {
                 let texture = ui.data(|map| {
-                    map.get_temp::<AtomicResource<EguiTextures>>(egui::Id::NULL)
+                    map.get_temp::<AtomicResource<EguiTextures>>(egui::Id::null())
                         .unwrap()
                         .borrow()
                         .unwrap()

--- a/framework_crates/bones_framework/src/render/ui/widgets/bordered_frame.rs
+++ b/framework_crates/bones_framework/src/render/ui/widgets/bordered_frame.rs
@@ -266,7 +266,7 @@ impl BorderedFramePrepared {
         };
         if ui.is_rect_visible(paint_rect) {
             let texture = ui.data(|map| {
-                map.get_temp::<AtomicResource<EguiTextures>>(egui::Id::NULL)
+                map.get_temp::<AtomicResource<EguiTextures>>(egui::Id::null())
                     .unwrap()
                     .borrow()
                     .unwrap()

--- a/framework_crates/bones_scripting/Cargo.toml
+++ b/framework_crates/bones_scripting/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace      = true
 [dependencies]
 async-channel   = "1.9"
 tracing         = "0.1"
-bevy_tasks      = { version = "0.12", features = ["multi-threaded"] }
+bevy_tasks      = { version = "0.11", features = ["multi-threaded"] }
 bones_lib       = { version = "0.3", path = "../bones_lib" }
 bones_asset     = { version = "0.3", path = "../bones_asset" }
 piccolo         = { version = "0.3" }

--- a/framework_crates/bones_scripting/src/lua.rs
+++ b/framework_crates/bones_scripting/src/lua.rs
@@ -264,7 +264,7 @@ impl Default for LuaEngine {
     /// Initialize the Lua engine.
     fn default() -> Self {
         // Make sure the compute task pool is initialized
-        ComputeTaskPool::get_or_init(TaskPool::new);
+        ComputeTaskPool::init(TaskPool::new);
 
         #[cfg(not(target_arch = "wasm32"))]
         let executor = {

--- a/other_crates/bones_matchmaker/Cargo.toml
+++ b/other_crates/bones_matchmaker/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow                 = "1.0"
-bevy_tasks             = "0.12"
+bevy_tasks             = "0.11"
 bytes                  = "1.2"
 either                 = "1.8"
 futures-lite           = "2.3"

--- a/other_crates/bones_matchmaker/examples/matchmaker_client.rs
+++ b/other_crates/bones_matchmaker/examples/matchmaker_client.rs
@@ -59,7 +59,7 @@ fn configure_client() -> ClientConfig {
 }
 
 pub fn main() {
-    IoTaskPool::get_or_init(TaskPool::new);
+    IoTaskPool::init(TaskPool::new);
     let task_pool = IoTaskPool::get();
     futures_lite::future::block_on(task_pool.spawn(async move {
         if let Err(e) = client().await {

--- a/other_crates/bones_matchmaker/src/cli.rs
+++ b/other_crates/bones_matchmaker/src/cli.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use tracing::metadata::LevelFilter;
 
 pub fn start() {
-    IoTaskPool::get_or_init(TaskPool::new);
+    IoTaskPool::init(TaskPool::new);
     let task_pool = IoTaskPool::get();
     configure_logging();
 

--- a/other_crates/quinn_runtime_bevy/Cargo.toml
+++ b/other_crates/quinn_runtime_bevy/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 [dependencies]
 async-executor = "1.4"
 async-io       = "2.3"
-bevy_tasks     = "0.12"
+bevy_tasks     = "0.11"
 futures-lite   = "2.3"
 pin-project    = "1.0"
 quinn          = { version = "0.10", default-features = false, features = ["native-certs", "tls-rustls"] }

--- a/other_crates/type_ulid/src/lib.rs
+++ b/other_crates/type_ulid/src/lib.rs
@@ -1,4 +1,4 @@
-//! A simple crate containing the [`TypeUlid`] trait to allow associating [`Ulid`][ulid::Ulid]
+//! A simple crate containing the [`TypeUlid`] trait to allow associating [`Ulid`]
 //! identifiers with Rust types.
 //!
 //! # Example


### PR DESCRIPTION
- Downgrade bevy to 0.11
  - Changes to `bevy_sprite` make the upgrade too complicated to do at the moment
- Upgrade `bitfield-rle` to `0.2.1`
  - Fixes the CI advisory errors for the `failure` crate