### PR TITLE
feat: Single success systems + helpers

### DIFF
--- a/framework_crates/bones_ecs/src/stage.rs
+++ b/framework_crates/bones_ecs/src/stage.rs
@@ -170,6 +170,27 @@ impl SystemStages {
 
         self
     }
+
+    /// Remove all systems from all stages, including startup and single success systems. Resets has_started as well, allowing for startup systems to run once again.
+    pub fn reset_remove_all_systems(&mut self) {
+        // Reset the has_started flag
+        self.has_started = false;
+        self.remove_all_systems();
+    }
+
+    /// Remove all systems from all stages, including startup and single success systems. Does not reset has_started.
+    pub fn remove_all_systems(&mut self) {
+        // Clear startup systems
+        self.startup_systems.clear();
+
+        // Clear single success systems
+        self.single_success_systems.clear();
+
+        // Clear systems from each stage
+        for stage in &mut self.stages {
+            stage.remove_all_systems();
+        }
+    }
 }
 
 /// Trait for system stages. A stage is a
@@ -183,6 +204,8 @@ pub trait SystemStage: Sync + Send {
 
     /// Add a system to this stage.
     fn add_system(&mut self, system: StaticSystem<(), ()>);
+    /// Remove all systems from this stage.
+    fn remove_all_systems(&mut self);
 }
 
 /// A collection of systems that will be run in order.
@@ -234,6 +257,10 @@ impl SystemStage for SimpleSystemStage {
 
     fn add_system(&mut self, system: StaticSystem<(), ()>) {
         self.systems.push(system);
+    }
+
+    fn remove_all_systems(&mut self) {
+        self.systems.clear();
     }
 }
 

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -163,37 +163,11 @@ impl World {
         self.components.get::<T>().borrow_mut()
     }
 
-    /// Provides an interface for resetting entities, resources, and components.
-    /// Maintains the entities resource if resetting resources but not entities.
-    pub fn reset_internals(
-        &mut self,
-        reset_components: bool,
-        reset_entities: bool,
-        reset_resources: bool,
-    ) {
+    /// Provides an interface for resetting entities, and components.
+    pub fn reset_internals(&mut self, reset_components: bool, reset_entities: bool) {
         if reset_entities {
             let mut entities = self.resource_mut::<Entities>();
             entities.kill_all();
-        }
-
-        if reset_resources {
-            // Temporarily take out the Entities resource if we're not resetting entities
-            let entities = if !reset_entities {
-                self.resources.remove::<Entities>()
-            } else {
-                None
-            };
-
-            // Clear all resources
-            self.resources = Resources::new();
-
-            // If we didn't reset entities, put the Entities resource back
-            if let Some(entities) = entities {
-                self.resources.insert(entities);
-            } else {
-                // If we did reset entities, ensure we have a new Entities resource
-                self.resources.insert(Entities::default());
-            }
         }
 
         if reset_components {

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -146,6 +146,22 @@ impl World {
     pub fn get_resource_mut<T: HasSchema>(&mut self) -> Option<RefMut<T>> {
         self.resources.get_mut()
     }
+
+    /// Borrow a component store from the world.
+    /// # Panics
+    /// Panics if the component store does not exist in the world.
+    #[track_caller]
+    pub fn component<T: HasSchema>(&self) -> Ref<ComponentStore<T>> {
+        self.components.get::<T>().borrow()
+    }
+
+    /// Mutably borrow a component store from the world.
+    /// # Panics
+    /// Panics if the component store does not exist in the world.
+    #[track_caller]
+    pub fn component_mut<T: HasSchema>(&self) -> RefMut<ComponentStore<T>> {
+        self.components.get::<T>().borrow_mut()
+    }
 }
 
 /// Creates an instance of the type this trait is implemented for

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -167,9 +167,9 @@ impl World {
     /// Maintains the entities resource if resetting resources but not entities.
     pub fn reset_internals(
         &mut self,
+        reset_components: bool,
         reset_entities: bool,
         reset_resources: bool,
-        reset_components: bool,
     ) {
         if reset_entities {
             let mut entities = self.resource_mut::<Entities>();

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -185,17 +185,44 @@ pub enum SocketTarget {
 #[schema(no_default)]
 pub struct NetworkInfo {
     /// Current frame of simulation step
-    pub current_frame: i32,
+    current_frame: i32,
 
     /// Last confirmed frame by all clients.
     /// Anything that occurred on this frame is agreed upon by all clients.
-    pub last_confirmed_frame: i32,
+    last_confirmed_frame: i32,
 
     /// Socket
-    pub socket: Socket,
+    socket: Socket,
 
     /// Networking stats for each connected player, stored at the [player_idx] index for each respective player.
-    pub player_network_stats: SVec<PlayerNetworkStats>,
+    player_network_stats: SVec<PlayerNetworkStats>,
+}
+
+impl NetworkInfo {
+    /// Getter for the current frame number.
+    pub fn current_frame(&self) -> i32 {
+        self.current_frame
+    }
+
+    /// Getter for the last confirmed frame.
+    pub fn last_confirmed_frame(&self) -> i32 {
+        self.last_confirmed_frame
+    }
+
+    /// Getter for player_network_stats.
+    pub fn player_network_stats(&self) -> &SVec<PlayerNetworkStats> {
+        &self.player_network_stats
+    }
+
+    /// Getter for socket.
+    pub fn socket(&self) -> Maybe<&Socket> {
+        Maybe::Set(&self.socket)
+    }
+
+    /// Mutable getter for socket.
+    pub fn socket_mut(&mut self) -> Maybe<&mut Socket> {
+        Maybe::Set(&mut self.socket)
+    }
 }
 
 /// Resource tracking which players have been disconnected.

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -193,7 +193,7 @@ pub enum SyncingInfo {
         last_confirmed_frame: i32,
         /// Socket
         socket: Socket,
-        /// Networking stats for each connected player, stored at the [player_idx] index for each respective player.
+        /// Networking stats for each connected player, stored at the \[player_idx\] index for each respective player.
         player_network_stats: SVec<PlayerNetworkStats>,
     },
     /// Holds data for an offline session

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -204,6 +204,16 @@ pub enum SyncingInfo {
 }
 
 impl SyncingInfo {
+    /// Checks if the session is online.
+    pub fn is_online(&self) -> bool {
+        matches!(self, SyncingInfo::Online { .. })
+    }
+
+    /// Checks if the session is offline.
+    pub fn is_offline(&self) -> bool {
+        matches!(self, SyncingInfo::Offline { .. })
+    }
+
     /// Getter for the current frame (number).
     pub fn current_frame(&self) -> i32 {
         match self {

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -104,11 +104,9 @@ impl Session {
         &mut self,
         reset_components: bool,
         reset_entities: bool,
-        reset_resources: bool,
         reset_systems: bool,
     ) {
-        self.world
-            .reset_internals(reset_components, reset_entities, reset_resources);
+        self.world.reset_internals(reset_components, reset_entities);
         if reset_systems {
             self.reset_remove_all_systems();
         }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -92,6 +92,27 @@ impl Session {
     pub fn restore(&mut self, world: &mut World) {
         std::mem::swap(&mut self.world, world)
     }
+
+    /// Set the session runner for this session.
+    pub fn set_session_runner(&mut self, runner: Box<dyn SessionRunner>) {
+        self.runner = runner;
+    }
+
+    /// Provides an interface for resetting various internal parts of the Session.
+    /// Note this does not fully reset the entire Session.
+    pub fn reset_internals(
+        &mut self,
+        reset_entities: bool,
+        reset_resources: bool,
+        reset_components: bool,
+        reset_systems: bool,
+    ) {
+        self.world
+            .reset_internals(reset_entities, reset_resources, reset_components);
+        if reset_systems {
+            self.reset_remove_all_systems();
+        }
+    }
 }
 
 impl Default for Session {

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -102,13 +102,13 @@ impl Session {
     /// Note this does not fully reset the entire Session.
     pub fn reset_internals(
         &mut self,
+        reset_components: bool,
         reset_entities: bool,
         reset_resources: bool,
-        reset_components: bool,
         reset_systems: bool,
     ) {
         self.world
-            .reset_internals(reset_entities, reset_resources, reset_components);
+            .reset_internals(reset_components, reset_entities, reset_resources);
         if reset_systems {
             self.reset_remove_all_systems();
         }


### PR DESCRIPTION
This PR includes:
- Implementing a "single success system" flow, which allows a user to write a system that keeps trying to run every frame until it succeeds. This is handy for a bunch of use cases that were less friendly to write as always-on systems. Implemented with output `Option<()>` type to allow for users to take advantage of `?` when calling various getter methods.
- Adds easier access to components from `World`
- Adds methods for removing all systems, providing more flexibility of managing a session from within it