### PR TITLE
fix!: `bones_framework` not compiling with --no-default-features + net debug window behind feature flag `net-debug` (BREAKING)

### DIFF
--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -25,6 +25,9 @@ audio = ["dep:kira"]
 ## Enable the scripting system.
 scripting = ["dep:bones_scripting"]
 
+## Enable networking debug window + frame prediction history.
+net-debug = ["ui"]
+
 #! ### Audio formats
 #! These features enable different audio formats
 

--- a/framework_crates/bones_framework/src/debug.rs
+++ b/framework_crates/bones_framework/src/debug.rs
@@ -1,4 +1,4 @@
-//! Implements bones egui debug windows and tools.
+//! Implements bones egui debug windows and tools. Requires 'ui' feature flag.
 
 use crate::prelude::*;
 

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -85,7 +85,9 @@ impl lib::SessionPlugin for DefaultSessionPlugin {
 /// Default plugins for bones framework games.
 pub struct DefaultGamePlugin;
 impl lib::GamePlugin for DefaultGamePlugin {
+    #[allow(unused_variables)]
     fn install(self, game: &mut lib::Game) {
+        #[cfg(feature = "audio")]
         game.install_plugin(render::audio::game_plugin);
 
         #[cfg(feature = "scripting")]

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -20,9 +20,12 @@ pub use glam;
 /// The prelude.
 pub mod prelude {
     pub use crate::{
-        animation::*, debug, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
+        animation::*, input::prelude::*, params::*, render::prelude::*, storage::*, time::*,
         utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin, ExitBones,
     };
+
+    #[cfg(feature = "ui")]
+    pub use crate::debug;
 
     #[cfg(not(target_arch = "wasm32"))]
     pub use crate::networking::prelude::*;
@@ -42,13 +45,15 @@ pub mod prelude {
 }
 
 pub mod animation;
-pub mod debug;
 pub mod input;
 pub mod params;
 pub mod render;
 pub mod storage;
 pub mod time;
 pub mod utils;
+
+#[cfg(feature = "ui")]
+pub mod debug;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod networking;

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -3,8 +3,7 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use bones_matchmaker_proto::{MATCH_ALPN, PLAY_ALPN};
-use debug::PlayerSyncState;
-use ggrs::{NetworkStats, P2PSession, PlayerHandle};
+use ggrs::P2PSession;
 use instant::Duration;
 use once_cell::sync::Lazy;
 use tracing::{debug, error, info, trace, warn};
@@ -12,18 +11,26 @@ use tracing::{debug, error, info, trace, warn};
 use crate::prelude::*;
 
 use self::{
-    debug::{NetworkDebugMessage, NETWORK_DEBUG_CHANNEL},
     input::{DenseInput, NetworkInputConfig, NetworkPlayerControl, NetworkPlayerControls},
     socket::Socket,
 };
+
+#[cfg(feature = "net-debug")]
+use {
+    self::debug::{NetworkDebugMessage, PlayerSyncState, NETWORK_DEBUG_CHANNEL},
+    ggrs::{NetworkStats, PlayerHandle},
+};
+
 use crate::input::PlayerControls as PlayerControlsTrait;
 
-pub mod debug;
 pub mod input;
 pub mod lan;
 pub mod online;
 pub mod proto;
 pub mod socket;
+
+#[cfg(feature = "net-debug")]
+pub mod debug;
 
 /// Runtime, needed to execute network related calls.
 pub static RUNTIME: Lazy<tokio::runtime::Runtime> =
@@ -52,9 +59,10 @@ impl From<ggrs::InputStatus> for NetworkInputStatus {
 
 /// Module prelude.
 pub mod prelude {
-    pub use super::{
-        debug::prelude::*, input, lan, online, proto, DisconnectedPlayers, NetworkInfo, RUNTIME,
-    };
+    pub use super::{input, lan, online, proto, DisconnectedPlayers, NetworkInfo, RUNTIME};
+
+    #[cfg(feature = "net-debug")]
+    pub use super::debug::prelude::*;
 }
 
 /// Muliplier for framerate that will be used when playing an online match.
@@ -312,6 +320,7 @@ where
             .unwrap_or(NETWORK_LOCAL_INPUT_DELAY_DEFAULT);
 
         // Notify debugger of setting
+        #[cfg(feature = "net-debug")]
         NETWORK_DEBUG_CHANNEL
             .sender
             .try_send(NetworkDebugMessage::SetMaxPrediction(max_prediction))
@@ -404,13 +413,16 @@ where
             };
         }
 
-        let current_frame_original = self.session.current_frame();
+        #[cfg(feature = "net-debug")]
         // Current frame before we start network update loop
-        // let current_frame_original = self.session.current_frame();
+        let current_frame_original = self.session.current_frame();
+
         for event in self.session.events() {
             match event {
                 ggrs::GgrsEvent::Synchronizing { addr, total, count } => {
                     info!(player=%addr, %total, progress=%count, "Syncing network player");
+
+                    #[cfg(feature = "net-debug")]
                     NETWORK_DEBUG_CHANNEL
                         .sender
                         .try_send(NetworkDebugMessage::PlayerSync((
@@ -421,6 +433,8 @@ where
                 }
                 ggrs::GgrsEvent::Synchronized { addr } => {
                     info!(player=%addr, "Syncrhonized network client");
+
+                    #[cfg(feature = "net-debug")]
                     NETWORK_DEBUG_CHANNEL
                         .sender
                         .try_send(NetworkDebugMessage::PlayerSync((
@@ -432,6 +446,8 @@ where
                 ggrs::GgrsEvent::Disconnected { addr } => {
                     warn!(player=%addr, "Player Disconnected");
                     self.disconnected_players.push(addr);
+
+                    #[cfg(feature = "net-debug")]
                     NETWORK_DEBUG_CHANNEL
                         .sender
                         .try_send(NetworkDebugMessage::DisconnectedPlayers(
@@ -453,6 +469,7 @@ where
                     );
                     skip_frames = skip_count;
 
+                    #[cfg(feature = "net-debug")]
                     NETWORK_DEBUG_CHANNEL
                         .sender
                         .try_send(NetworkDebugMessage::SkipFrame {
@@ -491,15 +508,19 @@ where
                         .unwrap();
                 }
 
-                let current_frame = self.session.current_frame();
-                let confirmed_frame = self.session.confirmed_frame();
-                NETWORK_DEBUG_CHANNEL
-                    .sender
-                    .try_send(NetworkDebugMessage::FrameUpdate {
-                        current: current_frame,
-                        last_confirmed: confirmed_frame,
-                    })
-                    .unwrap();
+                #[cfg(feature = "net-debug")]
+                {
+                    let current_frame = self.session.current_frame();
+                    let confirmed_frame = self.session.confirmed_frame();
+
+                    NETWORK_DEBUG_CHANNEL
+                        .sender
+                        .try_send(NetworkDebugMessage::FrameUpdate {
+                            current: current_frame,
+                            last_confirmed: confirmed_frame,
+                        })
+                        .unwrap();
+                }
 
                 if skip_frames > 0 {
                     skip_frames = skip_frames.saturating_sub(1);
@@ -588,6 +609,8 @@ where
                         }
                         ggrs::GgrsError::PredictionThreshold => {
                             warn!("Freezing game while waiting for network to catch-up.");
+
+                            #[cfg(feature = "net-debug")]
                             NETWORK_DEBUG_CHANNEL
                                 .sender
                                 .try_send(NetworkDebugMessage::FrameFroze {
@@ -606,17 +629,20 @@ where
         self.last_run = Some(frame_start);
 
         // Fetch GGRS network stats of remote players and send to net debug tool
-        let mut network_stats: Vec<(PlayerHandle, NetworkStats)> = vec![];
-        for handle in self.session.remote_player_handles().iter() {
-            if let Ok(stats) = self.session.network_stats(*handle) {
-                network_stats.push((*handle, stats));
+        #[cfg(feature = "net-debug")]
+        {
+            let mut network_stats: Vec<(PlayerHandle, NetworkStats)> = vec![];
+            for handle in self.session.remote_player_handles().iter() {
+                if let Ok(stats) = self.session.network_stats(*handle) {
+                    network_stats.push((*handle, stats));
+                }
             }
-        }
-        if !network_stats.is_empty() {
-            NETWORK_DEBUG_CHANNEL
-                .sender
-                .try_send(NetworkDebugMessage::NetworkStats { network_stats })
-                .unwrap();
+            if !network_stats.is_empty() {
+                NETWORK_DEBUG_CHANNEL
+                    .sender
+                    .try_send(NetworkDebugMessage::NetworkStats { network_stats })
+                    .unwrap();
+            }
         }
     }
 

--- a/framework_crates/bones_framework/src/networking/debug.rs
+++ b/framework_crates/bones_framework/src/networking/debug.rs
@@ -5,6 +5,8 @@
 //! - Displays last frame with skips and how many frames were skipped.
 //!
 //! To display window, use `egui_ctx.set_state::<NetworkDebugMenuState>();` ( after setting open = true ).
+//!
+//! `net-debug` feature flag is required.
 #![allow(missing_docs)]
 
 use async_channel::{Receiver, Sender};

--- a/framework_crates/bones_framework/src/render.rs
+++ b/framework_crates/bones_framework/src/render.rs
@@ -30,6 +30,8 @@ pub mod ui;
 pub fn render_plugin(session: &mut Session) {
     session
         .install_plugin(sprite::sprite_plugin)
-        .install_plugin(ui::ui_plugin)
         .install_plugin(camera::plugin);
+
+    #[cfg(feature = "ui")]
+    session.install_plugin(ui::ui_plugin);
 }


### PR DESCRIPTION
Locked some debug window that uses egui behind ui flag, fixed missing audio/ui cfg blocks in a few places.

The network debug system is now behind `net-debug`. This way it is not compiled if undesired, as it depends on 'ui' and is only useful if displayed in egui. Also probably something we will want to disable in release builds in the future.

Fixes #442 