### PR TITLE
feat: Impl `QueryItem` for `UntypedComponentStore`.

### DIFF
--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -150,6 +150,17 @@ where
     OptionalQueryItemMut(component_ref, PhantomData)
 }
 
+impl<'a> QueryItem for &'a Ref<'a, UntypedComponentStore> {
+    type Iter = UntypedComponentBitsetIterator<'a>;
+    fn apply_bitset(&self, bitset: &mut BitSetVec) {
+        bitset.bit_and(self.bitset());
+    }
+
+    fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
+        UntypedComponentStore::iter_with_bitset(self, bitset)
+    }
+}
+
 impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
     type Iter = ComponentBitsetIterator<'a, T>;
     fn apply_bitset(&self, bitset: &mut BitSetVec) {


### PR DESCRIPTION
Submitting on behalf of @tekhnaeraav:

Minor tweak that allows you use untyped component stores in `entities.iter_with()`.