### PR TITLE
feat: add option to supply fixed secret key to the matchmaker

### DIFF
--- a/other_crates/bones_matchmaker/src/cli.rs
+++ b/other_crates/bones_matchmaker/src/cli.rs
@@ -1,12 +1,23 @@
 use clap::Parser;
 use tracing::metadata::LevelFilter;
+use tracing::warn;
 
 pub async fn start() {
     configure_logging();
 
     let args = crate::Config::parse();
+    let secret_key = match std::env::var("BONES_MATCHMAKER_SECRET_KEY") {
+        Ok(key) => match key.parse::<iroh_net::key::SecretKey>() {
+            Ok(key) => Some(key),
+            Err(_) => {
+                warn!("invalid matchmaker key provided");
+                None
+            }
+        },
+        Err(_) => None,
+    };
 
-    if let Err(e) = super::server(args).await {
+    if let Err(e) = super::server(args, secret_key).await {
         eprintln!("Error: {e}");
     }
 }


### PR DESCRIPTION
Key can be passed in via `BONES_MATCHMAKER_SECRET_KEY`

To show the secret key when generating, you can pass `--print-secret-key` to the binary now

Closes #405