### PR TITLE
fix: Fix race condition on if EguiCtx is initialized before bones game

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -309,6 +309,7 @@ impl BonesBevyRenderer {
         .init_resource::<BonesGameEntity>();
 
         let assets_are_loaded = |data: Res<BonesData>| {
+            // Game is not required to have AssetServer, so default to true.
             data.asset_server
                 .as_ref()
                 .map(|x| x.load_progress.is_finished())

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -312,7 +312,7 @@ impl BonesBevyRenderer {
             data.asset_server
                 .as_ref()
                 .map(|x| x.load_progress.is_finished())
-                .unwrap_or(true)
+                .unwrap_or(false)
         };
         let assets_not_loaded = |data: Res<BonesData>| {
             data.asset_server

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -312,7 +312,7 @@ impl BonesBevyRenderer {
             data.asset_server
                 .as_ref()
                 .map(|x| x.load_progress.is_finished())
-                .unwrap_or(false)
+                .unwrap_or(true)
         };
         let assets_not_loaded = |data: Res<BonesData>| {
             data.asset_server

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -28,7 +28,7 @@ use glam::*;
 
 use bevy_prototype_lyon::prelude as lyon;
 use bones_framework::prelude::{
-    self as bones, BitSet, ComponentIterBitset, SchemaBox, SCHEMA_REGISTRY,
+    self as bones, BitSet, ComponentIterBitset, EguiCtx, SchemaBox, SCHEMA_REGISTRY,
 };
 use prelude::convert::{IntoBevy, IntoBones};
 use serde::{de::Visitor, Deserialize, Serialize};
@@ -320,6 +320,8 @@ impl BonesBevyRenderer {
                 .map(|x| !x.load_progress.is_finished())
                 .unwrap_or(true)
         };
+        let egui_ctx_initialized =
+            |data: Res<BonesData>| data.game.shared_resource::<EguiCtx>().is_some();
 
         // Add the world sync systems
         app.add_systems(
@@ -350,7 +352,11 @@ impl BonesBevyRenderer {
                 ),
             )
                 .chain()
-                .run_if(assets_are_loaded),
+                // We should not run unless EguiCtx initialized, and assets loaded.
+                // setup_egui system already is gated by assets_are_loaded, so this should be fine
+                // with only checking EguiCtx.
+                // .run_if(assets_are_loaded)
+                .run_if(egui_ctx_initialized),
         );
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -352,10 +352,7 @@ impl BonesBevyRenderer {
                 ),
             )
                 .chain()
-                // We should not run unless EguiCtx initialized, and assets loaded.
-                // setup_egui system already is gated by assets_are_loaded, so this should be fine
-                // with only checking EguiCtx.
-                // .run_if(assets_are_loaded)
+                .run_if(assets_are_loaded)
                 .run_if(egui_ctx_initialized),
         );
 


### PR DESCRIPTION
Speculative fix for #377 (see for context)

It seems both the `setup_egui` and `step_bones_game` systems are gated by if assets are loaded, which is an async process. My theory is that assets finish loading after PreUpdate, before Update, so bones steps without EguiCtx.

This prevents `step_bones_game` from being run until EguiCtx is inserted in `setup_egui`. ~~Becaues `setup_egui` is gated by assets loaded, `step_bones_game` is also implicitly gated by assets loaded. I only check one `run_if` condition to avoid overhead executing systems that make up the core game loop.~~