### PR TITLE
fix: Use BorderlessFullscreen instead of true fullscreen (fix alt+tab)

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -790,17 +790,17 @@ fn step_bones_game(world: &mut World) {
         None => {
             data.game.insert_shared_resource(bones::Window {
                 size: vec2(window.width(), window.height()),
-                fullscreen: matches!(&window.mode, WindowMode::Fullscreen),
+                fullscreen: matches!(&window.mode, WindowMode::BorderlessFullscreen),
             });
             data.game.shared_resource_cell().unwrap()
         }
     };
     let bones_window = bones_window.borrow_mut().unwrap();
 
-    let is_fullscreen = matches!(&window.mode, WindowMode::Fullscreen);
+    let is_fullscreen = matches!(&window.mode, WindowMode::BorderlessFullscreen);
     if is_fullscreen != bones_window.fullscreen {
         window.mode = if bones_window.fullscreen {
-            WindowMode::Fullscreen
+            WindowMode::BorderlessFullscreen
         } else {
             WindowMode::Windowed
         };


### PR DESCRIPTION
Using borderless fullscreen mode fixes alt tab not working in fullscreen. Probably should support both - but this seems like a preferable default.

One side effect I see in jumpy is that when fullscreen on high res display the UI scaling no longer gets tiny (now looks as I'd expect). I'd show screenshots to compare, but the screenshot tool on macOS doesn't work in true fullscreen mode either 😉 

Any concerns with this?