### PR TITLE
fix: Disable MSAA in pixel art mode

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -146,6 +146,7 @@ impl BonesBevyRenderer {
             .build();
         if self.pixel_art {
             plugins = plugins.set(ImagePlugin::default_nearest());
+            app.insert_resource(Msaa::Off);
         }
 
         app.add_plugins(plugins).add_plugins((


### PR DESCRIPTION
Disable MSAA when in pixel art mode. It seems to add artifacts with texture sampling. Example: https://github.com/fishfolk/jumpy/issues/1014

