### PR TITLE
feat: Added player networking info + preparation for future EventManager work

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -385,6 +385,28 @@ impl SyncingInfo {
             SyncingInfo::Offline { .. } => 0,
         }
     }
+
+    /// Getter for the number of players, if offline defaults to 0.
+    pub fn players_count(&self) -> usize {
+        match self {
+            SyncingInfo::Online {
+                players_network_stats,
+                ..
+            } => players_network_stats.len(),
+            SyncingInfo::Offline { .. } => 0,
+        }
+    }
+
+    /// Getter for the number of players, if offline defaults to None.
+    pub fn players_count_checked(&self) -> Option<usize> {
+        match self {
+            SyncingInfo::Online {
+                players_network_stats,
+                ..
+            } => Some(players_network_stats.len()),
+            SyncingInfo::Offline { .. } => None,
+        }
+    }
 }
 
 /// Resource tracking which players have been disconnected.

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -185,17 +185,44 @@ pub enum SocketTarget {
 #[schema(no_default)]
 pub struct NetworkInfo {
     /// Current frame of simulation step
-    pub current_frame: i32,
+    current_frame: i32,
 
     /// Last confirmed frame by all clients.
     /// Anything that occurred on this frame is agreed upon by all clients.
-    pub last_confirmed_frame: i32,
+    last_confirmed_frame: i32,
 
     /// Socket
-    pub socket: Socket,
+    socket: Socket,
 
     /// Networking stats for each connected player, stored at the [player_idx] index for each respective player.
-    pub player_network_stats: SVec<PlayerNetworkStats>,
+    player_network_stats: SVec<PlayerNetworkStats>,
+}
+
+impl NetworkInfo {
+    /// Getter for the current frame number.
+    pub fn current_frame(&self) -> i32 {
+        self.current_frame
+    }
+
+    /// Getter for the last confirmed frame.
+    pub fn last_confirmed_frame(&self) -> i32 {
+        self.last_confirmed_frame
+    }
+
+    /// Getter for player_network_stats.
+    pub fn player_network_stats(&self) -> &SVec<PlayerNetworkStats> {
+        &self.player_network_stats
+    }
+
+    /// Getter for socket.
+    pub fn socket(&self) -> Maybe<&Socket> {
+        Maybe::Set(&self.socket)
+    }
+
+    /// Mutable getter for socket.
+    pub fn socket_mut(&mut self) -> Maybe<&mut Socket> {
+        Maybe::Set(&mut self.socket)
+    }
 }
 
 /// Resource tracking which players have been disconnected.

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -195,6 +195,10 @@ pub enum SyncingInfo {
         socket: Socket,
         /// Networking stats for each connected player, stored at the \[player_idx\] index for each respective player.
         players_network_stats: SVec<PlayerNetworkStats>,
+        /// The local player's index
+        local_player_idx: usize,
+        /// The local input delay set for this session
+        local_frame_delay: usize,
     },
     /// Holds data for an offline session
     Offline {
@@ -350,6 +354,36 @@ impl SyncingInfo {
             .map(|stats| stats.ping)
             .max()
             .unwrap_or(0)
+    }
+
+    /// Getter for the local player index, if offline defaults to None.
+    pub fn local_player_idx_checked(&self) -> Option<usize> {
+        match self {
+            SyncingInfo::Online {
+                local_player_idx, ..
+            } => Some(*local_player_idx),
+            SyncingInfo::Offline { .. } => None,
+        }
+    }
+
+    /// Getter for the local player index, if offline defaults to 0.
+    pub fn local_player_idx(&self) -> usize {
+        match self {
+            SyncingInfo::Online {
+                local_player_idx, ..
+            } => *local_player_idx,
+            SyncingInfo::Offline { .. } => 0,
+        }
+    }
+
+    /// Getter for the local frame delay.
+    pub fn local_frame_delay(&self) -> usize {
+        match self {
+            SyncingInfo::Online {
+                local_frame_delay, ..
+            } => *local_frame_delay,
+            SyncingInfo::Offline { .. } => 0,
+        }
     }
 }
 
@@ -735,6 +769,8 @@ where
                                         last_confirmed_frame: self.session.confirmed_frame(),
                                         socket: self.socket.clone(),
                                         players_network_stats: players_network_stats.into(),
+                                        local_player_idx: self.local_player_idx as usize,
+                                        local_frame_delay: self.local_input_delay,
                                     });
 
                                     // Disconnected players persisted on session runner, and updated each frame.

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -193,7 +193,7 @@ pub enum SyncingInfo {
         last_confirmed_frame: i32,
         /// Socket
         socket: Socket,
-        /// Networking stats for each connected player, stored at the [player_idx] index for each respective player.
+        /// Networking stats for each connected player, stored at the \[player_idx\] index for each respective player.
         player_network_stats: SVec<PlayerNetworkStats>,
     },
     /// Holds data for an offline session

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -204,6 +204,16 @@ pub enum SyncingInfo {
 }
 
 impl SyncingInfo {
+    /// Checks if the session is online.
+    pub fn is_online(&self) -> bool {
+        matches!(self, SyncingInfo::Online { .. })
+    }
+
+    /// Checks if the session is offline.
+    pub fn is_offline(&self) -> bool {
+        matches!(self, SyncingInfo::Offline { .. })
+    }
+
     /// Getter for the current frame (number).
     pub fn current_frame(&self) -> i32 {
         match self {


### PR DESCRIPTION
This PR covers the following:

1. Exposing player networking info from ggrs -> into an accessible resource for anyone to use.
2. Provide a bunch of helper methods for easily fetching averages/highest/lowest from networking info.
3. Convert `NetworkingInfo` struct to `SyncingInfo` (as discussed previously on discord) which supports both Online/Offline variants and put all fields behind getters. This will allow us to have a standardized interface for implementing EventManager in the future that watches current/last confirmed frame. (Of note this hasn't inserted the offline variant anywhere, as that can wait for the EventManager work itself).