### PR TITLE
feat: Integrating AudioCenter into bones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,12 +393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-arena"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3207,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
 dependencies = [
  "mint",
 ]
@@ -4169,17 +4163,18 @@ dependencies = [
 
 [[package]]
 name = "kira"
-version = "0.8.7"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8968f1eda49cdf4f6406fd5ffe590c3ca2778a1b0e50b5684974b138a99dfb2f"
+checksum = "5c48d4719537e9af8467214f42c76425afbde24fb33e8d06686ab764e2a98e0b"
 dependencies = [
- "atomic-arena",
  "cpal",
- "glam 0.25.0",
+ "glam 0.28.0",
  "mint",
+ "paste",
  "ringbuf",
  "send_wrapper",
  "symphonia",
+ "triple_buffer",
 ]
 
 [[package]]
@@ -7437,6 +7432,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e66931c8eca6381f0d34656a9341f09bd462010488c1a3bc0acd3f2d08dffce"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -102,7 +102,7 @@ egui_plot  = "0.23"
 ttf-parser = { version = "0.24", default-features = false, optional = true }
 
 # Audio
-kira = { version = "0.8.6", features = ["cpal"], default-features = false, optional = true }
+kira = { version = "0.9.4", features = ["cpal"], default-features = false, optional = true }
 
 # Localization
 fluent         = { version = "0.15", optional = true }

--- a/framework_crates/bones_framework/src/audio.rs
+++ b/framework_crates/bones_framework/src/audio.rs
@@ -1,0 +1,44 @@
+//! Audio session, systems, and resources.
+
+pub mod audio_center;
+pub mod audio_manager;
+
+use crate::prelude::*;
+pub use audio_center::*;
+pub use audio_manager::*;
+use kira::sound::static_sound::StaticSoundHandle;
+use std::time::Duration;
+
+/// The amount of time to spend fading the music in and out.
+pub const MUSIC_FADE_DURATION: Duration = Duration::from_millis(500);
+/// Name of the default bones audio session
+pub const DEFAULT_BONES_AUDIO_SESSION: &str = "BONES_AUDIO";
+
+/// Sets up audio-related resources and the default bones audio session
+pub fn game_plugin(game: &mut Game) {
+    AudioSource::register_schema();
+    game.init_shared_resource::<AudioCenter>();
+    game.insert_shared_resource(AudioManager::default());
+    game.init_shared_resource::<AssetServer>();
+
+    let session = game.sessions.create(DEFAULT_BONES_AUDIO_SESSION);
+    // Audio doesn't do any rendering
+    session.visible = false;
+    session
+        .stages
+        .add_system_to_stage(First, _process_audio_events)
+        .add_system_to_stage(Last, _kill_finished_audios);
+}
+
+/// Holds the handles and the volume to be played for a piece of Audio.
+#[derive(HasSchema)]
+#[schema(no_clone, no_default, opaque)]
+#[repr(C)]
+pub struct Audio {
+    /// The handle for the audio.
+    handle: StaticSoundHandle,
+    /// The original volume requested for the audio.
+    volume: f64,
+    /// The bones handle for the audio source.
+    bones_handle: Handle<AudioSource>,
+}

--- a/framework_crates/bones_framework/src/audio.rs
+++ b/framework_crates/bones_framework/src/audio.rs
@@ -6,11 +6,10 @@ pub mod audio_manager;
 use crate::prelude::*;
 pub use audio_center::*;
 pub use audio_manager::*;
+pub use kira;
+pub use kira::sound::static_sound::StaticSoundData;
 use kira::sound::static_sound::StaticSoundHandle;
-use std::time::Duration;
 
-/// The amount of time to spend fading the music in and out.
-pub const MUSIC_FADE_DURATION: Duration = Duration::from_millis(500);
 /// Name of the default bones audio session
 pub const DEFAULT_BONES_AUDIO_SESSION: &str = "BONES_AUDIO";
 

--- a/framework_crates/bones_framework/src/audio/audio_manager.rs
+++ b/framework_crates/bones_framework/src/audio/audio_manager.rs
@@ -1,0 +1,97 @@
+//! Audio Manager resource and systems.
+
+use std::io::Cursor;
+use crate::prelude::*;
+use kira;
+use kira::{
+    manager::{
+        backend::{cpal::CpalBackend, mock::MockBackend, Backend},
+        AudioManager as KiraAudioManager,
+    },
+    sound::{
+        static_sound::StaticSoundData,
+       SoundData,
+    },
+};
+
+
+
+/// The audio manager resource which can be used to play sounds.
+#[derive(HasSchema, Deref, DerefMut)]
+#[schema(no_clone)]
+pub struct AudioManager(KiraAudioManager<CpalWithFallbackBackend>);
+
+impl Default for AudioManager {
+    fn default() -> Self {
+        Self(KiraAudioManager::<CpalWithFallbackBackend>::new(default()).unwrap())
+    }
+}
+
+/// Kira audio backend that will fall back to a dummy backend if setting up the Cpal backend
+/// fails with an error.
+#[allow(clippy::large_enum_variant)]
+pub enum CpalWithFallbackBackend {
+    /// This is a working Cpal backend.
+    Cpal(CpalBackend),
+    /// This is a dummy backend since Cpal didn't work.
+    Dummy(MockBackend),
+}
+
+impl Backend for CpalWithFallbackBackend {
+    type Settings = <CpalBackend as Backend>::Settings;
+    type Error = <CpalBackend as Backend>::Error;
+
+    fn setup(settings: Self::Settings) -> Result<(Self, u32), Self::Error> {
+        match CpalBackend::setup(settings) {
+            Ok((back, bit)) => Ok((Self::Cpal(back), bit)),
+            Err(e) => {
+                tracing::error!("Error starting audio backend, using dummy backend instead: {e}");
+                Ok(MockBackend::setup(default())
+                    .map(|(back, bit)| (Self::Dummy(back), bit))
+                    .unwrap())
+            }
+        }
+    }
+
+    fn start(&mut self, renderer: kira::manager::backend::Renderer) -> Result<(), Self::Error> {
+        match self {
+            CpalWithFallbackBackend::Cpal(cpal) => cpal.start(renderer),
+            CpalWithFallbackBackend::Dummy(dummy) => {
+                dummy.start(renderer).unwrap();
+                Ok(())
+            }
+        }
+    }
+}
+
+/// The audio source asset type, contains no data, but [`Handle<AudioSource>`] is still useful
+/// because it uniquely represents a sound/music that may be played outside of bones.
+#[derive(Clone, HasSchema, Debug, Deref, DerefMut)]
+#[schema(no_default)]
+#[type_data(asset_loader(["ogg", "mp3", "flac", "wav"], AudioLoader))]
+pub struct AudioSource(pub StaticSoundData);
+
+impl SoundData for &AudioSource {
+    type Error = <StaticSoundData as SoundData>::Error;
+    type Handle = <StaticSoundData as SoundData>::Handle;
+
+    fn into_sound(self) -> Result<(Box<dyn kira::sound::Sound>, Self::Handle), Self::Error> {
+        self.0.clone().into_sound()
+    }
+}
+
+/// The audio file asset loader.
+pub struct AudioLoader;
+impl AssetLoader for AudioLoader {
+    fn load(
+        &self,
+        _ctx: AssetLoadCtx,
+        bytes: &[u8],
+    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+        let bytes = bytes.to_vec();
+        Box::pin(async move {
+            let data = StaticSoundData::from_cursor(Cursor::new(bytes))?;
+            Ok(SchemaBox::new(AudioSource(data)))
+        })
+    }
+}

--- a/framework_crates/bones_framework/src/audio/audio_manager.rs
+++ b/framework_crates/bones_framework/src/audio/audio_manager.rs
@@ -1,6 +1,5 @@
 //! Audio Manager resource and systems.
 
-use std::io::Cursor;
 use crate::prelude::*;
 use kira;
 use kira::{
@@ -8,13 +7,9 @@ use kira::{
         backend::{cpal::CpalBackend, mock::MockBackend, Backend},
         AudioManager as KiraAudioManager,
     },
-    sound::{
-        static_sound::StaticSoundData,
-       SoundData,
-    },
+    sound::{static_sound::StaticSoundData, SoundData},
 };
-
-
+use std::io::Cursor;
 
 /// The audio manager resource which can be used to play sounds.
 #[derive(HasSchema, Deref, DerefMut)]

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -52,6 +52,9 @@ pub mod storage;
 pub mod time;
 pub mod utils;
 
+#[cfg(feature = "audio")]
+pub mod audio;
+
 #[cfg(feature = "ui")]
 pub mod debug;
 
@@ -93,7 +96,7 @@ impl lib::GamePlugin for DefaultGamePlugin {
     #[allow(unused_variables)]
     fn install(self, game: &mut lib::Game) {
         #[cfg(feature = "audio")]
-        game.install_plugin(render::audio::game_plugin);
+        game.install_plugin(audio::game_plugin);
 
         #[cfg(feature = "scripting")]
         game.install_plugin(bones_scripting::ScriptingGamePlugin::default());

--- a/framework_crates/bones_framework/src/render.rs
+++ b/framework_crates/bones_framework/src/render.rs
@@ -7,14 +7,11 @@ pub mod prelude {
     pub use super::{camera::*, color::*, line::*, sprite::*, tilemap::*, transform::*};
 
     #[cfg(feature = "audio")]
-    pub use super::audio::*;
+    pub use super::super::audio::*;
 
     #[cfg(feature = "ui")]
     pub use super::ui::{widgets::*, *};
 }
-
-#[cfg(feature = "audio")]
-pub mod audio;
 
 pub mod camera;
 pub mod color;

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -1,9 +1,11 @@
 //! Audio components.
+//! 
 
+use std::collections::VecDeque;
+use kira::sound::PlaybackState;
 use std::io::Cursor;
-
+use tracing::warn;
 use crate::prelude::*;
-
 pub use kira::{self, sound::static_sound::StaticSoundData};
 use kira::{
     manager::{
@@ -11,13 +13,251 @@ use kira::{
         AudioManager as KiraAudioManager,
     },
     sound::SoundData,
+    tween::Tween,
+    sound::static_sound::{StaticSoundHandle, StaticSoundSettings},
 };
+use kira::{Volume, tween};
+use std::time::Duration;
 
-/// The game plugin for the audio system.
+/// The amount of time to spend fading the music in and out.
+pub const MUSIC_FADE_DURATION: Duration = Duration::from_millis(500);
+/// Default music volume
+pub const DEFAULT_MUSIC_VOLUME: f64 = 0.1;
+/// Name of the default bones audio session
+pub const DEFAULT_BONES_AUDIO_SESSION: &'static str  = "BONES_AUDIO";
+
+/// Sets up audio-related resources and the default bones audio session
 pub fn game_plugin(game: &mut Game) {
     AudioSource::register_schema();
+    game.init_shared_resource::<AudioCenter>();
     game.insert_shared_resource(AudioManager::default());
     game.init_shared_resource::<AssetServer>();
+
+    let session = game.sessions.create(DEFAULT_BONES_AUDIO_SESSION);
+    // Audio doesn't do any rendering
+    session.visible = false;
+    session
+        .stages
+        .add_system_to_stage(First, process_audio_events)
+        .add_system_to_stage(Last, kill_finished_audios);
+}
+
+/// A resource that can be used to control game audios.
+#[derive(HasSchema)]
+#[schema(no_clone)]
+pub struct AudioCenter {
+    /// Buffer for audio events that have not yet been processed.
+    events: VecDeque<AudioEvent>,
+    /// The handle to the current music.
+    music: Option<Audio>,
+    /// The volume scale for main audio.
+    main_volume_scale: f32,
+    /// The volume scale for music.
+    music_volume_scale: f32,
+    /// The volume scale for sound effects.
+    effects_volume_scale: f32,
+}
+
+impl Default for AudioCenter {
+    fn default() -> Self {
+        Self {
+            events: VecDeque::with_capacity(16),
+            music: None,
+            main_volume_scale: 1.0,
+            music_volume_scale: 1.0,
+            effects_volume_scale: 1.0,
+        }
+    }
+}
+
+impl AudioCenter {
+    /// Push an audio event to the queue for later processing.
+    pub fn push_event(&mut self, event: AudioEvent) {
+        self.events.push_back(event);
+    }
+
+    /// Get the playback state of the music.
+    pub fn music_state(&self) -> Option<PlaybackState> {
+        self.music.as_ref().map(|m| m.handle.state())
+    }
+
+    /// Play a sound. These are usually short audios that indicate something
+    /// happened in game, e.g. a player jump, an explosion, etc.
+    /// Volume is scaled by both main_volume_scale, and effects_volume_scale.
+    pub fn play_sound(&mut self, sound_source: Handle<AudioSource>, volume: f64) {
+        self.events.push_back(AudioEvent::PlaySound {
+            sound_source,
+            volume,
+        })
+    }
+
+    /// Play some music, any current music is stopped. These may or may not loop.
+    /// Volume is scaled by both main_volume_scale, and music_volume_scale.
+    pub fn play_music(
+        &mut self,
+        sound_source: Handle<AudioSource>,
+        sound_settings: StaticSoundSettings,
+    ) {
+        self.events.push_back(AudioEvent::PlayMusic {
+            sound_source,
+            sound_settings: Box::new(sound_settings),
+        });
+    }
+
+    /// Sets the volume scale for main audio within the range of 0.0 to 1.0.
+    pub fn set_main_volume_scale(&mut self, main: f32) {
+        self.main_volume_scale = main.clamp(0.0, 1.0);
+    }
+
+    /// Sets the volume scale for music within the range of 0.0 to 1.0.
+    pub fn set_music_volume_scale(&mut self, music: f32) {
+        self.music_volume_scale = music.clamp(0.0, 1.0);
+    }
+
+    /// Sets the volume scale for effects within the range of 0.0 to 1.0.
+    pub fn set_effects_volume_scale(&mut self, effects: f32) {
+        self.effects_volume_scale = effects.clamp(0.0, 1.0);
+    }
+
+    /// Sets the volume scales for main, music, and effects within the range of 0.0 to 1.0.
+    pub fn set_volume_scales(&mut self, main: f32, music: f32, effects: f32) {
+        self.set_main_volume_scale(main);
+        self.set_music_volume_scale(music);
+        self.set_effects_volume_scale(effects);
+        self.events.push_back(AudioEvent::VolumeScaleChange {
+            main_volume: self.main_volume_scale,
+            music_volume: self.music_volume_scale,
+            effects_volume: self.effects_volume_scale,
+        });
+    }
+}
+
+/// An audio event that may be sent to the [`AudioCenter`] resource for
+/// processing.
+#[derive(Clone, Debug)]
+pub enum AudioEvent {
+    /// Update the volume of all audios using the new scale values.
+    /// This event is used to adjust the overall volume of the application.
+    VolumeScaleChange {
+        /// The main volume scale factor.
+        main_volume: f32,
+        /// The music volume scale factor.
+        music_volume: f32,
+        /// The effects volume scale factor.
+        effects_volume: f32,
+    },
+    /// Play some music.
+    ///
+    /// Any current music is stopped.
+    PlayMusic {
+        /// The handle for the music.
+        sound_source: Handle<AudioSource>,
+        /// The settings for the music.
+        sound_settings: Box<StaticSoundSettings>,
+    },
+    /// Play a sound.
+    PlaySound {
+        /// The handle to the sound to play.
+        sound_source: Handle<AudioSource>,
+        /// The volume to play the sound at.
+        volume: f64,
+    },
+}
+
+/// Holds the handle and the volume to be played for a piece of Audio. 
+#[derive(HasSchema)]
+#[schema(no_clone, no_default, opaque)]
+#[repr(C)]
+pub struct Audio {
+    /// The handle for the audio.
+    handle: StaticSoundHandle,
+    /// The original volume requested for the audio.
+    volume: f64,
+}
+
+fn process_audio_events(
+    mut audio_manager: ResMut<AudioManager>,
+    mut audio_center: ResMut<AudioCenter>,
+    assets: ResInit<AssetServer>,
+    mut entities: ResMut<Entities>,
+    mut audios: CompMut<Audio>,
+) {
+    for event in audio_center.events.drain(..).collect::<Vec<_>>() {
+        match event {
+            AudioEvent::VolumeScaleChange {
+                main_volume,
+                music_volume,
+                effects_volume,
+            } => {
+                let tween = Tween::default();
+                // Update music volume
+                if let Some(music) = &mut audio_center.music {
+                    let volume = (main_volume as f64) * (music_volume as f64) * music.volume;
+                    if let Err(err) = music.handle.set_volume(volume, tween) {
+                        warn!("Error setting music volume: {err}");
+                    }
+                }
+                // Update sound volumes
+                for audio in audios.iter_mut() {
+                    let volume = (main_volume as f64) * (effects_volume as f64) * audio.volume;
+                    if let Err(err) = audio.handle.set_volume(volume, tween) {
+                        warn!("Error setting audio volume: {err}");
+                    }
+                }
+            }
+            AudioEvent::PlayMusic {
+                sound_source,
+                mut sound_settings,
+            } => {
+                // Stop the current music
+                if let Some(mut music) = audio_center.music.take() {
+                    let tween = Tween {
+                        start_time: kira::StartTime::Immediate,
+                        duration: MUSIC_FADE_DURATION,
+                        easing: tween::Easing::Linear,
+                    };
+                    music.handle.stop(tween).unwrap();
+                }
+                // Scale the requested volume by the volume scales
+                let volume = match sound_settings.volume {
+                    tween::Value::Fixed(vol) => vol.as_amplitude(),
+                    _ => DEFAULT_MUSIC_VOLUME,
+                };
+                let scaled_volume = (audio_center.main_volume_scale as f64) * (audio_center.music_volume_scale as f64) * volume;
+                sound_settings.volume = tween::Value::Fixed(Volume::Amplitude(scaled_volume));
+                // Play the new music
+                let sound_data = assets.get(sound_source).with_settings(*sound_settings);
+                match audio_manager.play(sound_data) {
+                    Err(err) => warn!("Error playing music: {err}"),
+                    Ok(handle) => audio_center.music = Some(Audio { handle, volume }),
+                }
+            }
+            AudioEvent::PlaySound {
+                sound_source,
+                volume,
+            } => {
+                let scaled_volume = (audio_center.main_volume_scale as f64) * (audio_center.effects_volume_scale as f64) * volume;
+                let sound_data = assets
+                    .get(sound_source)
+                    .with_settings(StaticSoundSettings::default().volume(scaled_volume));
+                match audio_manager.play(sound_data) {
+                    Err(err) => warn!("Error playing sound: {err}"),
+                    Ok(handle) => {
+                        let audio_ent = entities.create();
+                        audios.insert(audio_ent, Audio { handle, volume });
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn kill_finished_audios(entities: Res<Entities>, audios: Comp<Audio>, mut commands: Commands) {
+    for (audio_ent, audio) in entities.iter_with(&audios) {
+        if audio.handle.state() == PlaybackState::Stopped {
+            commands.add(move |mut entities: ResMut<Entities>| entities.kill(audio_ent));
+        }
+    }
 }
 
 /// The audio manager resource which can be used to play sounds.

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -23,7 +23,7 @@ pub use kira::sound::static_sound::StaticSoundSettings;
 /// The amount of time to spend fading the music in and out.
 pub const MUSIC_FADE_DURATION: Duration = Duration::from_millis(500);
 /// Name of the default bones audio session
-pub const DEFAULT_BONES_AUDIO_SESSION: &'static str  = "BONES_AUDIO";
+pub const DEFAULT_BONES_AUDIO_SESSION: &str  = "BONES_AUDIO";
 
 /// Sets up audio-related resources and the default bones audio session
 pub fn game_plugin(game: &mut Game) {
@@ -281,7 +281,7 @@ fn process_audio_events(
                     let scaled_volume = (audio_center.main_volume_scale as f64) * (audio_center.music_volume_scale as f64) * volume;
                     sound_settings.volume = tween::Value::Fixed(Volume::Amplitude(scaled_volume));
                     // Play the new music
-                    let sound_data = assets.get(sound_source.clone()).with_settings(*sound_settings);
+                    let sound_data = assets.get(sound_source).with_settings(*sound_settings);
                     match audio_manager.play(sound_data) {
                         Err(err) => warn!("Error playing music: {err}"),
                         Ok(handle) => audio_center.music = Some(Audio { handle, volume, bones_handle: sound_source }),
@@ -294,7 +294,7 @@ fn process_audio_events(
             } => {
                 let scaled_volume = (audio_center.main_volume_scale as f64) * (audio_center.effects_volume_scale as f64) * volume;
                 let sound_data = assets
-                    .get(sound_source.clone())
+                    .get(sound_source)
                     .with_settings(StaticSoundSettings::default().volume(scaled_volume));
                 match audio_manager.play(sound_data) {
                     Err(err) => warn!("Error playing sound: {err}"),

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -107,17 +107,27 @@ impl AudioCenter {
         });
     }
 
-
     /// Plays music with advanced settings.
     /// Volume is scaled by both main_volume_scale and music_volume_scale.
+    ///
+    /// # Parameters
+    ///
+    /// * `sound_source` - The handle for the audio source to play
+    /// * `volume` - The volume to play the music at (0.0 to 1.0)
+    /// * `loop_music` - Whether the music should loop indefinitely
+    /// * `reverse` - Whether to play the audio in reverse
+    /// * `start_position` - The position in seconds to start playback from
+    /// * `playback_rate` - The playback rate (1.0 is normal speed, 0.5 is half speed, 2.0 is double speed)
+    /// * `skip_restart` - If true, won't restart the music if it's already playing the same track
+   #[allow(clippy::too_many_arguments)]
     pub fn play_music_advanced(
         &mut self,
         sound_source: Handle<AudioSource>,
         volume: f64,
         loop_music: bool,
-        start_position: f64,
         reverse: bool,
-        playback_rate: f64,
+        start_position: f64,
+        playback_rate: f64, 
         skip_restart: bool,
     ) {
         let clamped_volume = volume.clamp(0.0, 1.0);

--- a/framework_crates/bones_framework/src/render/audio.rs
+++ b/framework_crates/bones_framework/src/render/audio.rs
@@ -14,10 +14,11 @@ use kira::{
     },
     sound::SoundData,
     tween::Tween,
-    sound::static_sound::{StaticSoundHandle, StaticSoundSettings},
+    sound::static_sound::StaticSoundHandle,
 };
 use kira::{Volume, tween};
 use std::time::Duration;
+pub use kira::sound::static_sound::StaticSoundSettings;
 
 /// The amount of time to spend fading the music in and out.
 pub const MUSIC_FADE_DURATION: Duration = Duration::from_millis(500);
@@ -89,33 +90,34 @@ impl AudioCenter {
         })
     }
 
-    /// Play some music, forcibly stopping any current music.
-    /// Volume is scaled by both main_volume_scale, and music_volume_scale.
-    pub fn play_music(
-        &mut self,
-        sound_source: Handle<AudioSource>,
-        sound_settings: StaticSoundSettings,
-    ) {
+    /// Play music, forcibly stopping any current music.
+    /// Volume is scaled by both main_volume_scale and music_volume_scale.
+    pub fn play_music(&mut self, sound_source: Handle<AudioSource>, volume: f64) {
+        let clamped_volume = volume.clamp(0.0, 1.0);
+        let settings = StaticSoundSettings::new().volume(Volume::Amplitude(clamped_volume));
         self.events.push_back(AudioEvent::PlayMusic {
             sound_source,
-            sound_settings: Box::new(sound_settings),
+            sound_settings: Box::new(settings),
             force_restart: true,
         });
     }
 
-    /// Play some music, but only if it's different from the currently playing music.
-    /// Volume is scaled by both main_volume_scale, and music_volume_scale.
-    pub fn play_music_checked(
+    /// Play music with advanced settings.
+    /// * `sound_settings`: Custom StaticSoundSettings for the music.
+    /// * `skip_restart`: Skips restarting the music from the beginning if playing same track again.
+    pub fn play_music_advanced(
         &mut self,
         sound_source: Handle<AudioSource>,
         sound_settings: StaticSoundSettings,
+        skip_restart: bool,
     ) {
         self.events.push_back(AudioEvent::PlayMusic {
             sound_source,
             sound_settings: Box::new(sound_settings),
-            force_restart: false,
+            force_restart: !skip_restart,
         });
     }
+
 
     /// Sets the volume scale for main audio within the range of 0.0 to 1.0.
     pub fn set_main_volume_scale(&mut self, main: f32) {


### PR DESCRIPTION
Moved AudioCenter out of jumpy -> bones.

Reworked to remove the dependency on using a game's settings struct directly + streamlining the interfaces such as having both play_sound and play_music be super easy to use, with extra _advanced and _custom methods for different levels of advanced features/usability on music.

Tested both music/sounds work.