### PR TITLE
feat: Add socket to NetworkInfo

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -205,7 +205,8 @@ pub enum SocketTarget {
 }
 
 /// Resource updated each frame exposing current frame and last confirmed of online session.
-#[derive(HasSchema, Copy, Clone, Default)]
+#[derive(HasSchema, Clone)]
+#[schema(no_default)]
 pub struct NetworkInfo {
     /// Current frame of simulation step
     pub current_frame: i32,
@@ -213,6 +214,9 @@ pub struct NetworkInfo {
     /// Last confirmed frame by all clients.
     /// Anything that occurred on this frame is agreed upon by all clients.
     pub last_confirmed_frame: i32,
+
+    /// Socket
+    pub socket: BoxedNonBlockingSocket,
 }
 
 /// [`SessionRunner`] implementation that uses [`ggrs`] for network play.
@@ -511,6 +515,7 @@ where
                                     world.insert_resource(NetworkInfo {
                                         current_frame: self.session.current_frame(),
                                         last_confirmed_frame: self.session.confirmed_frame(),
+                                        socket: self.socket.clone(),
                                     });
 
                                     {


### PR DESCRIPTION
Expose socket via `NetworkInfo` (resource managed by net session runner). 

`NetworkMatchSocket` resource only exists in menu session. This change makes it easier to get socket from game session. 

It might make sense to instead make this a shared resource and add Option so it may be default, however I worry about forgetting to clean this shared resource up when it is no longer relevant (If left multi-player game and went to single player and didn't clear shared resource, we would start executing online paths of code). 