### PR TITLE
fix: changed SystemParam derive macro to use ::bones_ecs instead of ::bones_framework

### DIFF
--- a/framework_crates/bones_asset/src/lib.rs
+++ b/framework_crates/bones_asset/src/lib.rs
@@ -48,12 +48,221 @@ pub enum Maybe<T> {
 
 impl<T> Maybe<T> {
     /// Convert this [`Maybe`] into an [`Option`].
+    #[inline]
     pub fn option(self) -> Option<T> {
         self.into()
+    }
+
+    /// Returns `true` if the option is a `Set` value.
+    #[inline]
+    pub fn is_set(&self) -> bool {
+        matches!(self, Maybe::Set(_))
+    }
+
+    /// Returns `true` if the option is an `Unset` value.
+    #[inline]
+    pub fn is_unset(&self) -> bool {
+        matches!(self, Maybe::Unset)
+    }
+
+    /// Returns `true` if the option is a `Set` value.
+    #[inline]
+    pub fn is_some(&self) -> bool {
+        matches!(self, Maybe::Set(_))
+    }
+
+    /// Returns `true` if the option is an `Unset` value.
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        matches!(self, Maybe::Unset)
+    }
+
+    /// Returns `true` if the option is a `Set` value containing the given value.
+    #[inline]
+    pub fn contains<U>(&self, x: &U) -> bool
+    where
+        U: PartialEq<T>,
+    {
+        match self {
+            Maybe::Set(y) => x == y,
+            Maybe::Unset => false,
+        }
+    }
+
+    /// Converts from `&Maybe<T>` to `Maybe<&T>`.
+    #[inline]
+    pub fn as_ref(&self) -> Maybe<&T> {
+        match *self {
+            Maybe::Unset => Maybe::Unset,
+            Maybe::Set(ref x) => Maybe::Set(x),
+        }
+    }
+
+    /// Converts from `&mut Maybe<T>` to `Maybe<&mut T>`.
+    #[inline]
+    pub fn as_mut(&mut self) -> Maybe<&mut T> {
+        match *self {
+            Maybe::Unset => Maybe::Unset,
+            Maybe::Set(ref mut x) => Maybe::Set(x),
+        }
+    }
+
+    /// Returns the contained `Set` value, consuming the `self` value.
+    #[inline]
+    #[track_caller]
+    pub fn expect(self, msg: &str) -> T {
+        self.option().expect(msg)
+    }
+
+    /// Returns the contained `Set` value, consuming the `self` value.
+    #[inline]
+    #[track_caller]
+    pub fn unwrap(self) -> T {
+        self.option().unwrap()
+    }
+
+    /// Returns the contained `Set` value or a provided default.
+    #[inline]
+    pub fn unwrap_or(self, default: T) -> T {
+        self.option().unwrap_or(default)
+    }
+
+    /// Returns the contained `Set` value or computes it from a closure.
+    #[inline]
+    pub fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
+        self.option().unwrap_or_else(f)
+    }
+
+    /// Maps a `Maybe<T>` to `Maybe<U>` by applying a function to a contained value.
+    #[inline]
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Maybe<U> {
+        self.option().map(f).into()
+    }
+
+    /// Returns `Unset` if the option is `Unset`, otherwise calls `f` with the wrapped value and returns the result.
+    #[inline]
+    pub fn and_then<U, F: FnOnce(T) -> Maybe<U>>(self, f: F) -> Maybe<U> {
+        self.option().and_then(|x| f(x).option()).into()
+    }
+
+    /// Returns `Unset` if the option is `Unset`, otherwise returns `optb`.
+    #[inline]
+    pub fn and<U>(self, optb: Maybe<U>) -> Maybe<U> {
+        self.option().and(optb.option()).into()
+    }
+
+    /// Returns `Unset` if the option is `Unset`, otherwise calls `predicate` with the wrapped value and returns:
+    #[inline]
+    pub fn filter<P: FnOnce(&T) -> bool>(self, predicate: P) -> Maybe<T> {
+        self.option().filter(predicate).into()
+    }
+
+    /// Returns the option if it contains a value, otherwise returns `optb`.
+    #[inline]
+    pub fn or(self, optb: Maybe<T>) -> Maybe<T> {
+        self.option().or(optb.option()).into()
+    }
+
+    /// Returns the option if it contains a value, otherwise calls `f` and returns the result.
+    #[inline]
+    pub fn or_else<F: FnOnce() -> Maybe<T>>(self, f: F) -> Maybe<T> {
+        self.option().or_else(|| f().option()).into()
+    }
+
+    /// Returns `Set` if exactly one of `self`, `optb` is `Set`, otherwise returns `Unset`.
+    #[inline]
+    pub fn xor(self, optb: Maybe<T>) -> Maybe<T> {
+        self.option().xor(optb.option()).into()
+    }
+
+    /// Inserts `v` into the option if it is `Unset`, then returns a mutable reference to the contained value.
+    #[inline]
+    pub fn get_or_insert(&mut self, v: T) -> &mut T {
+        if let Maybe::Unset = self {
+            *self = Maybe::Set(v);
+        }
+        match self {
+            Maybe::Set(ref mut v) => v,
+            Maybe::Unset => unreachable!(),
+        }
+    }
+
+    /// Inserts a value computed from `f` into the option if it is `Unset`, then returns a mutable reference to the contained value.
+    #[inline]
+    pub fn get_or_insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
+        if let Maybe::Unset = self {
+            *self = Maybe::Set(f());
+        }
+        match self {
+            Maybe::Set(ref mut v) => v,
+            Maybe::Unset => unreachable!(),
+        }
+    }
+
+    /// Takes the value out of the option, leaving an `Unset` in its place.
+    #[inline]
+    pub fn take(&mut self) -> Maybe<T> {
+        std::mem::replace(self, Maybe::Unset)
+    }
+
+    /// Replaces the actual value in the option by the value given in parameter, returning the old value if present.
+    #[inline]
+    pub fn replace(&mut self, value: T) -> Maybe<T> {
+        std::mem::replace(self, Maybe::Set(value))
+    }
+
+    /// Zips `self` with another `Maybe`.
+    #[inline]
+    pub fn zip<U>(self, other: Maybe<U>) -> Maybe<(T, U)> {
+        self.option().zip(other.option()).into()
+    }
+
+    /// Returns the contained `Set` value, consuming the `self` value, without checking that the value is not `Unset`.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method on an `Unset` value is undefined behavior.
+    #[inline]
+    pub unsafe fn unwrap_unchecked(self) -> T {
+        self.option().unwrap_unchecked()
+    }
+
+    /// Maps a `Maybe<T>` to `U` by applying a function to a contained value, or returns a default.
+    #[inline]
+    pub fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
+        self.option().map_or(default, f)
+    }
+
+    /// Maps a `Maybe<T>` to `U` by applying a function to a contained value, or computes a default.
+    #[inline]
+    pub fn map_or_else<U, D: FnOnce() -> U, F: FnOnce(T) -> U>(self, default: D, f: F) -> U {
+        self.option().map_or_else(default, f)
+    }
+
+    /// Returns the contained `Set` value or a default.
+    #[inline]
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        self.option().unwrap_or_default()
+    }
+
+    /// Transforms the `Maybe<T>` into a `Result<T, E>`, mapping `Set(v)` to `Ok(v)` and `Unset` to `Err(err)`.
+    #[inline]
+    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
+        self.option().ok_or(err)
+    }
+
+    /// Transforms the `Maybe<T>` into a `Result<T, E>`, mapping `Set(v)` to `Ok(v)` and `Unset` to `Err(err())`.
+    #[inline]
+    pub fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
+        self.option().ok_or_else(err)
     }
 }
 
 impl<T> From<Maybe<T>> for Option<T> {
+    #[inline]
     fn from(value: Maybe<T>) -> Self {
         match value {
             Maybe::Set(s) => Some(s),
@@ -63,6 +272,7 @@ impl<T> From<Maybe<T>> for Option<T> {
 }
 
 impl<T> From<Option<T>> for Maybe<T> {
+    #[inline]
     fn from(value: Option<T>) -> Self {
         match value {
             Some(s) => Maybe::Set(s),

--- a/framework_crates/bones_ecs/macros/core/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/core/src/lib.rs
@@ -41,13 +41,13 @@ fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
     let state_types: Punctuated<TokenStream, Token![,]> =
         Punctuated::from_iter(fields.named.iter().map(|field| {
             let ty = &field.ty;
-            quote! { <#ty as ::bones_framework::prelude::SystemParam>::State }
+            quote! { <#ty as ::bones_ecs::prelude::SystemParam>::State }
         }));
 
     let get_state_items: Punctuated<TokenStream, Token![,]> =
         Punctuated::from_iter(fields.named.iter().map(|field| {
             let ty = &field.ty;
-            quote! { <#ty as ::bones_framework::prelude::SystemParam>::get_state(world) }
+            quote! { <#ty as ::bones_ecs::prelude::SystemParam>::get_state(world) }
         }));
 
     let borrow_param_fields: Punctuated<TokenStream, Token![,]> = fields
@@ -59,20 +59,20 @@ fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
             let ty = &field.ty;
             let index = Index { index: index as u32, span: Span::call_site() };
             quote! {
-                #ident: <#ty as ::bones_framework::prelude::SystemParam>::borrow(world, &mut state.#index)
+                #ident: <#ty as ::bones_ecs::prelude::SystemParam>::borrow(world, &mut state.#index)
             }
         })
         .collect();
 
     Ok(quote! {
-        impl<#lifetime> ::bones_framework::prelude::SystemParam for #ident<#lifetime> {
+        impl<#lifetime> ::bones_ecs::prelude::SystemParam for #ident<#lifetime> {
             type State = ( #state_types );
             type Param<'p> = #ident<'p>;
-            fn get_state(world: &::bones_framework::prelude::World) -> Self::State {
+            fn get_state(world: &::bones_ecs::prelude::World) -> Self::State {
                 ( #get_state_items )
             }
             fn borrow<'s>(
-                world: &'s ::bones_framework::prelude::World,
+                world: &'s ::bones_ecs::prelude::World,
                 state: &'s mut Self::State,
             ) -> Self::Param<'s> {
                 Self::Param { #borrow_param_fields }
@@ -104,25 +104,25 @@ mod tests {
     #[test]
     fn correct_system_param_impl() {
         let expected = quote! {
-            impl<'a> ::bones_framework::prelude::SystemParam for MySystemParam<'a> {
+            impl<'a> ::bones_ecs::prelude::SystemParam for MySystemParam<'a> {
                 type State = (
-                    <Commands<'a> as ::bones_framework::prelude::SystemParam>::State,
-                    <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::State
+                    <Commands<'a> as ::bones_ecs::prelude::SystemParam>::State,
+                    <ResMut<'a, Entities> as ::bones_ecs::prelude::SystemParam>::State
                 );
                 type Param<'p> = MySystemParam<'p>;
-                fn get_state(world: &::bones_framework::prelude::World) -> Self::State {
+                fn get_state(world: &::bones_ecs::prelude::World) -> Self::State {
                     (
-                        <Commands<'a> as ::bones_framework::prelude::SystemParam>::get_state(world),
-                        <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::get_state(world)
+                        <Commands<'a> as ::bones_ecs::prelude::SystemParam>::get_state(world),
+                        <ResMut<'a, Entities> as ::bones_ecs::prelude::SystemParam>::get_state(world)
                     )
                 }
                 fn borrow<'s>(
-                    world: &'s ::bones_framework::prelude::World,
+                    world: &'s ::bones_ecs::prelude::World,
                     state: &'s mut Self::State,
                 ) -> Self::Param<'s> {
                     Self::Param {
-                        commands: <Commands<'a> as ::bones_framework::prelude::SystemParam>::borrow(world, &mut state.0),
-                        entities: <ResMut<'a, Entities> as ::bones_framework::prelude::SystemParam>::borrow(world, &mut state.1)
+                        commands: <Commands<'a> as ::bones_ecs::prelude::SystemParam>::borrow(world, &mut state.0),
+                        entities: <ResMut<'a, Entities> as ::bones_ecs::prelude::SystemParam>::borrow(world, &mut state.1)
                     }
                 }
             }

--- a/framework_crates/bones_ecs/macros/core/src/lib.rs
+++ b/framework_crates/bones_ecs/macros/core/src/lib.rs
@@ -57,7 +57,10 @@ fn _generate_system_param_impl(input: TokenStream) -> syn::Result<TokenStream> {
         .map(|(index, field)| {
             let ident = field.ident.as_ref().unwrap();
             let ty = &field.ty;
-            let index = Index { index: index as u32, span: Span::call_site() };
+            let index = Index {
+                index: index as u32,
+                span: Span::call_site(),
+            };
             quote! {
                 #ident: <#ty as ::bones_ecs::prelude::SystemParam>::borrow(world, &mut state.#index)
             }


### PR DESCRIPTION
The change allows using the bones_ecs crate SystemParam macro (under feature flag "derive") without bones_framework dependency, which I believe is unintendedly required at the moment.