### PR TITLE
feat: Adding rumble support

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/input.rs
+++ b/framework_crates/bones_bevy_renderer/src/input.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 use bevy::input::{
     gamepad::GamepadEvent,
     keyboard::KeyboardInput,

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -23,6 +23,8 @@ mod render;
 use render::*;
 mod ui;
 use ui::*;
+mod rumble;
+use rumble::*;
 
 use bevy::prelude::*;
 use bones_framework::prelude as bones;
@@ -222,6 +224,13 @@ impl BonesBevyRenderer {
                 .after(bevy_egui::EguiSet::ProcessInput)
                 .before(bevy_egui::EguiSet::BeginFrame),
         );
+        // Insert rumble resource and add system
+        app.init_resource::<GamepadRumbleRequests>();
+        app.add_systems(
+            Update,
+            handle_bones_rumble.run_if(assets_are_loaded.or_else(move || !self.preload)),
+        );
+
         if self.preload {
             app.add_systems(Update, asset_load_status.run_if(assets_not_loaded));
         }

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -25,7 +25,7 @@ mod ui;
 use ui::*;
 mod rumble;
 use bevy::prelude::*;
-use bones::GamepadRumbleRequests;
+use bones::GamepadsRumble;
 use bones_framework::prelude as bones;
 use rumble::*;
 
@@ -195,7 +195,7 @@ impl BonesBevyRenderer {
             .insert_shared_resource(bones::EguiTextures::default());
 
         // Insert rumble resource and add system
-        self.game.init_shared_resource::<GamepadRumbleRequests>();
+        self.game.init_shared_resource::<GamepadsRumble>();
         app.add_systems(
             Update,
             handle_bones_rumble.run_if(assets_are_loaded.or_else(move || !self.preload)),

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -24,10 +24,10 @@ use render::*;
 mod ui;
 use ui::*;
 mod rumble;
-use rumble::*;
-
 use bevy::prelude::*;
+use bones::GamepadRumbleRequests;
 use bones_framework::prelude as bones;
+use rumble::*;
 
 use bevy::{
     input::InputSystem,
@@ -191,9 +191,15 @@ impl BonesBevyRenderer {
         )));
         storage.load();
         self.game.insert_shared_resource(storage);
-
         self.game
             .insert_shared_resource(bones::EguiTextures::default());
+
+        // Insert rumble resource and add system
+        self.game.init_shared_resource::<GamepadRumbleRequests>();
+        app.add_systems(
+            Update,
+            handle_bones_rumble.run_if(assets_are_loaded.or_else(move || !self.preload)),
+        );
 
         // Insert empty inputs that will be updated by the `insert_bones_input` system later.
         self.game.init_shared_resource::<bones::KeyboardInputs>();
@@ -223,12 +229,6 @@ impl BonesBevyRenderer {
                 .run_if(assets_are_loaded.or_else(move || !self.preload))
                 .after(bevy_egui::EguiSet::ProcessInput)
                 .before(bevy_egui::EguiSet::BeginFrame),
-        );
-        // Insert rumble resource and add system
-        app.init_resource::<GamepadRumbleRequests>();
-        app.add_systems(
-            Update,
-            handle_bones_rumble.run_if(assets_are_loaded.or_else(move || !self.preload)),
         );
 
         if self.preload {

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -1,0 +1,46 @@
+// framework_crates/bones_bevy_renderer/src/rumble.rs
+// use crate::bones::HasSchema;
+use bevy::input::gamepad::{
+    GamepadRumbleIntensity as BevyGamepadRumbleIntensity,
+    GamepadRumbleRequest as BevyGamepadRumbleRequest,
+};
+use bevy::prelude::*;
+use bevy::utils::Duration;
+use bones::GamepadRumbleRequest;
+use bones_framework::prelude as bones;
+
+/// Struct that wraps a list of gamepad rumble requests as a resource
+#[derive(Resource, Default, Clone)]
+pub struct GamepadRumbleRequests(pub Vec<GamepadRumbleRequest>);
+
+pub fn handle_bones_rumble(
+    mut bones_rumble_requests: ResMut<GamepadRumbleRequests>,
+    mut rumble_requests: EventWriter<BevyGamepadRumbleRequest>,
+) {
+    for request in bones_rumble_requests.0.drain(..) {
+        match request {
+            bones::GamepadRumbleRequest::Add {
+                gamepad,
+                intensity,
+                duration,
+            } => {
+                let bevy_intensity = BevyGamepadRumbleIntensity {
+                    strong_motor: intensity.strong_motor(),
+                    weak_motor: intensity.weak_motor(),
+                };
+
+                let gamepad = Gamepad::new(gamepad as usize);
+
+                rumble_requests.send(BevyGamepadRumbleRequest::Add {
+                    gamepad,
+                    intensity: bevy_intensity,
+                    duration: Duration::from_secs_f32(duration),
+                });
+            }
+            bones::GamepadRumbleRequest::Stop { gamepad } => {
+                let gamepad = Gamepad::new(gamepad as usize);
+                rumble_requests.send(BevyGamepadRumbleRequest::Stop { gamepad });
+            }
+        }
+    }
+}

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -1,3 +1,4 @@
+use crate::bones::SVec;
 use crate::BonesGame;
 use bevy::input::gamepad::{
     GamepadRumbleIntensity as BevyGamepadRumbleIntensity,
@@ -12,7 +13,7 @@ pub fn handle_bones_rumble(
     mut rumble_requests: EventWriter<BevyGamepadRumbleRequest>,
 ) {
     if let Some(mut bones_rumble_requests) = game.shared_resource_mut::<bones::GamepadsRumble>() {
-        for request in bones_rumble_requests.requests.drain(..) {
+        for request in &bones_rumble_requests.requests {
             match request {
                 bones::GamepadRumbleRequest::Trigger {
                     gamepad,
@@ -24,16 +25,16 @@ pub fn handle_bones_rumble(
                         weak_motor: intensity.weak_motor(),
                     };
 
-                    let gamepad = Gamepad::new(gamepad as usize);
+                    let gamepad = Gamepad::new(gamepad.clone() as usize);
 
                     rumble_requests.send(BevyGamepadRumbleRequest::Add {
                         gamepad,
                         intensity: bevy_intensity,
-                        duration: Duration::from_secs_f32(duration),
+                        duration: Duration::from_secs_f32(duration.clone()),
                     });
                 }
                 bones::GamepadRumbleRequest::Stop { gamepad } => {
-                    let gamepad = Gamepad::new(gamepad as usize);
+                    let gamepad = Gamepad::new(gamepad.clone() as usize);
                     rumble_requests.send(BevyGamepadRumbleRequest::Stop { gamepad });
                 }
             }

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -8,15 +8,13 @@ use bevy::utils::Duration;
 use bones_framework::prelude as bones;
 
 pub fn handle_bones_rumble(
-    mut game: ResMut<BonesGame>,
+    game: ResMut<BonesGame>,
     mut rumble_requests: EventWriter<BevyGamepadRumbleRequest>,
 ) {
-    if let Some(mut bones_rumble_requests) =
-        game.shared_resource_mut::<bones::GamepadRumbleRequests>()
-    {
-        for request in bones_rumble_requests.0.drain(..) {
+    if let Some(mut bones_rumble_requests) = game.shared_resource_mut::<bones::GamepadsRumble>() {
+        while let Some(request) = bones_rumble_requests.requests.pop() {
             match request {
-                bones::GamepadRumbleRequest::Add {
+                bones::GamepadRumbleRequest::Trigger {
                     gamepad,
                     intensity,
                     duration,

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -25,16 +25,16 @@ pub fn handle_bones_rumble(
                         weak_motor: intensity.weak_motor(),
                     };
 
-                    let gamepad = Gamepad::new(gamepad.clone() as usize);
+                    let gamepad = Gamepad::new(*gamepad as usize);
 
                     rumble_requests.send(BevyGamepadRumbleRequest::Add {
                         gamepad,
                         intensity: bevy_intensity,
-                        duration: Duration::from_secs_f32(duration.clone()),
+                        duration: Duration::from_secs_f32(*duration),
                     });
                 }
                 bones::GamepadRumbleRequest::Stop { gamepad } => {
-                    let gamepad = Gamepad::new(gamepad.clone() as usize);
+                    let gamepad = Gamepad::new(*gamepad as usize);
                     rumble_requests.send(BevyGamepadRumbleRequest::Stop { gamepad });
                 }
             }

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -1,45 +1,43 @@
-// framework_crates/bones_bevy_renderer/src/rumble.rs
-// use crate::bones::HasSchema;
+use crate::BonesGame;
 use bevy::input::gamepad::{
     GamepadRumbleIntensity as BevyGamepadRumbleIntensity,
     GamepadRumbleRequest as BevyGamepadRumbleRequest,
 };
 use bevy::prelude::*;
 use bevy::utils::Duration;
-use bones::GamepadRumbleRequest;
 use bones_framework::prelude as bones;
 
-/// Struct that wraps a list of gamepad rumble requests as a resource
-#[derive(Resource, Default, Clone)]
-pub struct GamepadRumbleRequests(pub Vec<GamepadRumbleRequest>);
-
 pub fn handle_bones_rumble(
-    mut bones_rumble_requests: ResMut<GamepadRumbleRequests>,
+    mut game: ResMut<BonesGame>,
     mut rumble_requests: EventWriter<BevyGamepadRumbleRequest>,
 ) {
-    for request in bones_rumble_requests.0.drain(..) {
-        match request {
-            bones::GamepadRumbleRequest::Add {
-                gamepad,
-                intensity,
-                duration,
-            } => {
-                let bevy_intensity = BevyGamepadRumbleIntensity {
-                    strong_motor: intensity.strong_motor(),
-                    weak_motor: intensity.weak_motor(),
-                };
-
-                let gamepad = Gamepad::new(gamepad as usize);
-
-                rumble_requests.send(BevyGamepadRumbleRequest::Add {
+    if let Some(mut bones_rumble_requests) =
+        game.shared_resource_mut::<bones::GamepadRumbleRequests>()
+    {
+        for request in bones_rumble_requests.0.drain(..) {
+            match request {
+                bones::GamepadRumbleRequest::Add {
                     gamepad,
-                    intensity: bevy_intensity,
-                    duration: Duration::from_secs_f32(duration),
-                });
-            }
-            bones::GamepadRumbleRequest::Stop { gamepad } => {
-                let gamepad = Gamepad::new(gamepad as usize);
-                rumble_requests.send(BevyGamepadRumbleRequest::Stop { gamepad });
+                    intensity,
+                    duration,
+                } => {
+                    let bevy_intensity = BevyGamepadRumbleIntensity {
+                        strong_motor: intensity.strong_motor(),
+                        weak_motor: intensity.weak_motor(),
+                    };
+
+                    let gamepad = Gamepad::new(gamepad as usize);
+
+                    rumble_requests.send(BevyGamepadRumbleRequest::Add {
+                        gamepad,
+                        intensity: bevy_intensity,
+                        duration: Duration::from_secs_f32(duration),
+                    });
+                }
+                bones::GamepadRumbleRequest::Stop { gamepad } => {
+                    let gamepad = Gamepad::new(gamepad as usize);
+                    rumble_requests.send(BevyGamepadRumbleRequest::Stop { gamepad });
+                }
             }
         }
     }

--- a/framework_crates/bones_bevy_renderer/src/rumble.rs
+++ b/framework_crates/bones_bevy_renderer/src/rumble.rs
@@ -12,7 +12,7 @@ pub fn handle_bones_rumble(
     mut rumble_requests: EventWriter<BevyGamepadRumbleRequest>,
 ) {
     if let Some(mut bones_rumble_requests) = game.shared_resource_mut::<bones::GamepadsRumble>() {
-        while let Some(request) = bones_rumble_requests.requests.pop() {
+        for request in bones_rumble_requests.requests.drain(..) {
             match request {
                 bones::GamepadRumbleRequest::Trigger {
                     gamepad,
@@ -38,5 +38,6 @@ pub fn handle_bones_rumble(
                 }
             }
         }
+        bones_rumble_requests.requests = SVec::new();
     }
 }

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -318,7 +318,7 @@ impl GamepadsRumble {
     pub fn trigger_all(&mut self, intensity: GamepadRumbleIntensity, duration: f32) {
         for gamepad in 0..self.enabled_gamepads.len() {
             if self.is_enabled(gamepad as u32) {
-                self.trigger(gamepad as u32, intensity.clone(), duration);
+                self.trigger(gamepad as u32, intensity, duration);
             }
         }
     }
@@ -337,7 +337,6 @@ impl GamepadsRumble {
         self.enabled_gamepads
             .get(gamepad as usize)
             .unwrap_or(&false)
-            .clone()
     }
 
     /// Checks if a specific gamepad is disabled for rumble (no rumble trigger requests will work).

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -261,7 +261,6 @@ impl GamepadRumbleIntensity {
         self.weak_motor = value.clamp(0.0, 1.0);
     }
 }
-
 /// Represents a request to either add or stop rumble on a specific gamepad
 #[derive(HasSchema, Clone, Debug)]
 pub enum GamepadRumbleRequest {
@@ -290,3 +289,35 @@ impl Default for GamepadRumbleRequest {
 /// Resource that holds the list of gamepad rumble requests to be processed
 #[derive(HasSchema, Default, Clone)]
 pub struct GamepadRumbleRequests(pub Vec<GamepadRumbleRequest>);
+
+impl GamepadRumbleRequests {
+    /// Adds rumble to a specific gamepad.
+    pub fn add(&mut self, gamepad: u32, intensity: GamepadRumbleIntensity, duration: f32) {
+        self.0.push(GamepadRumbleRequest::Add {
+            gamepad,
+            intensity,
+            duration,
+        });
+    }
+
+    /// Stops rumble on a specific gamepad.
+    pub fn stop(&mut self, gamepad: u32) {
+        self.0.push(GamepadRumbleRequest::Stop { gamepad });
+    }
+
+    /// Adds rumble to all gamepads (0-3).
+    pub fn add_all(&mut self, intensity: GamepadRumbleIntensity, duration: f32) {
+        self.0
+            .extend((0..4).map(|gamepad| GamepadRumbleRequest::Add {
+                gamepad,
+                intensity: intensity.clone(),
+                duration,
+            }));
+    }
+
+    /// Stops rumble on all gamepads (0-3).
+    pub fn stop_all(&mut self) {
+        self.0
+            .extend((0..4).map(|gamepad| GamepadRumbleRequest::Stop { gamepad }));
+    }
+}

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -334,10 +334,12 @@ impl GamepadsRumble {
 
     /// Checks if a specific gamepad is enabled for rumble.
     pub fn is_enabled(&self, gamepad: u32) -> bool {
-        self.enabled_gamepads
-            .get(gamepad as usize)
-            .unwrap_or(&false)
-            .clone()
+        let gamepad_index = gamepad as usize;
+        if gamepad_index < self.enabled_gamepads.len() {
+            self.enabled_gamepads[gamepad_index]
+        } else {
+            false
+        }
     }
 
     /// Checks if a specific gamepad is disabled for rumble (no rumble trigger requests will work).

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -337,6 +337,7 @@ impl GamepadsRumble {
         self.enabled_gamepads
             .get(gamepad as usize)
             .unwrap_or(&false)
+            .clone()
     }
 
     /// Checks if a specific gamepad is disabled for rumble (no rumble trigger requests will work).

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -175,54 +175,67 @@ pub struct GamepadRumbleIntensity {
 }
 
 impl GamepadRumbleIntensity {
+    /// Represents no rumble intensity.
     pub const ZERO: Self = Self {
         strong_motor: 0.0,
         weak_motor: 0.0,
     };
+    /// Represents maximum rumble intensity for both motors.
     pub const MAX_BOTH: Self = Self {
         strong_motor: 1.0,
         weak_motor: 1.0,
     };
+    /// Represents maximum rumble intensity for the strong motor only.
     pub const MAX_STRONG: Self = Self {
         strong_motor: 1.0,
         weak_motor: 0.0,
     };
+    /// Represents maximum rumble intensity for the weak motor only.
     pub const MAX_WEAK: Self = Self {
         strong_motor: 0.0,
         weak_motor: 1.0,
     };
+    /// Represents medium rumble intensity for both motors.
     pub const MEDIUM_BOTH: Self = Self {
         strong_motor: 0.5,
         weak_motor: 0.5,
     };
+    /// Represents medium rumble intensity for the strong motor only.
     pub const MEDIUM_STRONG: Self = Self {
         strong_motor: 0.5,
         weak_motor: 0.0,
     };
+    /// Represents medium rumble intensity for the weak motor only.
     pub const MEDIUM_WEAK: Self = Self {
         strong_motor: 0.0,
         weak_motor: 0.5,
     };
+    /// Represents light rumble intensity for both motors.
     pub const LIGHT_BOTH: Self = Self {
         strong_motor: 0.25,
         weak_motor: 0.25,
     };
+    /// Represents light rumble intensity for the strong motor only.
     pub const LIGHT_STRONG: Self = Self {
         strong_motor: 0.25,
         weak_motor: 0.0,
     };
+    /// Represents light rumble intensity for the weak motor only.
     pub const LIGHT_WEAK: Self = Self {
         strong_motor: 0.0,
         weak_motor: 0.25,
     };
+    /// Represents very light rumble intensity for both motors.
     pub const VERY_LIGHT_BOTH: Self = Self {
         strong_motor: 0.1,
         weak_motor: 0.1,
     };
+    /// Represents very light rumble intensity for the strong motor only.
     pub const VERY_LIGHT_STRONG: Self = Self {
         strong_motor: 0.1,
         weak_motor: 0.0,
     };
+    /// Represents very light rumble intensity for the weak motor only.
     pub const VERY_LIGHT_WEAK: Self = Self {
         strong_motor: 0.0,
         weak_motor: 0.1,
@@ -274,6 +287,6 @@ impl Default for GamepadRumbleRequest {
     }
 }
 
-/// Struct that wraps a list of gamepad rumble requests as a resource
+/// Resource that holds the list of gamepad rumble requests to be processed
 #[derive(HasSchema, Default, Clone)]
 pub struct GamepadRumbleRequests(pub Vec<GamepadRumbleRequest>);

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -273,3 +273,7 @@ impl Default for GamepadRumbleRequest {
         GamepadRumbleRequest::Stop { gamepad: 0 }
     }
 }
+
+/// Struct that wraps a list of gamepad rumble requests as a resource
+#[derive(HasSchema, Default, Clone)]
+pub struct GamepadRumbleRequests(pub Vec<GamepadRumbleRequest>);

--- a/framework_crates/bones_framework/src/input/gamepad.rs
+++ b/framework_crates/bones_framework/src/input/gamepad.rs
@@ -1,5 +1,4 @@
 //! Gamepad input resource.
-
 use crate::prelude::*;
 
 /// Resource containing the gamepad input events detected this frame.
@@ -163,5 +162,114 @@ impl std::fmt::Display for GamepadAxis {
                 GamepadAxis::Other(n) => return write!(f, "Axis {n}"),
             }
         )
+    }
+}
+
+/// Struct that represents intensity of a rumble
+#[derive(HasSchema, Default, Clone, Debug, Copy)]
+pub struct GamepadRumbleIntensity {
+    /// The intensity of the strong motor, between 0.0 - 1.0.
+    strong_motor: f32,
+    /// The intensity of the weak motor, between 0.0 - 1.0.
+    weak_motor: f32,
+}
+
+impl GamepadRumbleIntensity {
+    pub const ZERO: Self = Self {
+        strong_motor: 0.0,
+        weak_motor: 0.0,
+    };
+    pub const MAX_BOTH: Self = Self {
+        strong_motor: 1.0,
+        weak_motor: 1.0,
+    };
+    pub const MAX_STRONG: Self = Self {
+        strong_motor: 1.0,
+        weak_motor: 0.0,
+    };
+    pub const MAX_WEAK: Self = Self {
+        strong_motor: 0.0,
+        weak_motor: 1.0,
+    };
+    pub const MEDIUM_BOTH: Self = Self {
+        strong_motor: 0.5,
+        weak_motor: 0.5,
+    };
+    pub const MEDIUM_STRONG: Self = Self {
+        strong_motor: 0.5,
+        weak_motor: 0.0,
+    };
+    pub const MEDIUM_WEAK: Self = Self {
+        strong_motor: 0.0,
+        weak_motor: 0.5,
+    };
+    pub const LIGHT_BOTH: Self = Self {
+        strong_motor: 0.25,
+        weak_motor: 0.25,
+    };
+    pub const LIGHT_STRONG: Self = Self {
+        strong_motor: 0.25,
+        weak_motor: 0.0,
+    };
+    pub const LIGHT_WEAK: Self = Self {
+        strong_motor: 0.0,
+        weak_motor: 0.25,
+    };
+    pub const VERY_LIGHT_BOTH: Self = Self {
+        strong_motor: 0.1,
+        weak_motor: 0.1,
+    };
+    pub const VERY_LIGHT_STRONG: Self = Self {
+        strong_motor: 0.1,
+        weak_motor: 0.0,
+    };
+    pub const VERY_LIGHT_WEAK: Self = Self {
+        strong_motor: 0.0,
+        weak_motor: 0.1,
+    };
+
+    /// Get the intensity of the strong motor.
+    pub fn strong_motor(&self) -> f32 {
+        self.strong_motor
+    }
+
+    /// Set the intensity of the strong motor, clamping it between 0.0 and 1.0.
+    pub fn set_strong_motor(&mut self, value: f32) {
+        self.strong_motor = value.clamp(0.0, 1.0);
+    }
+
+    /// Get the intensity of the weak motor.
+    pub fn weak_motor(&self) -> f32 {
+        self.weak_motor
+    }
+
+    /// Set the intensity of the weak motor, clamping it between 0.0 and 1.0.
+    pub fn set_weak_motor(&mut self, value: f32) {
+        self.weak_motor = value.clamp(0.0, 1.0);
+    }
+}
+
+/// Represents a request to either add or stop rumble on a specific gamepad
+#[derive(HasSchema, Clone, Debug)]
+pub enum GamepadRumbleRequest {
+    /// Request to add rumble to a gamepad.
+    Add {
+        /// The ID of the gamepad to rumble.
+        gamepad: u32,
+        /// The intensity of the rumble.
+        intensity: GamepadRumbleIntensity,
+        /// The duration of the rumble in seconds.
+        duration: f32,
+    },
+    /// Request to stop rumble on a gamepad.
+    Stop {
+        /// The ID of the gamepad to stop rumbling.
+        gamepad: u32,
+    },
+}
+
+impl Default for GamepadRumbleRequest {
+    fn default() -> Self {
+        GamepadRumbleRequest::Stop { gamepad: 0 }
     }
 }


### PR DESCRIPTION
Added support for gamepad rumble into bones. Changed the interface compared to bevy's implementation with:
- Imo more straightforward naming/hiding abstractions like "requests"
- implementing an enable/disable layer which makes it easier for games to fully turn off rumble for a given gamepad without having to include `if` statements across their entire code (ie. during startup game can read from settings that gamepad X has rumble disabled, just call .disable(), and write code that always tries to use rumble without extra boilerplate).