### PR TITLE
fix: fix undefined behavior in `SVec::pop()`.

### DIFF
--- a/framework_crates/bones_schema/src/alloc/resizable.rs
+++ b/framework_crates/bones_schema/src/alloc/resizable.rs
@@ -13,6 +13,7 @@ use super::layout::*;
 /// it has room for.
 ///
 /// Dropping a [`ResizableAlloc`] will de-allocate it's memory.
+#[derive(Debug)]
 pub struct ResizableAlloc {
     /// The pointer to the allocation. May be dangling for a capacity of zero or for a zero-sized
     /// layout.

--- a/framework_crates/bones_schema/src/alloc/vec.rs
+++ b/framework_crates/bones_schema/src/alloc/vec.rs
@@ -543,8 +543,7 @@ impl<T: HasSchema> SVec<T> {
         unsafe {
             self.vec.raw_pop().map(|ptr| {
                 let mut ret = MaybeUninit::<T>::uninit();
-                ret.as_mut_ptr()
-                    .copy_from_nonoverlapping(ptr as *mut T, self.vec.schema.layout().size());
+                ret.as_mut_ptr().copy_from_nonoverlapping(ptr as *mut T, 1);
                 ret.assume_init()
             })
         }
@@ -1041,5 +1040,12 @@ mod test {
         let svec: SVec<i32> = original_vec.clone().into();
         let vec_from_svec: Vec<i32> = svec.into();
         assert_eq!(original_vec, vec_from_svec);
+    }
+
+    #[test]
+    fn miri_error_001() {
+        let mut vec: SVec<i32> = SVec::new();
+        vec.push(10);
+        vec.pop();
     }
 }


### PR DESCRIPTION
Fixes a mistake regarding the behavior of `copy_from_nonoverlapping()`. When copying from a typed pointer, we provide the number items to copy, not the number of bytes.