### PR TITLE
feat: Add Session commands to modify sessions from game code

### DIFF
--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -11,7 +11,7 @@ pub use bones_ecs as ecs;
 /// Bones lib prelude
 pub mod prelude {
     pub use crate::{
-        ecs::prelude::*, instant::Instant, time::*, Game, GamePlugin, Session, SessionCommands,
+        ecs::prelude::*, instant::Instant, time::*, Game, GamePlugin, Session, SessionCommand,
         SessionOptions, SessionPlugin, SessionRunner, Sessions,
     };
 }
@@ -22,19 +22,6 @@ pub mod time;
 use std::{collections::VecDeque, fmt::Debug, sync::Arc};
 
 use crate::prelude::*;
-
-/// Commands that operate on [`Sessions`], called after all sessions update.
-/// These may be used to add/delete/modify sessions.
-///
-/// `SessionCommands` must be installed as a shared resource to take effect.
-/// This may be achieved while installing a [`GamePlugin`].
-///
-/// `SessionCommands` is useful in a situation where you want to remove / recreate
-/// a session from within it's own system. You cannot do this while the `Session` is running
-#[derive(HasSchema, Default, Deref, DerefMut)]
-#[schema(no_clone)]
-pub struct SessionCommands(VecDeque<Box<dyn FnOnce(&mut Sessions) + Sync + Send>>);
-
 /// A bones game. This includes all of the game worlds, and systems.
 #[derive(Deref, DerefMut)]
 pub struct Session {
@@ -412,23 +399,20 @@ impl Game {
                 self.sessions.map.insert(session_name, current_session);
             }
 
-            // Extract `SessionCommands` from optional shared resource
-            // (Swap to avoid double borrow of self)
-            let mut session_commands = SessionCommands::default();
-            if let Some(mut new_commands) = self.shared_resource_mut::<SessionCommands>() {
-                std::mem::swap(&mut session_commands.0, &mut new_commands.0);
-            }
-
-            // Execute Session Commands
-            for command in session_commands.0.drain(..) {
-                command(&mut self.sessions);
-            }
-
             // Run any after session game systems
             if let Some(systems) = game_systems.after_session.get_mut(&session_name) {
                 for system in systems {
                     system(self)
                 }
+            }
+        }
+
+        // Execute Session Commands
+        {
+            let mut session_commands: VecDeque<Box<SessionCommand>> = default();
+            std::mem::swap(&mut session_commands, &mut self.sessions.commands);
+            for command in session_commands.drain(..) {
+                command(&mut self.sessions);
             }
         }
 
@@ -520,12 +504,24 @@ impl GameSystems {
     }
 }
 
+/// Type of session command
+pub type SessionCommand = dyn FnOnce(&mut Sessions) + Sync + Send;
+
 /// Container for multiple game sessions.
 ///
 /// Each session shares the same [`Entities`].
-#[derive(HasSchema, Default, Debug)]
+#[derive(HasSchema, Default)]
 pub struct Sessions {
     map: UstrMap<Session>,
+
+    /// Commands that operate on [`Sessions`], called after all sessions update.
+    /// These may be used to add/delete/modify sessions.
+    ///
+    /// Commands are useful in a situation where you want to remove / recreate
+    /// a session from within it's own system. You cannot do this while the `Session` is running.
+    ///
+    /// Commands added inside a session command will not be executed until next frame.
+    commands: VecDeque<Box<SessionCommand>>,
 }
 
 /// Resource that allows you to configure the current session.
@@ -596,6 +592,11 @@ impl Sessions {
     /// Iterate over sessions.
     pub fn iter(&self) -> std::collections::hash_map::Iter<Ustr, Session> {
         self.map.iter()
+    }
+
+    /// Add a [`SessionCommand`] to queue.
+    pub fn add_command(&mut self, command: Box<SessionCommand>) {
+        self.commands.push_back(command);
     }
 }
 


### PR DESCRIPTION
Add SessionCommands which may be inserted as shared resource. Runs after session execution, before the "after_session" GameSystems.

One thing I don't like about this is it only works as shared resource, if user does not insert shared resource, and tries to do ResMutInit, they run into trouble. Not sure what the best way to avoid that is.