### PR TITLE
feat: added "serde" feature flag for bones_ecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "glam 0.24.2",
  "once_map",
  "paste",
+ "serde",
  "thiserror",
 ]
 
@@ -6436,9 +6437,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
@@ -6454,9 +6455,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -34,7 +34,7 @@ bitset-core = "0.1"
 thiserror   = "1.0"
 glam        = { version = "0.24", optional = true }
 paste       = { version = "1.0", optional = true }
-serde       = { version = "1.0", features = ["derive"], optional = true }
+serde       = { version = "1", features = ["derive"], optional = true }
 once_map    = "0.4.12"
 
 [dev-dependencies]

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -34,7 +34,7 @@ bitset-core = "0.1"
 thiserror   = "1.0"
 glam        = { version = "0.24", optional = true }
 paste       = { version = "1.0", optional = true }
-serde       = { version = "1.0.206", features = ["derive"], optional = true }
+serde       = { version = "1.0", features = ["derive"], optional = true }
 once_map    = "0.4.12"
 
 [dev-dependencies]

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -14,6 +14,7 @@ keywords.workspace      = true
 default = ["derive", "keysize16"]
 derive  = ["dep:bones_ecs_macros"]
 glam    = ["dep:glam", "dep:paste", "bones_schema/glam"]
+serde   = ["dep:serde"]
 
 keysize16 = []
 keysize20 = []
@@ -33,6 +34,7 @@ bitset-core = "0.1"
 thiserror   = "1.0"
 glam        = { version = "0.24", optional = true }
 paste       = { version = "1.0", optional = true }
+serde       = { version = "1.0.206", features = ["derive"], optional = true }
 once_map    = "0.4.12"
 
 [dev-dependencies]

--- a/framework_crates/bones_ecs/src/bitset.rs
+++ b/framework_crates/bones_ecs/src/bitset.rs
@@ -43,6 +43,7 @@ pub(crate) const BITSET_SLICE_COUNT: usize = BITSET_SIZE / (32 * 8 / 8);
 
 /// The type of bitsets used to track entities in component storages.
 /// Mostly used to create caches.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Deref, DerefMut, Clone, Debug)]
 pub struct BitSetVec(pub Vec<[u32; 8]>);
 

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -55,6 +55,7 @@ impl Default for Entity {
 ///
 /// It also holds a list of entities that were recently killed, which allows to remove components of
 /// deleted entities at the end of a game frame.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, HasSchema)]
 pub struct Entities {
     /// Bitset containing all living entities


### PR DESCRIPTION
There were existing of `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]` lines already (f.e. on Entity struct), but serde feature flag itself was missing from bones_ecs.

Also added `cfg_attr(feature = "serde") ...` line to Entities and BitSetVec so Entities struct can be serialized.