### PR TITLE
fix: re-enable msaa for pixel art mode

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -148,7 +148,7 @@ impl BonesBevyRenderer {
             .build();
         if self.pixel_art {
             plugins = plugins.set(ImagePlugin::default_nearest());
-            app.insert_resource(Msaa::Off);
+            // app.insert_resource(Msaa::Off);
         }
 
         app.add_plugins(plugins).add_plugins((


### PR DESCRIPTION
Tried turning it off to reduce some artifacts but I think this it is worse without it, maybe some other AA would work better, but not going to worry about this for now.