### PR TITLE
feat(networking): Support restarting network session

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -45,7 +45,7 @@ impl From<ggrs::InputStatus> for NetworkInputStatus {
 
 /// Module prelude.
 pub mod prelude {
-    pub use super::{certs, debug::prelude::*, input, lan, online, proto};
+    pub use super::{certs, debug::prelude::*, input, lan, online, proto, NetworkInfo};
 }
 
 /// Muliplier for framerate that will be used when playing an online match.
@@ -178,6 +178,17 @@ pub enum SocketTarget {
     Player(usize),
     /// Broadcast to all players.
     All,
+}
+
+/// Resource updated each frame exposing current frame and last confirmed of online session.
+#[derive(HasSchema, Copy, Clone, Default)]
+pub struct NetworkInfo {
+    /// Current frame of simulation step
+    pub current_frame: i32,
+
+    /// Last confirmed frame by all clients.
+    /// Anything that occurred on this frame is agreed upon by all clients.
+    pub last_confirmed_frame: i32,
 }
 
 /// [`SessionRunner`] implementation that uses [`ggrs`] for network play.
@@ -457,6 +468,11 @@ where
                                 } => {
                                     // Input has been consumed, signal that we are in new input frame
                                     self.input_collector.advance_frame();
+
+                                    world.insert_resource(NetworkInfo {
+                                        current_frame: self.session.current_frame(),
+                                        last_confirmed_frame: self.session.confirmed_frame(),
+                                    });
 
                                     {
                                         world

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -576,4 +576,21 @@ where
                 .unwrap();
         }
     }
+
+    fn restart_session(&mut self) {
+        // Rebuild session info from runner + create new runner
+
+        // Increment match id so messages from previous match that are still in flight
+        // will be filtered out.
+        self.socket.0.increment_match_id();
+
+        let runner_info = GgrsSessionRunnerInfo {
+            socket: self.socket.clone(),
+            player_is_local: self.player_is_local,
+            player_count: self.session.num_players(),
+            max_prediction_window: Some(self.session.max_prediction()),
+            local_input_delay: Some(self.local_input_delay),
+        };
+        *self = GgrsSessionRunner::new(self.network_fps as f32, runner_info);
+    }
 }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -140,6 +140,7 @@ pub trait SessionRunner: Sync + Send + 'static {
     ///     world.resource_mut::<Time>().update_with_instant(now);
     ///     stages.run(world);
     /// }
+    /// fn restart_session(&mut self) {}
     /// # }
     /// ```
     fn step(&mut self, now: Instant, world: &mut World, stages: &mut SystemStages);

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -143,6 +143,12 @@ pub trait SessionRunner: Sync + Send + 'static {
     /// # }
     /// ```
     fn step(&mut self, now: Instant, world: &mut World, stages: &mut SystemStages);
+
+    /// Restart Session Runner. This should reset accumulated time, inputs, etc.
+    ///
+    /// The expectation is that current players using it may continue to, so something like a network
+    /// socket or player info should persist.
+    fn restart_session(&mut self);
 }
 
 /// The default [`SessionRunner`], which just runs the systems once every time it is run.
@@ -152,6 +158,12 @@ impl SessionRunner for DefaultSessionRunner {
     fn step(&mut self, now: instant::Instant, world: &mut World, stages: &mut SystemStages) {
         world.resource_mut::<Time>().update_with_instant(now);
         stages.run(world)
+    }
+
+    // This is a no-op as no state, but implemented this way in case that changes later.
+    #[allow(clippy::default_constructed_unit_structs)]
+    fn restart_session(&mut self) {
+        *self = DefaultSessionRunner::default();
     }
 }
 


### PR DESCRIPTION
These are changes in prep for map transition. Session runner now has a restart function. When game session is reset, network session runner can be restarted by re-initializing it and using existing socket with increment match id. 

Sockets now wrap ggrs messages with a match_id that allows filtering in flight messages from previous matches out to avoid issues when re-creating ggrs session.

Note that GGRS takes a boxed socket - incrementing match id on our NetworkMatchSocket or other cloned socket will not impact current ggrs socket, which is fine as we are re-creating ggrs session anyway. It may only be effectively updated by cloning socket, incrementing, and re-creating ggrs session. This also avoids issues with interior mutability of NetworkMatchSocket (arc wrapping socket), so we operate by cloning / saving boxed socket + updating this. 

Additionally added resource `NetworkInfo` which is updated by net session runner before each step. Contains current + last confirmed frame, which gameplay code may use to confirm events (such as map transition) have been synchronized + confirmed by all players.

These changes + session commands PR should be everything we need on the bones side to get map transitions in.