### PR TITLE
feat(logging)!: Move logging setup to `setup_logging`, disable bevy LogPlugin, add logging to file system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "csscolorparser",
+ "directories",
  "document-features",
  "egui",
  "egui_plot",
@@ -1483,6 +1484,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-wasm",
  "ttf-parser",
@@ -7367,6 +7369,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "parking_lot",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tracing-tracy",
  "tracing-wasm",
  "ttf-parser",
  "unic-langid",
@@ -3101,6 +3102,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,6 +4332,19 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -6357,6 +6385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7446,6 +7480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a90519f16f55e5c62ffd5976349f10744435a919ecff83d918300575dfb69b"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7454,6 +7499,26 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373db47331c3407b343538df77eea2516884a0b126cdfb4b135acfd400015dd7"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf0064dcb31c99aa1244c1b93439359e53f72ed217eef5db50abd442241e9a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
  "ttf-parser",
  "unic-langid",
 ]

--- a/demos/assets_minimal/src/main.rs
+++ b/demos/assets_minimal/src/main.rs
@@ -20,7 +20,7 @@ struct GameMeta {
 
 fn main() {
     // Setup logging
-    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+    setup_logs!();
 
     // First create bones game.
     let mut game = Game::new();

--- a/demos/assets_minimal/src/main.rs
+++ b/demos/assets_minimal/src/main.rs
@@ -19,6 +19,9 @@ struct GameMeta {
 }
 
 fn main() {
+    // Setup logging
+    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+
     // First create bones game.
     let mut game = Game::new();
 

--- a/demos/features/src/main.rs
+++ b/demos/features/src/main.rs
@@ -85,7 +85,7 @@ struct PersistedTextData(String);
 
 fn main() {
     // Setup logging
-    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+    setup_logs!();
 
     // Register persistent data's schema so that it can be loaded by the storage loader.
     PersistedTextData::register_schema();

--- a/demos/features/src/main.rs
+++ b/demos/features/src/main.rs
@@ -84,6 +84,9 @@ struct TileMeta {
 struct PersistedTextData(String);
 
 fn main() {
+    // Setup logging
+    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+
     // Register persistent data's schema so that it can be loaded by the storage loader.
     PersistedTextData::register_schema();
 

--- a/demos/hello_world/src/main.rs
+++ b/demos/hello_world/src/main.rs
@@ -2,6 +2,9 @@ use bones_bevy_renderer::BonesBevyRenderer;
 use bones_framework::prelude::*;
 
 fn main() {
+    // Setup logging
+    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+
     // First create bones game.
     let mut game = Game::new();
 

--- a/demos/hello_world/src/main.rs
+++ b/demos/hello_world/src/main.rs
@@ -3,7 +3,7 @@ use bones_framework::prelude::*;
 
 fn main() {
     // Setup logging
-    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+    setup_logs!();
 
     // First create bones game.
     let mut game = Game::new();

--- a/demos/scripting/src/main.rs
+++ b/demos/scripting/src/main.rs
@@ -13,7 +13,7 @@ struct GameMeta {
 
 fn main() {
     // Setup logging
-    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+    setup_logs!();
 
     let mut game = Game::new();
     game.install_plugin(DefaultGamePlugin);

--- a/demos/scripting/src/main.rs
+++ b/demos/scripting/src/main.rs
@@ -12,6 +12,9 @@ struct GameMeta {
 }
 
 fn main() {
+    // Setup logging
+    let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+
     let mut game = Game::new();
     game.install_plugin(DefaultGamePlugin);
     game.shared_resource_mut::<AssetServer>()

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -24,7 +24,7 @@ use render::*;
 mod ui;
 use ui::*;
 mod rumble;
-use bevy::prelude::*;
+use bevy::{log::LogPlugin, prelude::*};
 use bones::GamepadsRumble;
 use bones_framework::prelude as bones;
 use rumble::*;
@@ -145,6 +145,7 @@ impl BonesBevyRenderer {
                 }),
                 ..default()
             })
+            .disable::<LogPlugin>()
             .build();
         if self.pixel_art {
             plugins = plugins.set(ImagePlugin::default_nearest());

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -72,7 +72,7 @@ image_bmp = ["image/bmp"]
 #
 # Note that bones is primarily instrumented with puffin scopes, tracy only captures tracing spans.
 # This flag only enables span capture in logging plugin, `bevy/trace_tracy` may be used to enable tracy.
-tracing-tracy = ["logging"]
+tracing-tracy = ["logging", "dep:tracing-tracy"]
 
 document-features = ["dep:document-features"]
 
@@ -95,9 +95,12 @@ instant       = { version = "0.1", features = ["wasm-bindgen"] }
 noise         = "0.9"
 once_cell     = "1.17"
 thiserror     = "1.0"
-tracing       = "0.1"
+
+# Tracing
+tracing            = "0.1"
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 tracing-appender   = { version = "0.2", optional = true, features = ["parking_lot"] }
+tracing-tracy      = { version = "0.11.0", optional = true, default-features = false }
 
 # Render
 csscolorparser = "0.6"

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -11,13 +11,15 @@ categories.workspace    = true
 keywords.workspace      = true
 
 [features]
-default = ["image_png", "ui", "localization", "audio", "audio_ogg", "scripting"]
+default = ["image_png", "ui", "localization", "logging", "audio", "audio_ogg", "scripting"]
 #! Cargo feature supported in `bones_framework`.
 
 ## Enable the `ui` module, powered by [`egui`].
 ui = ["dep:egui", "dep:ttf-parser"]
 ## Enable the localization module, powered by [`fluent`](https://github.com/projectfluent/fluent-rs).
 localization = ["dep:fluent", "dep:fluent-langneg", "dep:intl-memoizer", "dep:unic-langid", "dep:sys-locale"]
+
+logging = ["dep:tracing-subscriber", "dep:tracing-wasm"]
 
 ## Enable the audio system.
 audio = ["dep:kira"]
@@ -66,6 +68,12 @@ image_ico = ["image/ico"]
 ## Enable BMP image loader.
 image_bmp = ["image/bmp"]
 
+# Enables tracy tracing subscriber to capture tracing spans for profiling with Tracy.
+#
+# Note that bones is primarily instrumented with puffin scopes, tracy only captures tracing spans.
+# This flag only enables span capture in logging plugin, `bevy/trace_tracy` may be used to enable tracy.
+tracing-tracy = ["logging"]
+
 document-features = ["dep:document-features"]
 
 [dependencies]
@@ -88,6 +96,7 @@ noise         = "0.9"
 once_cell     = "1.17"
 thiserror     = "1.0"
 tracing       = "0.1"
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 
 # Render
 csscolorparser = "0.6"
@@ -134,3 +143,7 @@ smallvec               = "1.10"
 iroh-quinn             = { version = "0.10" }
 iroh-net               = { version = "0.22" }
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tracing-wasm = { version = "0.2.1", optional = true }

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -19,7 +19,7 @@ ui = ["dep:egui", "dep:ttf-parser"]
 ## Enable the localization module, powered by [`fluent`](https://github.com/projectfluent/fluent-rs).
 localization = ["dep:fluent", "dep:fluent-langneg", "dep:intl-memoizer", "dep:unic-langid", "dep:sys-locale"]
 
-logging = ["dep:tracing-subscriber", "dep:tracing-wasm"]
+logging = ["dep:tracing-subscriber", "dep:tracing-wasm", "dep:tracing-appender"]
 
 ## Enable the audio system.
 audio = ["dep:kira"]
@@ -97,6 +97,7 @@ once_cell     = "1.17"
 thiserror     = "1.0"
 tracing       = "0.1"
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
+tracing-appender   = { version = "0.2", optional = true, features = ["parking_lot"] }
 
 # Render
 csscolorparser = "0.6"
@@ -144,6 +145,8 @@ iroh-quinn             = { version = "0.10" }
 iroh-net               = { version = "0.22" }
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
 
+
+directories = "5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tracing-wasm = { version = "0.2.1", optional = true }

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -42,6 +42,9 @@ pub mod prelude {
 
     #[cfg(feature = "localization")]
     pub use crate::localization::*;
+
+    #[cfg(feature = "logging")]
+    pub use crate::logging::*;
 }
 
 pub mod animation;
@@ -63,6 +66,9 @@ pub use bones_scripting as scripting;
 
 #[cfg(feature = "localization")]
 pub mod localization;
+
+#[cfg(feature = "logging")]
+pub mod logging;
 
 /// External crate documentation.
 ///
@@ -92,6 +98,9 @@ pub struct DefaultGamePlugin;
 impl lib::GamePlugin for DefaultGamePlugin {
     #[allow(unused_variables)]
     fn install(self, game: &mut lib::Game) {
+        #[cfg(feature = "logging")]
+        game.install_plugin(logging::LogPlugin::default());
+
         #[cfg(feature = "audio")]
         game.install_plugin(render::audio::game_plugin);
 

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -44,7 +44,7 @@ pub mod prelude {
     pub use crate::localization::*;
 
     #[cfg(feature = "logging")]
-    pub use crate::logging::*;
+    pub use crate::logging::prelude::*;
 }
 
 pub mod animation;
@@ -98,9 +98,6 @@ pub struct DefaultGamePlugin;
 impl lib::GamePlugin for DefaultGamePlugin {
     #[allow(unused_variables)]
     fn install(self, game: &mut lib::Game) {
-        #[cfg(feature = "logging")]
-        game.install_plugin(logging::LogPlugin::default());
-
         #[cfg(feature = "audio")]
         game.install_plugin(render::audio::game_plugin);
 

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -1,21 +1,35 @@
-//! Logging module for bones, enabled with feature "logging". Configures global tracing subscriber.
+//! Logging module for bones. Configures global tracing subscriber.
+//!
+//! Enabled with feature "logging".
+#![allow(clippy::needless_doctest_main)]
 
-use std::error::Error;
+use std::{error::Error, path::PathBuf};
 
-use tracing::{error, Level};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     filter::{FromEnvError, ParseError},
     layer::SubscriberExt,
     EnvFilter, Layer, Registry,
 };
 
-use bones_lib::{Game, GamePlugin};
+#[allow(unused_imports)]
+use tracing::{error, warn, Level};
 
-/// A boxed [`Layer`] that can be used with [`LogPlugin`].
+use bones_asset::HasSchema;
+use bones_lib::prelude::Deref;
+
+/// Logging prelude
+pub mod prelude {
+    pub use super::{
+        setup_logging, LogFileConfig, LogFileError, LogFileRotation, LogPath, LogSettings,
+    };
+}
+
+/// A boxed [`Layer`] that can be used with [`setup_logging`].
 pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
 /// Plugin to enable tracing. Configures global tracing subscriber.
-pub struct LogPlugin {
+pub struct LogSettings {
     /// Filters logs using the [`EnvFilter`] format
     pub filter: String,
 
@@ -25,85 +39,282 @@ pub struct LogPlugin {
 
     /// Optionally add an extra [`Layer`] to the tracing subscriber
     ///
-    /// This function is only called once, when the plugin is installed.
+    /// This function is only called once, when logging is initialized.
     ///
     /// Because [`BoxedLayer`] takes a `dyn Layer`, `Vec<Layer>` is also an acceptable return value.
+    pub custom_layer: fn() -> Option<BoxedLayer>,
+
+    /// The (qualifier, organization, application) that will be used to pick a persistent storage
+    /// location for the game.
     ///
-    /// Access to [`Game`] is also provided to allow for communication between the
-    /// `Subscriber` and the [`Game`].
+    /// For example: `("org", "fishfolk", "jumpy")`
     ///
-    /// Please see the `examples/log_layers.rs` for a complete example.
-    pub custom_layer: fn(game: &mut Game) -> Option<BoxedLayer>,
+    /// Used to determine directory to write log files if
+    // pub app_namespace: Option<(String, String, String)>,
+
+    /// Set to write log output to file system. Not supported on wasm.
+    pub log_file: Option<LogFileConfig>,
 }
 
-impl Default for LogPlugin {
+impl Default for LogSettings {
     fn default() -> Self {
         Self {
             filter: "wgpu=error,naga=warn".to_string(),
             level: Level::INFO,
-            custom_layer: |_| None,
+            custom_layer: || None,
+            log_file: None,
         }
     }
 }
 
-impl GamePlugin for LogPlugin {
-    fn install(self, game: &mut Game) {
-        let finished_subscriber;
-        let subscriber = Registry::default();
+/// How often to rotate log file.
+#[derive(Copy, Clone, Default)]
+#[allow(missing_docs)]
+pub enum LogFileRotation {
+    Minutely,
+    Hourly,
+    #[default]
+    Daily,
+    Never,
+}
 
-        // add optional layer provided by user
-        let subscriber = subscriber.with((self.custom_layer)(game));
+impl From<LogFileRotation> for tracing_appender::rolling::Rotation {
+    fn from(value: LogFileRotation) -> Self {
+        match value {
+            LogFileRotation::Minutely => Rotation::MINUTELY,
+            LogFileRotation::Hourly => Rotation::HOURLY,
+            LogFileRotation::Daily => Rotation::DAILY,
+            LogFileRotation::Never => Rotation::NEVER,
+        }
+    }
+}
 
-        let default_filter = { format!("{},{}", self.level, self.filter) };
-        let filter_layer = EnvFilter::try_from_default_env()
-            .or_else(|from_env_error| {
-                _ = from_env_error
-                    .source()
-                    .and_then(|source| source.downcast_ref::<ParseError>())
-                    .map(|parse_err| {
-                        // we cannot use the `error!` macro here because the logger is not ready yet.
-                        eprintln!("LogPlugin failed to parse filter from env: {}", parse_err);
-                    });
+/// Error for file logging.
+#[derive(Debug, thiserror::Error)]
+pub enum LogFileError {
+    /// Failed to determine a log directory.
+    #[error("Could not determine log dir: {0}")]
+    LogDirFail(String),
+    /// Attempted to setup file logging on unsupported platform.
+    #[error("Logging to file system is unsupported on platform: {0}")]
+    Unsupported(String),
+}
 
-                Ok::<EnvFilter, FromEnvError>(EnvFilter::builder().parse_lossy(&default_filter))
-            })
-            .unwrap();
-        let subscriber = subscriber.with(filter_layer);
+/// Path to save log files. [`LogPath::find_app_data_dir`] may be used to
+/// to automatically find OS appropriate app data path from app namespace strings, e.g. ("org", "fishfolk", "jumpy")
+#[derive(Clone, Deref)]
+pub struct LogPath(pub PathBuf);
 
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
+impl LogPath {
+    /// Find OS app data path for provided app namespace (e.g. ("org", "fishfolk", "jumpy"))
+    ///
+    /// Will error if failed to resole this directory for OS or on unsupported platform such as wasm.
+    ///
+    /// i.e. ~/.local/share/org.fishfolk.jumpy/logs,
+    //       C:\Users\<User>\Appdata\Roaming\org.fishfolk.jumpy\logs,
+    ///      ~/Library/Application Support/org.fishfolk.jumpy/logs
+    #[allow(unused_variables)]
+    pub fn find_app_data_dir(
+        app_namespace: (String, String, String),
+    ) -> Result<Self, LogFileError> {
+        #[cfg(not(target_arch = "wasm32"))]
         {
-            #[cfg(feature = "tracing-tracy")]
-            let tracy_layer = tracing_tracy::TracyLayer::default();
-
-            // note: the implementation of `Default` reads from the env var NO_COLOR
-            // to decide whether to use ANSI color codes, which is common convention
-            // https://no-color.org/
-            let fmt_layer = tracing_subscriber::fmt::Layer::default();
-
-            // bevy_render::renderer logs a `tracy.frame_mark` event every frame
-            // at Level::INFO. Formatted logs should omit it.
-            #[cfg(feature = "tracing-tracy")]
-            let fmt_layer =
-                fmt_layer.with_filter(tracing_subscriber::filter::FilterFn::new(|meta| {
-                    meta.fields().field("tracy.frame_mark").is_none()
-                }));
-
-            let subscriber = subscriber.with(fmt_layer);
-
-            #[cfg(feature = "tracing-tracy")]
-            let subscriber = subscriber.with(tracy_layer);
-            finished_subscriber = subscriber;
+            directories::ProjectDirs::from(
+                app_namespace.0.as_str(),
+                app_namespace.1.as_str(),
+                app_namespace.2.as_str(),
+            )
+            // error message from `ProjectDirs::from` docs
+            .ok_or(LogFileError::LogDirFail(
+                "no valid home directory path could be retrieved from the operating system"
+                    .to_string(),
+            ))
+            .map(|dirs| LogPath(dirs.data_dir().join("logs")))
         }
 
         #[cfg(target_arch = "wasm32")]
         {
-            finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
-                tracing_wasm::WASMLayerConfig::default(),
-            ));
-        }
-
-        if let Err(err) = tracing::subscriber::set_global_default(finished_subscriber) {
-            error!("{err} - bones logging failed to set global subscriber. This was enabled with 'logging' feature flag.");
+            Err(LogFileError::Unsupported("wasm32".to_string()))
         }
     }
+}
+
+/// Settings to enable writing tracing output to files.
+pub struct LogFileConfig {
+    /// Path to store log files - use [`LogPath`]'s helper function to find good default path.
+    pub log_path: LogPath,
+
+    /// How often to rotate log file.
+    pub rotation: LogFileRotation,
+
+    /// Beginning of log file name (e.g. "Jumpy.log"), timestamp will be appended to this
+    /// if using rotatig logs.
+    pub file_name_prefix: String,
+
+    /// If set, will cleanup the oldest log files in directory that match `file_name_prefix` until under max
+    /// file count. Otherwise no log files will be cleaned up.
+    pub max_log_files: Option<usize>,
+}
+
+/// Guard for file logging thread, this should be held onto for duration of app, if dropped
+/// writing to log file will stop.
+///
+/// It is recommended to hold onto this in main() to ensure all logs are flushed when app is
+/// exiting. See [`tracing_appender::non_blocking::WorkerGuard`] docs for details.
+#[derive(HasSchema)]
+#[schema(no_clone, no_default)]
+pub struct LogFileGuard(tracing_appender::non_blocking::WorkerGuard);
+
+/// Setup the global tracing subscriber, and optionally enable logging to file system.
+///
+/// if [`LogFileConfig`] was provided in settings and is supported on this platform (cannot log to file system on wasm),
+/// this function will return a [`LogFileGuard`]. This must be kept alive for duration of process to capture all logs,
+/// see [`LogFileGuard`] docs.
+///
+/// # Examples
+///
+/// Default without logging to file
+/// ```
+/// fn main() {
+///     let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
+/// }
+/// ```
+///
+/// Enable tracing to log files:
+/// ```
+/// fn main() {
+///     let log_file =
+///         match LogPath::find_app_data_dir(("org".into(), "fishfolk".into(), "jumpy".into())) {
+///             Ok(log_path) => Some(LogFileConfig {
+///                 log_path,
+///                 rotation: LogFileRotation::Daily,
+///                 file_name_prefix: "Jumpy.log".to_string(),
+///                 max_log_files: Some(7),
+///             }),
+///             Err(err) => {
+///                 // Cannot use error! macro as logging not configured yet.
+///                 eprintln!("Failed to configure file logging: {err}");
+///                 None
+///             }
+///         };
+///
+///     // _log_guard will be dropped when main exits, remains alive for duration of program.
+///     let _log_guard = bones_framework::logging::setup_logging(LogSettings {
+///         log_file,
+///         ..default()
+///     });
+/// }
+/// ```
+///
+///
+#[must_use]
+pub fn setup_logging(settings: LogSettings) -> Option<LogFileGuard> {
+    let finished_subscriber;
+    let subscriber = Registry::default();
+
+    // add optional layer provided by user
+    let subscriber = subscriber.with((settings.custom_layer)());
+
+    let default_filter = { format!("{},{}", settings.level, settings.filter) };
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|from_env_error| {
+            _ = from_env_error
+                .source()
+                .and_then(|source| source.downcast_ref::<ParseError>())
+                .map(|parse_err| {
+                    // we cannot use the `error!` macro here because the logger is not ready yet.
+                    eprintln!(
+                        "setup_logging() failed to parse filter from env: {}",
+                        parse_err
+                    );
+                });
+
+            Ok::<EnvFilter, FromEnvError>(EnvFilter::builder().parse_lossy(&default_filter))
+        })
+        .unwrap();
+    let subscriber = subscriber.with(filter_layer);
+
+    let log_file_guard;
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let (file_layer, file_guard) = match &settings.log_file {
+            Some(log_file) => {
+                let LogFileConfig {
+                    log_path,
+                    rotation,
+                    file_name_prefix,
+                    max_log_files,
+                } = log_file;
+
+                let file_appender = RollingFileAppender::builder()
+                    .filename_prefix(file_name_prefix)
+                    .rotation((*rotation).into());
+
+                let file_appender = match *max_log_files {
+                    Some(max) => file_appender.max_log_files(max),
+                    None => file_appender,
+                };
+
+                match file_appender.build(&**log_path) {
+                    Ok(file_appender) => {
+                        let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+                        let file_layer =
+                            tracing_subscriber::fmt::Layer::default().with_writer(non_blocking);
+                        (Some(file_layer), Some(LogFileGuard(_guard)))
+                    }
+                    Err(err) => {
+                        // we cannot use the `error!` macro here because the logger is not ready yet.
+                        eprintln!("Failed to configure tracing_appender layer for logging to file system - {err}");
+                        (None, None)
+                    }
+                }
+            }
+            None => (None, None),
+        };
+        let subscriber = subscriber.with(file_layer);
+        log_file_guard = file_guard;
+
+        #[cfg(feature = "tracing-tracy")]
+        let tracy_layer = tracing_tracy::TracyLayer::default();
+
+        // note: the implementation of `Default` reads from the env var NO_COLOR
+        // to decide whether to use ANSI color codes, which is common convention
+        // https://no-color.org/
+        let fmt_layer = tracing_subscriber::fmt::Layer::default();
+
+        // bevy_render::renderer logs a `tracy.frame_mark` event every frame
+        // at Level::INFO. Formatted logs should omit it.
+        #[cfg(feature = "tracing-tracy")]
+        let fmt_layer = fmt_layer.with_filter(tracing_subscriber::filter::FilterFn::new(|meta| {
+            meta.fields().field("tracy.frame_mark").is_none()
+        }));
+
+        let subscriber = subscriber.with(fmt_layer);
+
+        #[cfg(feature = "tracing-tracy")]
+        let subscriber = subscriber.with(tracy_layer);
+        finished_subscriber = subscriber;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
+            tracing_wasm::WASMLayerConfig::default(),
+        ));
+        log_file_guard = None;
+    }
+
+    if let Err(err) = tracing::subscriber::set_global_default(finished_subscriber) {
+        error!("{err} - `setup_logging` was called and configures global subscriber. Game may either setup subscriber itself, or call `setup_logging` from bones, but not both.");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        if settings.log_file.is_some() {
+            // Report this warning after setting up tracing subscriber so it will show up on wasm.
+            warn!("bones_framework::setup_logging() - `LogFileConfig` provided, however logging to file system is not supported in wasm.");
+        }
+    }
+
+    log_file_guard
 }

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -125,7 +125,7 @@ impl LogPath {
     #[allow(unused_variables)]
     pub fn find_app_data_dir(app_namespace: (&str, &str, &str)) -> Result<Self, LogFileError> {
         // Don't run this during tests, as Miri CI does not support the syscall.
-        #[cfg(all(not(target_arch = "wasm32"), not(test)))]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             directories::ProjectDirs::from(app_namespace.0, app_namespace.1, app_namespace.2)
                 // error message from `ProjectDirs::from` docs
@@ -139,11 +139,6 @@ impl LogPath {
         #[cfg(target_arch = "wasm32")]
         {
             Err(LogFileError::Unsupported("wasm32".to_string()))
-        }
-
-        #[cfg(test)]
-        {
-            Err(LogFileError::Unsupported("test".to_string()))
         }
     }
 }
@@ -209,7 +204,7 @@ impl Drop for LogFileGuard {
 /// ```
 ///
 /// ### Enable logging including logging to files:
-/// ```
+/// ```no_run
 /// use bones_framework::prelude::*;
 /// fn main() {
 ///     let log_file =
@@ -235,14 +230,14 @@ impl Drop for LogFileGuard {
 /// }
 /// ```
 /// or logging to file with defaults:
-/// ```
+/// ```no_run
 /// use bones_framework::logging::prelude::*;
 /// fn main() {
 ///     let _log_guard = bones_framework::logging::setup_logging_default(("org", "fishfolk", "jumpy"));
 /// }
 /// ```
 /// same with [`macros::setup_logs`] macro:
-/// ```
+/// ```no_run
 /// use bones_framework::prelude::*;
 /// fn main() {
 ///     setup_logs!("org", "fishfolk", "jumpy");
@@ -414,7 +409,7 @@ pub mod macros {
     /// file system will stop (console logging unimpacted).
     ///
     /// Usage for log defaults (logging to file system included):
-    /// ```
+    /// ```no_run
     /// use bones_framework::prelude::*;
     /// setup_logs!("org", "fishfolk", "jumpy");
     /// ```

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -30,7 +30,7 @@ pub struct LogPlugin {
     /// Because [`BoxedLayer`] takes a `dyn Layer`, `Vec<Layer>` is also an acceptable return value.
     ///
     /// Access to [`Game`] is also provided to allow for communication between the
-    /// [`Subscriber`] and the [`Game`].
+    /// `Subscriber` and the [`Game`].
     ///
     /// Please see the `examples/log_layers.rs` for a complete example.
     pub custom_layer: fn(game: &mut Game) -> Option<BoxedLayer>,

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -120,22 +120,16 @@ impl LogPath {
     //       C:\Users\<User>\Appdata\Roaming\org.fishfolk.jumpy\logs,
     ///      ~/Library/Application Support/org.fishfolk.jumpy/logs
     #[allow(unused_variables)]
-    pub fn find_app_data_dir(
-        app_namespace: (String, String, String),
-    ) -> Result<Self, LogFileError> {
+    pub fn find_app_data_dir(app_namespace: (&str, &str, &str)) -> Result<Self, LogFileError> {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            directories::ProjectDirs::from(
-                app_namespace.0.as_str(),
-                app_namespace.1.as_str(),
-                app_namespace.2.as_str(),
-            )
-            // error message from `ProjectDirs::from` docs
-            .ok_or(LogFileError::LogDirFail(
-                "no valid home directory path could be retrieved from the operating system"
-                    .to_string(),
-            ))
-            .map(|dirs| LogPath(dirs.data_dir().join("logs")))
+            directories::ProjectDirs::from(app_namespace.0, app_namespace.1, app_namespace.2)
+                // error message from `ProjectDirs::from` docs
+                .ok_or(LogFileError::LogDirFail(
+                    "no valid home directory path could be retrieved from the operating system"
+                        .to_string(),
+                ))
+                .map(|dirs| LogPath(dirs.data_dir().join("logs")))
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -195,7 +189,7 @@ pub struct LogFileGuard(tracing_appender::non_blocking::WorkerGuard);
 /// use bones_framework::prelude::*;
 /// fn main() {
 ///     let log_file =
-///         match LogPath::find_app_data_dir(("org".into(), "fishfolk".into(), "jumpy".into())) {
+///         match LogPath::find_app_data_dir(("org", "fishfolk", "jumpy")) {
 ///             Ok(log_path) => Some(LogFileConfig {
 ///                 log_path,
 ///                 rotation: LogFileRotation::Daily,
@@ -345,7 +339,7 @@ pub fn setup_logging(settings: LogSettings) -> Option<LogFileGuard> {
 ///
 /// See [`setup_logging`] docs for details.
 #[must_use]
-pub fn setup_logging_default(app_namespace: (String, String, String)) -> Option<LogFileGuard> {
+pub fn setup_logging_default(app_namespace: (&str, &str, &str)) -> Option<LogFileGuard> {
     let file_name_prefix = format!("{}.log", app_namespace.2);
     let log_file =
         match LogPath::find_app_data_dir((app_namespace.0, app_namespace.1, app_namespace.2)) {

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -124,7 +124,8 @@ impl LogPath {
     ///      ~/Library/Application Support/org.fishfolk.jumpy/logs
     #[allow(unused_variables)]
     pub fn find_app_data_dir(app_namespace: (&str, &str, &str)) -> Result<Self, LogFileError> {
-        #[cfg(not(target_arch = "wasm32"))]
+        // Don't run this during tests, as Miri CI does not support the syscall.
+        #[cfg(all(not(target_arch = "wasm32"), not(test)))]
         {
             directories::ProjectDirs::from(app_namespace.0, app_namespace.1, app_namespace.2)
                 // error message from `ProjectDirs::from` docs
@@ -138,6 +139,11 @@ impl LogPath {
         #[cfg(target_arch = "wasm32")]
         {
             Err(LogFileError::Unsupported("wasm32".to_string()))
+        }
+
+        #[cfg(test)]
+        {
+            Err(LogFileError::Unsupported("test".to_string()))
         }
     }
 }

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -1,6 +1,6 @@
-//! Logging module for bones. Configures global tracing subscriber.
+//! Logging module for bones. Provides implementation of global tracing subscriber and panic hook.
 //!
-//! Enabled with feature "logging".
+//! Enabled with feature "logging". See docs of [`setup_logging`] for details + usage.
 #![allow(clippy::needless_doctest_main)]
 
 use std::{

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -1,0 +1,109 @@
+//! Logging module for bones, enabled with feature "logging". Configures global tracing subscriber.
+
+use std::error::Error;
+
+use tracing::{error, Level};
+use tracing_subscriber::{
+    filter::{FromEnvError, ParseError},
+    layer::SubscriberExt,
+    EnvFilter, Layer, Registry,
+};
+
+use bones_lib::{Game, GamePlugin};
+
+/// A boxed [`Layer`] that can be used with [`LogPlugin`].
+pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
+
+/// Plugin to enable tracing. Configures global tracing subscriber.
+pub struct LogPlugin {
+    /// Filters logs using the [`EnvFilter`] format
+    pub filter: String,
+
+    /// Filters out logs that are "less than" the given level.
+    /// This can be further filtered using the `filter` setting.
+    pub level: tracing::Level,
+
+    /// Optionally add an extra [`Layer`] to the tracing subscriber
+    ///
+    /// This function is only called once, when the plugin is installed.
+    ///
+    /// Because [`BoxedLayer`] takes a `dyn Layer`, `Vec<Layer>` is also an acceptable return value.
+    ///
+    /// Access to [`Game`] is also provided to allow for communication between the
+    /// [`Subscriber`] and the [`Game`].
+    ///
+    /// Please see the `examples/log_layers.rs` for a complete example.
+    pub custom_layer: fn(game: &mut Game) -> Option<BoxedLayer>,
+}
+
+impl Default for LogPlugin {
+    fn default() -> Self {
+        Self {
+            filter: "wgpu=error,naga=warn".to_string(),
+            level: Level::INFO,
+            custom_layer: |_| None,
+        }
+    }
+}
+
+impl GamePlugin for LogPlugin {
+    fn install(self, game: &mut Game) {
+        let finished_subscriber;
+        let subscriber = Registry::default();
+
+        // add optional layer provided by user
+        let subscriber = subscriber.with((self.custom_layer)(game));
+
+        let default_filter = { format!("{},{}", self.level, self.filter) };
+        let filter_layer = EnvFilter::try_from_default_env()
+            .or_else(|from_env_error| {
+                _ = from_env_error
+                    .source()
+                    .and_then(|source| source.downcast_ref::<ParseError>())
+                    .map(|parse_err| {
+                        // we cannot use the `error!` macro here because the logger is not ready yet.
+                        eprintln!("LogPlugin failed to parse filter from env: {}", parse_err);
+                    });
+
+                Ok::<EnvFilter, FromEnvError>(EnvFilter::builder().parse_lossy(&default_filter))
+            })
+            .unwrap();
+        let subscriber = subscriber.with(filter_layer);
+
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
+        {
+            #[cfg(feature = "tracing-tracy")]
+            let tracy_layer = tracing_tracy::TracyLayer::default();
+
+            // note: the implementation of `Default` reads from the env var NO_COLOR
+            // to decide whether to use ANSI color codes, which is common convention
+            // https://no-color.org/
+            let fmt_layer = tracing_subscriber::fmt::Layer::default();
+
+            // bevy_render::renderer logs a `tracy.frame_mark` event every frame
+            // at Level::INFO. Formatted logs should omit it.
+            #[cfg(feature = "tracing-tracy")]
+            let fmt_layer =
+                fmt_layer.with_filter(tracing_subscriber::filter::FilterFn::new(|meta| {
+                    meta.fields().field("tracy.frame_mark").is_none()
+                }));
+
+            let subscriber = subscriber.with(fmt_layer);
+
+            #[cfg(feature = "tracing-tracy")]
+            let subscriber = subscriber.with(tracy_layer);
+            finished_subscriber = subscriber;
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
+                tracing_wasm::WASMLayerConfig::default(),
+            ));
+        }
+
+        if let Err(err) = tracing::subscriber::set_global_default(finished_subscriber) {
+            error!("{err} - bones logging failed to set global subscriber. This was enabled with 'logging' feature flag.");
+        }
+    }
+}

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -10,6 +10,7 @@ use std::{
     path::PathBuf,
 };
 
+#[allow(unused_imports)]
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     filter::{FromEnvError, ParseError},

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -167,6 +167,7 @@ pub struct LogFileConfig {
 /// exiting. See [`tracing_appender::non_blocking::WorkerGuard`] docs for details.
 #[derive(HasSchema)]
 #[schema(no_clone, no_default)]
+#[allow(dead_code)]
 pub struct LogFileGuard(tracing_appender::non_blocking::WorkerGuard);
 
 impl Drop for LogFileGuard {

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -183,6 +183,7 @@ pub struct LogFileGuard(tracing_appender::non_blocking::WorkerGuard);
 ///
 /// Default without logging to file
 /// ```
+/// use bones_framework::logging::prelude::*;
 /// fn main() {
 ///     let _log_guard = bones_framework::logging::setup_logging(LogSettings::default());
 /// }
@@ -190,6 +191,7 @@ pub struct LogFileGuard(tracing_appender::non_blocking::WorkerGuard);
 ///
 /// Enable tracing to log files:
 /// ```
+/// use bones_framework::prelude::*;
 /// fn main() {
 ///     let log_file =
 ///         match LogPath::find_app_data_dir(("org".into(), "fishfolk".into(), "jumpy".into())) {


### PR DESCRIPTION
Implement LogPlugin in bones based off Bevy's LogPlugin. 

Shouldn't be much of a change in behavior, just 1st step in adding additional log functionality in bones, such as saving game log files to disk. 

One difference is that it no longer includes the `tracing_error` crate layer, I will review how this is used in bevy and see if we want to add this dependency. Want to make sure not going to degrade in error reporting quality for errors originating in bevy. (Plus maybe there is something can learn from this / use in bones). Context: https://github.com/bevyengine/bevy/blob/3cf70ba4f9d62396240b186ff379d27a312d2aa2/crates/bevy_log/src/lib.rs#L205

Logging is behind a feature flag, enabled by default. May be removed if user wants their own global subscriber configured.