### PR TITLE
feat: Allow local input to be disabled on SessionRunner.

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -515,6 +515,11 @@ where
                                     // Input has been consumed, signal that we are in new input frame
                                     self.input_collector.advance_frame();
 
+                                    // TODO: Make sure NetworkInfo is initialized immediately when session is created,
+                                    // even before a frame has advanced.
+                                    //
+                                    // The existance of this resource may be used to determine if in an online match, and there could
+                                    // be race if expected it to exist but testing before first frame advance.
                                     world.insert_resource(NetworkInfo {
                                         current_frame: self.session.current_frame(),
                                         last_confirmed_frame: self.session.confirmed_frame(),

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -140,6 +140,7 @@ pub trait SessionRunner: Sync + Send + 'static {
     ///     stages.run(world);
     /// }
     /// fn restart_session(&mut self) {}
+    /// fn disable_local_input(&mut self, disable_input: bool) {}
     /// # }
     /// ```
     fn step(&mut self, now: Instant, world: &mut World, stages: &mut SystemStages);

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -149,6 +149,9 @@ pub trait SessionRunner: Sync + Send + 'static {
     /// The expectation is that current players using it may continue to, so something like a network
     /// socket or player info should persist.
     fn restart_session(&mut self);
+
+    /// Disable the capture of local input by this session.
+    fn disable_local_input(&mut self, input_disabled: bool);
 }
 
 /// The default [`SessionRunner`], which just runs the systems once every time it is run.
@@ -165,6 +168,9 @@ impl SessionRunner for DefaultSessionRunner {
     fn restart_session(&mut self) {
         *self = DefaultSessionRunner::default();
     }
+
+    // `DefaultSessionRunner` does not collect input so this impl is not relevant.
+    fn disable_local_input(&mut self, _input_disabled: bool) {}
 }
 
 /// The [`Game`] encompasses a complete bones game's logic, independent of the renderer and IO


### PR DESCRIPTION
Add SessionRunner trait API for disabling local input. The use case for this is that in Jumpy when pausing the game in networked play, we do not want to set net game session inactive, as network loop will stop running and we will timeout. Instead can allow it to continue simulating and disable local input instead as a "pause".