### PR TITLE
feat: single & first entity queries

### DIFF
--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -38,13 +38,13 @@ impl<'a> Iterator for UntypedComponentBitsetIterator<'a> {
     type Item = SchemaRef<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let max_id = self.components.max_id;
-        while !(self.bitset.bit_test(self.current_id)
-            && self.components.bitset.bit_test(self.current_id))
-            && self.current_id <= max_id
+        while self.current_id < max_id
+            && !(self.bitset.bit_test(self.current_id)
+                && self.components.bitset.bit_test(self.current_id))
         {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             Some(unsafe {
                 SchemaRef::from_ptr_schema(
@@ -71,11 +71,11 @@ impl<'a> Iterator for UntypedComponentOptionalBitsetIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         // We stop iterating at bitset length, not component store length, as we want to iterate over
         // whole bitset and return None for entities that don't have this optional component.
-        let max_id = self.bitset.bit_len() - 1;
-        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+        let max_id = self.bitset.bit_len();
+        while self.current_id < max_id && !self.bitset.bit_test(self.current_id) {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             if self.components.bitset.bit_test(self.current_id) {
                 Some(Some(unsafe {
@@ -110,13 +110,13 @@ impl<'a> Iterator for UntypedComponentBitsetIteratorMut<'a> {
     type Item = SchemaRefMut<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let max_id = self.components.max_id;
-        while !(self.bitset.bit_test(self.current_id)
-            && self.components.bitset.bit_test(self.current_id))
-            && self.current_id <= max_id
+        while self.current_id < max_id
+            && !(self.bitset.bit_test(self.current_id)
+                && self.components.bitset.bit_test(self.current_id))
         {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: We know that the index is within bounds, and we know that the pointer will be
             // valid for the new lifetime.
             Some(unsafe {
@@ -144,11 +144,11 @@ impl<'a> Iterator for UntypedComponentOptionalBitsetIteratorMut<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         // We do not stop iterating at component store length, as we want to iterate over
         // whole bitset and return None for entities that don't have this optional component.
-        let max_id = self.bitset.bit_len() - 1;
-        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+        let max_id = self.bitset.bit_len();
+        while self.current_id < max_id && !self.bitset.bit_test(self.current_id) {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             if self.components.bitset.bit_test(self.current_id) {
                 Some(Some(unsafe {

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -161,7 +161,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
     fn get_single_with_bitset(&self, bitset: Rc<BitSetVec>) -> Result<&T, QuerySingleError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_with_bitset_mut(
+    fn get_single_mut_with_bitset(
         &mut self,
         bitset: Rc<BitSetVec>,
     ) -> Result<&mut T, QuerySingleError>;
@@ -213,7 +213,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_with_bitset_mut(
+    fn get_single_mut_with_bitset(
         &mut self,
         bitset: Rc<BitSetVec>,
     ) -> Result<&mut T, QuerySingleError> {

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -111,7 +111,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets an immutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single(&self) -> Option<&T> {
+    pub fn get_single(&self) -> Result<&T, QueryItemError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single()
@@ -120,7 +120,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single_mut(&mut self) -> Option<&mut T> {
+    pub fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single_mut()
@@ -155,10 +155,10 @@ impl<T: HasSchema> ComponentStore<T> {
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Option<&T>;
+    fn get_single(&self) -> Result<&T, QueryItemError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Option<&mut T>;
+    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError>;
 
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
@@ -198,7 +198,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Option<&T> {
+    fn get_single(&self) -> Result<&T, QueryItemError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRef) -> &T {
             unsafe { r.cast_into_unchecked() }
@@ -207,7 +207,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Option<&mut T> {
+    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
@@ -343,7 +343,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, None);
+        assert_eq!(maybe_comp, Err(QueryItemError::NoEntities));
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Some(&a));
+        assert_eq!(maybe_comp, Ok(&a));
     }
 
     #[test]
@@ -374,6 +374,6 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, None);
+        assert_eq!(maybe_comp, Err(QueryItemError::MultipleEntities));
     }
 }

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -82,7 +82,7 @@ impl<T: HasSchema> ComponentStore<T> {
         self.untyped.get_mut_or_insert(entity, f)
     }
 
-    /// Get mutable references s to the component data for multiple entities at the same time.
+    /// Get mutable references to the component data for multiple entities at the same time.
     ///
     /// # Panics
     ///
@@ -206,7 +206,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     #[inline]
     fn iter_mut_with_bitset(&mut self, bitset: Rc<BitSetVec>) -> ComponentBitsetIteratorMut<T> {
         // SOUND: we know the schema matches.
-        fn map<T>(r: SchemaRefMut<'_>) -> &mut T {
+        fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
         }
 

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -109,6 +109,24 @@ impl<T: HasSchema> ComponentStore<T> {
         self.untyped.remove(entity)
     }
 
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    #[inline]
+    pub fn get_single(&self) -> Option<&T> {
+        // SOUND: we know the schema matches.
+        self.untyped
+            .get_single()
+            .map(|x| unsafe { x.cast_into_unchecked() })
+    }
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    #[inline]
+    pub fn get_single_mut(&mut self) -> Option<&mut T> {
+        // SOUND: we know the schema matches.
+        self.untyped
+            .get_single_mut()
+            .map(|x| unsafe { x.cast_into_mut_unchecked() })
+    }
+
     /// Iterates immutably over all components of this type.
     /// Very fast but doesn't allow joining with other component types.
     #[inline]
@@ -136,6 +154,12 @@ impl<T: HasSchema> ComponentStore<T> {
 ///
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    fn get_single(&self) -> Option<&T>;
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    fn get_single_mut(&mut self) -> Option<&mut T>;
+
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.
@@ -173,6 +197,24 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 }
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    fn get_single(&self) -> Option<&T> {
+        // SOUND: we know the schema matches.
+        fn map<T>(r: SchemaRef) -> &T {
+            unsafe { r.cast_into_unchecked() }
+        }
+        self.untyped.get_single().map(map)
+    }
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    fn get_single_mut(&mut self) -> Option<&mut T> {
+        // SOUND: we know the schema matches.
+        fn map<T>(r: SchemaRefMut) -> &mut T {
+            unsafe { r.cast_into_mut_unchecked() }
+        }
+        self.untyped.get_single_mut().map(map)
+    }
+
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -111,7 +111,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets an immutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single(&self) -> Result<&T, QueryItemError> {
+    pub fn get_single(&self) -> Result<&T, QuerySingleError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single()
@@ -120,7 +120,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
+    pub fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single_mut()
@@ -155,10 +155,10 @@ impl<T: HasSchema> ComponentStore<T> {
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Result<&T, QueryItemError>;
+    fn get_single(&self) -> Result<&T, QuerySingleError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError>;
+    fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError>;
 
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
@@ -198,7 +198,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Result<&T, QueryItemError> {
+    fn get_single(&self) -> Result<&T, QuerySingleError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRef) -> &T {
             unsafe { r.cast_into_unchecked() }
@@ -207,7 +207,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
+    fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
@@ -345,7 +345,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Err(QueryItemError::NoEntities));
+        assert_eq!(maybe_comp, Err(QuerySingleError::NoEntities));
     }
 
     #[test]
@@ -376,7 +376,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Err(QueryItemError::MultipleEntities));
+        assert_eq!(maybe_comp, Err(QuerySingleError::MultipleEntities));
     }
 
     #[test]

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,28 +492,28 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Option<SchemaRef> {
+    pub fn get_single(&self) -> Result<SchemaRef, QueryItemError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next()?;
+        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
         if iter.next().is_some() {
-            return None;
+            return Err(QueryItemError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx(i)
+        self.get_idx(i).ok_or(QueryItemError::NoEntities)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
+    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QueryItemError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next()?;
+        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
         if iter.next().is_some() {
-            return None;
+            return Err(QueryItemError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx_mut(i)
+        self.get_idx_mut(i).ok_or(QueryItemError::NoEntities)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -491,6 +491,25 @@ impl UntypedComponentStore {
         }
     }
 
+    /// Get a reference to the component store if there is exactly one instance of the component.
+    pub fn get_single(&self) -> Option<SchemaRef> {
+        if self.bitset().bit_count() == 1 {
+            self.get_idx(0)
+        } else {
+            None
+        }
+    }
+
+    /// Get a mutable reference to the component store if there is exactly one instance of the
+    /// component.
+    pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
+        if self.bitset().bit_count() == 1 {
+            self.get_idx_mut(0)
+        } else {
+            None
+        }
+    }
+
     /// Iterates immutably over all components of this type.
     ///
     /// Very fast but doesn't allow joining with other component types.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,28 +492,28 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Result<SchemaRef, QueryItemError> {
+    pub fn get_single(&self) -> Result<SchemaRef, QuerySingleError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
+        let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
-            return Err(QueryItemError::MultipleEntities);
+            return Err(QuerySingleError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx(i).ok_or(QueryItemError::NoEntities)
+        self.get_idx(i).ok_or(QuerySingleError::NoEntities)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QueryItemError> {
+    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QuerySingleError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
+        let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
-            return Err(QueryItemError::MultipleEntities);
+            return Err(QuerySingleError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx_mut(i).ok_or(QueryItemError::NoEntities)
+        self.get_idx_mut(i).ok_or(QuerySingleError::NoEntities)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,9 +492,12 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Result<SchemaRef, QuerySingleError> {
+    pub fn get_single_with_bitset(
+        &self,
+        bitset: Rc<BitSetVec>,
+    ) -> Result<SchemaRef, QuerySingleError> {
         let len = self.bitset().bit_len();
-        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let mut iter = (0..len).filter(|&i| bitset.bit_test(i) && self.bitset().bit_test(i));
         let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
             return Err(QuerySingleError::MultipleEntities);
@@ -505,9 +508,12 @@ impl UntypedComponentStore {
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QuerySingleError> {
+    pub fn get_single_with_bitset_mut(
+        &mut self,
+        bitset: Rc<BitSetVec>,
+    ) -> Result<SchemaRefMut, QuerySingleError> {
         let len = self.bitset().bit_len();
-        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let mut iter = (0..len).filter(|&i| bitset.bit_test(i) && self.bitset().bit_test(i));
         let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
             return Err(QuerySingleError::MultipleEntities);

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -493,21 +493,27 @@ impl UntypedComponentStore {
 
     /// Get a reference to the component store if there is exactly one instance of the component.
     pub fn get_single(&self) -> Option<SchemaRef> {
-        if self.bitset().bit_count() == 1 {
-            self.get_idx(0)
-        } else {
-            None
+        let len = self.bitset().bit_len();
+        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let i = iter.next()?;
+        if iter.next().is_some() {
+            return None;
         }
+        // TODO: add unchecked variant to avoid redundant validation
+        self.get_idx(i)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
     pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
-        if self.bitset().bit_count() == 1 {
-            self.get_idx_mut(0)
-        } else {
-            None
+        let len = self.bitset().bit_len();
+        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let i = iter.next()?;
+        if iter.next().is_some() {
+            return None;
         }
+        // TODO: add unchecked variant to avoid redundant validation
+        self.get_idx_mut(i)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -296,12 +296,10 @@ impl UntypedComponentStore {
         entity: Entity,
         f: impl FnOnce() -> T,
     ) -> &mut T {
-        if self.bitset.bit_test(entity.index() as usize) {
-            return self.get_mut(entity).unwrap();
-        } else {
+        if !self.bitset.bit_test(entity.index() as usize) {
             self.insert(entity, f());
-            self.get_mut(entity).unwrap()
         }
+        self.get_mut(entity).unwrap()
     }
 
     /// Get a [`SchemaRefMut`] to the component for the given [`Entity`]
@@ -601,9 +599,8 @@ impl<'a> Iterator for UntypedComponentStoreIter<'a> {
                 if let Some(ptr) = self.store.get_idx(self.idx) {
                     self.idx += 1;
                     break Some(ptr);
-                } else {
-                    self.idx += 1;
                 }
+                self.idx += 1;
             } else {
                 break None;
             }
@@ -628,9 +625,8 @@ impl<'a> Iterator for UntypedComponentStoreIterMut<'a> {
                     break Some(unsafe {
                         SchemaRefMut::from_ptr_schema(ptr.as_ptr(), ptr.schema())
                     });
-                } else {
-                    self.idx += 1;
                 }
+                self.idx += 1;
             } else {
                 break None;
             }

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -101,8 +101,9 @@ pub trait QueryItem {
 }
 
 /// An error that may occur when querying for a single entity. For example, via
-/// [`Entities::get_single_with`], or more directly with [`ComponentStore::get_single`] or
-/// [`ComponentStore::get_single_mut`].
+/// [`Entities::get_single_with`], or more directly with
+/// [`ComponentStore::get_single_with_bitset`] or
+/// [`ComponentStore::get_single_mut_with_bitset`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum QuerySingleError {
     /// No entity matches the query.

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -443,6 +443,19 @@ impl<'a, I: Iterator> Iterator for EntitiesIterWith<'a, I> {
 impl Entities {
     /// Get a single entity and components in the given query if there is exactly one entity
     /// matching the query.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the number of matching entities is not *exactly one*.
+    pub fn single_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> (Entity, <<Q as QueryItem>::Iter as Iterator>::Item) {
+        self.get_single_with(query).unwrap()
+    }
+
+    /// Get a single entity and components in the given query if there is exactly one entity
+    /// matching the query.
     pub fn get_single_with<Q: QueryItem>(
         &self,
         query: Q,

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -713,6 +713,8 @@ impl<'a> Iterator for EntityIterator<'a> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_snake_case)]
+
     use std::collections::HashSet;
 
     use crate::prelude::*;
@@ -726,7 +728,7 @@ mod tests {
     struct B(String);
 
     #[test]
-    fn create_kill_entities() {
+    fn entities__create_kill() {
         let mut entities = Entities::default();
         let e1 = entities.create();
         let e2 = entities.create();
@@ -754,7 +756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_interleaved_create_kill() {
+    fn entities__interleaved_create_kill() {
         let mut entities = Entities::default();
 
         let e1 = entities.create();
@@ -778,7 +780,7 @@ mod tests {
 
     #[test]
     /// Exercise basic operations on entities to increase code coverage
-    fn clone_debug_hash() {
+    fn entities__clone_debug_hash() {
         let mut entities = Entities::default();
         let e1 = entities.create();
         // Clone
@@ -795,7 +797,7 @@ mod tests {
     ///
     /// Exercises a code path not tested according to code coverage.
     #[test]
-    fn force_generate_next_section() {
+    fn entities__force_generate_next_section() {
         let mut entities = Entities::default();
         // Create enough entities to fil up the first section of the bitset
         for _ in 0..256 {
@@ -812,7 +814,7 @@ mod tests {
     #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
-    fn force_max_entity_panic() {
+    fn entities__force_max_entity_panic() {
         let mut entities = Entities::default();
         for _ in 0..(BITSET_SIZE + 1) {
             entities.create();
@@ -822,7 +824,7 @@ mod tests {
     #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
-    fn force_max_entity_panic2() {
+    fn entities__force_max_entity_panic2() {
         let mut entities = Entities::default();
         let mut e = None;
         for _ in 0..BITSET_SIZE {
@@ -835,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn iter_with_empty_bitset() {
+    fn entities__iter_with_empty_bitset() {
         let mut entities = Entities::default();
 
         // Create a couple entities
@@ -848,7 +850,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_one_component() {
+    fn entities__get_single__with_one_required() {
         let mut entities = Entities::default();
         (0..3).map(|_| entities.create()).count();
         let e = entities.create();
@@ -863,7 +865,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_two_components() {
+    fn entities__get_single__with_multiple_required() {
         let mut entities = Entities::default();
 
         let state_a = AtomicCell::new(ComponentStore::<A>::default());
@@ -892,7 +894,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_optional_component() {
+    fn entities__get_single__with_one_optional() {
         let mut entities = Entities::default();
         let state = AtomicCell::new(ComponentStore::<A>::default());
 
@@ -933,7 +935,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_optional_and_non_optional_components() {
+    fn entities__get_single__with_required_and_optional() {
         let mut entities = Entities::default();
         let state_a = AtomicCell::new(ComponentStore::<A>::default());
         let state_b = AtomicCell::new(ComponentStore::<B>::default());

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -649,9 +649,17 @@ impl<'a> Iterator for EntityIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{collections::HashSet, sync::Arc};
 
     use crate::prelude::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
+    #[repr(C)]
+    struct A(String);
+
+    #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
+    #[repr(C)]
+    struct B(String);
 
     #[test]
     fn create_kill_entities() {
@@ -773,5 +781,70 @@ mod tests {
         // Join with an empty bitset
         let bitset = BitSetVec::default();
         assert_eq!(entities.iter_with_bitset(&bitset).count(), 0);
+    }
+
+    #[test]
+    fn get_single_with_one_component() {
+        let mut entities = Entities::default();
+        (0..3).map(|_| entities.create()).count();
+        let e = entities.create();
+        let a = A("a".to_string());
+
+        let mut storage = ComponentStore::<A>::default();
+        storage.insert(e, a.clone());
+
+        let world = World::default();
+        let mut state = Arc::new(AtomicCell::new(storage));
+        let comp = <Comp<A> as SystemParam>::borrow(&world, &mut state);
+
+        assert_eq!(entities.get_single_with(&comp), Some((e, &a)));
+    }
+
+    #[test]
+    fn get_single_with_two_components() {
+        let mut entities = Entities::default();
+
+        let mut storage_a = ComponentStore::<A>::default();
+        let mut storage_b = ComponentStore::<B>::default();
+
+        let _e1 = entities.create();
+
+        let e2 = entities.create();
+        storage_a.insert(e2, A("a2".to_string()));
+
+        let e3 = entities.create();
+        storage_b.insert(e3, B("b3".to_string()));
+
+        let e4 = entities.create();
+        let mut a4 = A("a4".to_string());
+        let mut b4 = B("b4".to_string());
+        storage_a.insert(e4, a4.clone());
+        storage_b.insert(e4, b4.clone());
+
+        let world = World::default();
+        let mut state_a = Arc::new(AtomicCell::new(storage_a));
+        let mut state_b = Arc::new(AtomicCell::new(storage_b));
+
+        {
+            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
+            assert_eq!(
+                entities.get_single_with((&comp_a, &comp_b)),
+                Some((e4, (&a4, &b4)))
+            );
+        }
+
+        {
+            let mut comp_a = <CompMut<A> as SystemParam>::borrow(&world, &mut state_a);
+            let mut comp_b = <CompMut<B> as SystemParam>::borrow(&world, &mut state_b);
+            assert_eq!(
+                entities.get_single_with((&comp_a, &comp_b)),
+                Some((e4, (&a4, &b4)))
+            );
+            assert_eq!(
+                entities.get_single_with((&mut comp_a, &mut comp_b)),
+                Some((e4, (&mut a4, &mut b4)))
+            );
+        }
     }
 }

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -351,6 +351,17 @@ impl<'a, I: Iterator> Iterator for EntitiesIterWith<'a, I> {
 }
 
 impl Entities {
+    /// Iterates over entities using the provided bitset.
+    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
+        EntityIterator {
+            current_id: 0,
+            next_id: self.next_id,
+            entities: &self.alive,
+            generations: &self.generation,
+            bitset,
+        }
+    }
+
     /// Iterate over the entities and components in the given query.
     ///
     /// The [`QueryItem`] trait is automatically implemented for references to [`Comp`] and
@@ -504,17 +515,6 @@ impl Entities {
     /// Useful for joining over [`Entity`] and [`ComponentStore<T>`] at the same time.
     pub fn bitset(&self) -> &BitSetVec {
         &self.alive
-    }
-
-    /// Iterates over entities using the provided bitset.
-    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
-        EntityIterator {
-            current_id: 0,
-            next_id: self.next_id,
-            entities: &self.alive,
-            generations: &self.generation,
-            bitset,
-        }
     }
 }
 

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -371,8 +371,9 @@ macro_rules! impl_query {
                 let first = query.next();
                 let has_second = query.next().is_some();
                 match (first, has_second) {
+                    (None, _) => Err(QuerySingleError::NoEntities),
                     (Some(items), false) => Ok(items),
-                    _ => Err(QuerySingleError::MultipleEntities),
+                    (Some(_), true) => Err(QuerySingleError::MultipleEntities),
                 }
             }
 

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -265,7 +265,7 @@ where
         self,
         bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        match self.0.get_single_with_bitset_mut(bitset) {
+        match self.0.get_single_mut_with_bitset(bitset) {
             Ok(x) => Ok(Some(x)),
             Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -176,9 +176,9 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
 
     fn get_single_with_bitset(
         self,
-        _bitset: Rc<BitSetVec>,
+        bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        ComponentStore::get_single(&**self)
+        ComponentStore::get_single_with_bitset(&**self, bitset)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -195,9 +195,9 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
 
     fn get_single_with_bitset(
         self,
-        _bitset: Rc<BitSetVec>,
+        bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        ComponentStore::get_single(&**self)
+        ComponentStore::get_single_with_bitset(&**self, bitset)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -214,9 +214,9 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
 
     fn get_single_with_bitset(
         self,
-        _bitset: Rc<BitSetVec>,
+        bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        ComponentStore::get_single_mut(self)
+        ComponentStore::get_single_with_bitset_mut(self, bitset)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -237,9 +237,9 @@ where
 
     fn get_single_with_bitset(
         self,
-        _bitset: Rc<BitSetVec>,
+        bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        match self.0.get_single() {
+        match self.0.get_single_with_bitset(bitset) {
             Ok(single) => Ok(Some(single)),
             Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),
@@ -263,9 +263,9 @@ where
 
     fn get_single_with_bitset(
         self,
-        _bitset: Rc<BitSetVec>,
+        bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        match self.0.get_single_mut() {
+        match self.0.get_single_with_bitset_mut(bitset) {
             Ok(x) => Ok(Some(x)),
             Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),
@@ -839,6 +839,26 @@ mod tests {
             entities.kill(e1);
             entities.kill(e2);
         }
+    }
+
+    #[test]
+    fn query_item__get_single_with_bitset__uses_bitset() {
+        let mut entities = Entities::default();
+        let state = AtomicCell::new(ComponentStore::<A>::default());
+
+        let e = entities.create();
+        state.borrow_mut().insert(e, A("unexpected".to_string()));
+
+        let query = &state.borrow();
+        let bitset = Rc::new({
+            let mut bitset = BitSetVec::default();
+            bitset.bit_set(99);
+            bitset
+        });
+
+        let maybe_comp = query.get_single_with_bitset(bitset);
+
+        assert_eq!(maybe_comp, Err(QuerySingleError::NoEntities));
     }
 
     #[test]

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -713,7 +713,7 @@ impl<'a> Iterator for EntityIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, sync::Arc};
+    use std::collections::HashSet;
 
     use crate::prelude::*;
 
@@ -854,12 +854,10 @@ mod tests {
         let e = entities.create();
         let a = A("a".to_string());
 
-        let mut storage = ComponentStore::<A>::default();
-        storage.insert(e, a.clone());
+        let state = AtomicCell::new(ComponentStore::<A>::default());
+        state.borrow_mut().insert(e, a.clone());
 
-        let world = World::default();
-        let mut state = Arc::new(AtomicCell::new(storage));
-        let comp = <Comp<A> as SystemParam>::borrow(&world, &mut state);
+        let comp = state.borrow();
 
         assert_eq!(entities.get_single_with(&comp), Ok((e, &a)));
     }
@@ -868,77 +866,66 @@ mod tests {
     fn get_single_with_two_components() {
         let mut entities = Entities::default();
 
-        let mut storage_a = ComponentStore::<A>::default();
-        let mut storage_b = ComponentStore::<B>::default();
+        let state_a = AtomicCell::new(ComponentStore::<A>::default());
+        let state_b = AtomicCell::new(ComponentStore::<B>::default());
 
         let _e1 = entities.create();
 
         let e2 = entities.create();
-        storage_a.insert(e2, A("a2".to_string()));
+        state_a.borrow_mut().insert(e2, A("a2".to_string()));
 
         let e3 = entities.create();
-        storage_b.insert(e3, B("b3".to_string()));
+        state_b.borrow_mut().insert(e3, B("b3".to_string()));
 
         let e4 = entities.create();
-        let mut a4 = A("a4".to_string());
-        let mut b4 = B("b4".to_string());
-        storage_a.insert(e4, a4.clone());
-        storage_b.insert(e4, b4.clone());
+        let a4 = A("a4".to_string());
+        let b4 = B("b4".to_string());
+        state_a.borrow_mut().insert(e4, a4.clone());
+        state_b.borrow_mut().insert(e4, b4.clone());
 
-        let world = World::default();
-        let mut state_a = Arc::new(AtomicCell::new(storage_a));
-        let mut state_b = Arc::new(AtomicCell::new(storage_b));
-
-        {
-            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
-            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
-            assert_eq!(
-                entities.get_single_with((&comp_a, &comp_b)),
-                Ok((e4, (&a4, &b4)))
-            );
-        }
-
-        {
-            let mut comp_a = <CompMut<A> as SystemParam>::borrow(&world, &mut state_a);
-            let mut comp_b = <CompMut<B> as SystemParam>::borrow(&world, &mut state_b);
-            assert_eq!(
-                entities.get_single_with((&comp_a, &comp_b)),
-                Ok((e4, (&a4, &b4)))
-            );
-            assert_eq!(
-                entities.get_single_with((&mut comp_a, &mut comp_b)),
-                Ok((e4, (&mut a4, &mut b4)))
-            );
-        }
+        let comp_a = state_a.borrow();
+        let comp_b = state_b.borrow();
+        assert_eq!(
+            entities.get_single_with((&comp_a, &comp_b)),
+            Ok((e4, (&a4, &b4)))
+        );
     }
 
     #[test]
     fn get_single_with_optional_component() {
         let mut entities = Entities::default();
-
-        let world = World::default();
-        let mut state_a = Arc::new(AtomicCell::new(ComponentStore::<A>::default()));
+        let state = AtomicCell::new(ComponentStore::<A>::default());
 
         {
             let e = entities.create();
 
-            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+            let mut comp = state.borrow_mut();
 
-            assert_eq!(entities.get_single_with(&Optional(&comp_a)), Ok((e, None)));
+            assert_eq!(entities.get_single_with(&Optional(&comp)), Ok((e, None)));
+
+            assert_eq!(
+                entities.get_single_with(&mut OptionalMut(&mut comp)),
+                Ok((e, None))
+            );
 
             entities.kill(e);
         }
 
         {
             let e = entities.create();
-            let a = A("a".to_string());
-            state_a.borrow_mut().insert(e, a.clone());
+            let mut a = A("a".to_string());
+            state.borrow_mut().insert(e, a.clone());
 
-            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+            let mut comp = state.borrow_mut();
 
             assert_eq!(
-                entities.get_single_with(&Optional(&comp_a)),
+                entities.get_single_with(&Optional(&comp)),
                 Ok((e, Some(&a)))
+            );
+
+            assert_eq!(
+                entities.get_single_with(&mut OptionalMut(&mut comp)),
+                Ok((e, Some(&mut a)))
             );
 
             entities.kill(e);
@@ -948,21 +935,24 @@ mod tests {
     #[test]
     fn get_single_with_optional_and_non_optional_components() {
         let mut entities = Entities::default();
-
-        let world = World::default();
-        let mut state_a = Arc::new(AtomicCell::new(ComponentStore::<A>::default()));
-        let mut state_b = Arc::new(AtomicCell::new(ComponentStore::<B>::default()));
+        let state_a = AtomicCell::new(ComponentStore::<A>::default());
+        let state_b = AtomicCell::new(ComponentStore::<B>::default());
 
         {
             let e = entities.create();
             let a = A("a".to_string());
             state_a.borrow_mut().insert(e, a.clone());
 
-            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
-            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
+            let comp_a = state_a.borrow();
+            let mut comp_b = state_b.borrow_mut();
 
             assert_eq!(
                 entities.get_single_with((&comp_a, &Optional(&comp_b))),
+                Ok((e, (&a, None)))
+            );
+
+            assert_eq!(
+                entities.get_single_with((&comp_a, &mut OptionalMut(&mut comp_b))),
                 Ok((e, (&a, None)))
             );
 
@@ -972,16 +962,21 @@ mod tests {
         {
             let e = entities.create();
             let a = A("a".to_string());
-            let b = B("b".to_string());
+            let mut b = B("b".to_string());
             state_a.borrow_mut().insert(e, a.clone());
             state_b.borrow_mut().insert(e, b.clone());
 
-            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
-            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
+            let comp_a = state_a.borrow();
+            let mut comp_b = state_b.borrow_mut();
 
             assert_eq!(
                 entities.get_single_with((&comp_a, &Optional(&comp_b))),
                 Ok((e, (&a, Some(&b))))
+            );
+
+            assert_eq!(
+                entities.get_single_with((&comp_a, &mut OptionalMut(&mut comp_b))),
+                Ok((e, (&a, Some(&mut b))))
             );
 
             entities.kill(e);

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -236,7 +236,11 @@ where
         self,
         _bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
-        self.0.get_single().map(Some)
+        match self.0.get_single() {
+            Ok(single) => Ok(Some(single)),
+            Err(QueryItemError::NoEntities) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -258,8 +262,11 @@ where
         self,
         _bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
-        // TODO: is `Option<Option<&T>>` the correct return type?
-        self.0.get_single_mut().map(Some)
+        match self.0.get_single_mut() {
+            Ok(x) => Ok(Some(x)),
+            Err(QueryItemError::NoEntities) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -852,6 +859,82 @@ mod tests {
                 entities.get_single_with((&mut comp_a, &mut comp_b)),
                 Ok((e4, (&mut a4, &mut b4)))
             );
+        }
+    }
+
+    #[test]
+    fn get_single_with_optional_component() {
+        let mut entities = Entities::default();
+
+        let world = World::default();
+        let mut state_a = Arc::new(AtomicCell::new(ComponentStore::<A>::default()));
+
+        {
+            let e = entities.create();
+
+            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+
+            assert_eq!(entities.get_single_with(&Optional(&comp_a)), Ok((e, None)));
+
+            entities.kill(e);
+        }
+
+        {
+            let e = entities.create();
+            let a = A("a".to_string());
+            state_a.borrow_mut().insert(e, a.clone());
+
+            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+
+            assert_eq!(
+                entities.get_single_with(&Optional(&comp_a)),
+                Ok((e, Some(&a)))
+            );
+
+            entities.kill(e);
+        }
+    }
+
+    #[test]
+    fn get_single_with_optional_and_non_optional_components() {
+        let mut entities = Entities::default();
+
+        let world = World::default();
+        let mut state_a = Arc::new(AtomicCell::new(ComponentStore::<A>::default()));
+        let mut state_b = Arc::new(AtomicCell::new(ComponentStore::<B>::default()));
+
+        {
+            let e = entities.create();
+            let a = A("a".to_string());
+            state_a.borrow_mut().insert(e, a.clone());
+
+            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
+
+            assert_eq!(
+                entities.get_single_with((&comp_a, &Optional(&comp_b))),
+                Ok((e, (&a, None)))
+            );
+
+            entities.kill(e);
+        }
+
+        {
+            let e = entities.create();
+            let a = A("a".to_string());
+            let b = B("b".to_string());
+            state_a.borrow_mut().insert(e, a.clone());
+            state_b.borrow_mut().insert(e, b.clone());
+
+            let comp_a = <Comp<A> as SystemParam>::borrow(&world, &mut state_a);
+            let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
+
+            assert_eq!(
+                entities.get_single_with((&comp_a, &Optional(&comp_b))),
+                Ok((e, (&a, Some(&b))))
+            );
+
+            entities.kill(e);
         }
     }
 }

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -479,6 +479,40 @@ impl Entities {
             .map(|item| (entity, item))
     }
 
+    /// Get the first entity in the given bitset.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if there are no entities in the bitset.
+    pub fn first_with_bitset(&self, bitset: &BitSetVec) -> Entity {
+        self.get_first_with_bitset(bitset).unwrap()
+    }
+
+    /// Get the first entity in the given bitset.
+    pub fn get_first_with_bitset(&self, bitset: &BitSetVec) -> Option<Entity> {
+        self.iter_with_bitset(bitset).next()
+    }
+
+    /// Get the first entity and components in the given query.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if there are no entities that match the query.
+    pub fn first_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> (Entity, <<Q as QueryItem>::Iter as Iterator>::Item) {
+        self.get_first_with(query).unwrap()
+    }
+
+    /// Get the first entity and components in the given query.
+    pub fn get_first_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> Option<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item)> {
+        self.iter_with(query).next()
+    }
+
     /// Iterates over entities using the provided bitset.
     pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
         EntityIterator {


### PR DESCRIPTION
Closes #289.

## Changes

- Add `Entities::(get_)single_with` methods to get a single entity by a query
- Add `Entities::(get_)first_with_bitset` methods to get the first entity in the given bitset
- Add `Entities::(get_)first_with` methods to get the first entity in the given query

## Summary

Add convenience methods to get a single entity (and optionally its components) when there should only be one of the thing you're looking for. This could be useful, for example, to check if there is only one player alive in the game. You could use `Entities::get_single_with` which would allow you to detect when there is only one player (`Ok`) or when there are none/multiple (`Err`).

All methods have a panicking and non-panicking variant -- e.g. `get_single_with` returns a `Result<_, QuerySingleError>`, while `single_with` panics if the return value would not be `Ok`. The `*first_with*` methods either return an `Option` or panic.