### PR TITLE
feat: Extend SVec with more methods 

### DIFF
--- a/framework_crates/bones_schema/src/alloc/vec.rs
+++ b/framework_crates/bones_schema/src/alloc/vec.rs
@@ -372,7 +372,7 @@ impl SchemaVec {
 
     /// Clears the vector, removing all values.
     pub fn clear(&mut self) {
-        while let Some(_) = self.pop_box() {}
+        while self.pop_box().is_some() {}
     }
 
     /// Shortens the vector, keeping the first `len` elements and dropping the rest.

--- a/framework_crates/bones_schema/src/alloc/vec.rs
+++ b/framework_crates/bones_schema/src/alloc/vec.rs
@@ -715,7 +715,7 @@ impl<T: HasSchema> Iterator for SVecIntoIter<T> {
 impl<T: HasSchema> Drop for SVecIntoIter<T> {
     fn drop(&mut self) {
         // Ensure all remaining elements are properly dropped
-        while let Some(_) = self.next() {}
+        for _ in self.by_ref() {}
     }
 }
 

--- a/framework_crates/bones_schema/src/alloc/vec.rs
+++ b/framework_crates/bones_schema/src/alloc/vec.rs
@@ -379,10 +379,8 @@ impl SchemaVec {
     ///
     /// If `len` is greater than the vector's current length, this has no effect.
     pub fn truncate(&mut self, len: usize) {
-        if len < self.len {
-            while self.len > len {
-                self.pop_box();
-            }
+        while self.len > len {
+            self.pop_box();
         }
     }
 }


### PR DESCRIPTION
Adds a few more methods to SVec and also supports .into() SVec <-> Vec now both ways.