### PR TITLE
feat: single & first entity queries (take 2)

### DIFF
--- a/framework_crates/bones_ecs/src/components/iterator.rs
+++ b/framework_crates/bones_ecs/src/components/iterator.rs
@@ -38,13 +38,13 @@ impl<'a> Iterator for UntypedComponentBitsetIterator<'a> {
     type Item = SchemaRef<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let max_id = self.components.max_id;
-        while !(self.bitset.bit_test(self.current_id)
-            && self.components.bitset.bit_test(self.current_id))
-            && self.current_id <= max_id
+        while self.current_id < max_id
+            && !(self.bitset.bit_test(self.current_id)
+                && self.components.bitset.bit_test(self.current_id))
         {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             Some(unsafe {
                 SchemaRef::from_ptr_schema(
@@ -71,11 +71,11 @@ impl<'a> Iterator for UntypedComponentOptionalBitsetIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         // We stop iterating at bitset length, not component store length, as we want to iterate over
         // whole bitset and return None for entities that don't have this optional component.
-        let max_id = self.bitset.bit_len() - 1;
-        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+        let max_id = self.bitset.bit_len();
+        while self.current_id < max_id && !self.bitset.bit_test(self.current_id) {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             if self.components.bitset.bit_test(self.current_id) {
                 Some(Some(unsafe {
@@ -110,13 +110,13 @@ impl<'a> Iterator for UntypedComponentBitsetIteratorMut<'a> {
     type Item = SchemaRefMut<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let max_id = self.components.max_id;
-        while !(self.bitset.bit_test(self.current_id)
-            && self.components.bitset.bit_test(self.current_id))
-            && self.current_id <= max_id
+        while self.current_id < max_id
+            && !(self.bitset.bit_test(self.current_id)
+                && self.components.bitset.bit_test(self.current_id))
         {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: We know that the index is within bounds, and we know that the pointer will be
             // valid for the new lifetime.
             Some(unsafe {
@@ -144,11 +144,11 @@ impl<'a> Iterator for UntypedComponentOptionalBitsetIteratorMut<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         // We do not stop iterating at component store length, as we want to iterate over
         // whole bitset and return None for entities that don't have this optional component.
-        let max_id = self.bitset.bit_len() - 1;
-        while !self.bitset.bit_test(self.current_id) && self.current_id <= max_id {
+        let max_id = self.bitset.bit_len();
+        while self.current_id < max_id && !self.bitset.bit_test(self.current_id) {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= max_id {
+        let ret = if self.current_id < max_id {
             // SAFE: Here we are just getting a pointer, not doing anything unsafe with it.
             if self.components.bitset.bit_test(self.current_id) {
                 Some(Some(unsafe {

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -161,7 +161,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
     fn get_single_with_bitset(&self, bitset: Rc<BitSetVec>) -> Result<&T, QuerySingleError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_with_bitset_mut(
+    fn get_single_mut_with_bitset(
         &mut self,
         bitset: Rc<BitSetVec>,
     ) -> Result<&mut T, QuerySingleError>;
@@ -213,7 +213,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_with_bitset_mut(
+    fn get_single_mut_with_bitset(
         &mut self,
         bitset: Rc<BitSetVec>,
     ) -> Result<&mut T, QuerySingleError> {

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -111,7 +111,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets an immutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single(&self) -> Option<&T> {
+    pub fn get_single(&self) -> Result<&T, QueryItemError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single()
@@ -120,7 +120,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single_mut(&mut self) -> Option<&mut T> {
+    pub fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single_mut()
@@ -155,10 +155,10 @@ impl<T: HasSchema> ComponentStore<T> {
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Option<&T>;
+    fn get_single(&self) -> Result<&T, QueryItemError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Option<&mut T>;
+    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError>;
 
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
@@ -198,7 +198,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Option<&T> {
+    fn get_single(&self) -> Result<&T, QueryItemError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRef) -> &T {
             unsafe { r.cast_into_unchecked() }
@@ -207,7 +207,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Option<&mut T> {
+    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
@@ -343,7 +343,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, None);
+        assert_eq!(maybe_comp, Err(QueryItemError::NoEntities));
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Some(&a));
+        assert_eq!(maybe_comp, Ok(&a));
     }
 
     #[test]
@@ -374,6 +374,6 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, None);
+        assert_eq!(maybe_comp, Err(QueryItemError::MultipleEntities));
     }
 }

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -82,7 +82,7 @@ impl<T: HasSchema> ComponentStore<T> {
         self.untyped.get_mut_or_insert(entity, f)
     }
 
-    /// Get mutable references s to the component data for multiple entities at the same time.
+    /// Get mutable references to the component data for multiple entities at the same time.
     ///
     /// # Panics
     ///
@@ -206,7 +206,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     #[inline]
     fn iter_mut_with_bitset(&mut self, bitset: Rc<BitSetVec>) -> ComponentBitsetIteratorMut<T> {
         // SOUND: we know the schema matches.
-        fn map<T>(r: SchemaRefMut<'_>) -> &mut T {
+        fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
         }
 

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -109,6 +109,24 @@ impl<T: HasSchema> ComponentStore<T> {
         self.untyped.remove(entity)
     }
 
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    #[inline]
+    pub fn get_single(&self) -> Option<&T> {
+        // SOUND: we know the schema matches.
+        self.untyped
+            .get_single()
+            .map(|x| unsafe { x.cast_into_unchecked() })
+    }
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    #[inline]
+    pub fn get_single_mut(&mut self) -> Option<&mut T> {
+        // SOUND: we know the schema matches.
+        self.untyped
+            .get_single_mut()
+            .map(|x| unsafe { x.cast_into_mut_unchecked() })
+    }
+
     /// Iterates immutably over all components of this type.
     /// Very fast but doesn't allow joining with other component types.
     #[inline]
@@ -136,6 +154,12 @@ impl<T: HasSchema> ComponentStore<T> {
 ///
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    fn get_single(&self) -> Option<&T>;
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    fn get_single_mut(&mut self) -> Option<&mut T>;
+
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.
@@ -173,6 +197,24 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 }
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
+    /// Gets an immutable reference to the component if there is exactly one instance of it.
+    fn get_single(&self) -> Option<&T> {
+        // SOUND: we know the schema matches.
+        fn map<T>(r: SchemaRef) -> &T {
+            unsafe { r.cast_into_unchecked() }
+        }
+        self.untyped.get_single().map(map)
+    }
+
+    /// Gets a mutable reference to the component if there is exactly one instance of it.
+    fn get_single_mut(&mut self) -> Option<&mut T> {
+        // SOUND: we know the schema matches.
+        fn map<T>(r: SchemaRefMut) -> &mut T {
+            unsafe { r.cast_into_mut_unchecked() }
+        }
+        self.untyped.get_single_mut().map(map)
+    }
+
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
     /// Slower than `iter()` but allows joining between multiple component types.

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -111,7 +111,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets an immutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single(&self) -> Result<&T, QueryItemError> {
+    pub fn get_single(&self) -> Result<&T, QuerySingleError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single()
@@ -120,7 +120,7 @@ impl<T: HasSchema> ComponentStore<T> {
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
     #[inline]
-    pub fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
+    pub fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError> {
         // SOUND: we know the schema matches.
         self.untyped
             .get_single_mut()
@@ -155,10 +155,10 @@ impl<T: HasSchema> ComponentStore<T> {
 /// Automatically implemented for [`ComponentStore`].
 pub trait ComponentIterBitset<'a, T: HasSchema> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Result<&T, QueryItemError>;
+    fn get_single(&self) -> Result<&T, QuerySingleError>;
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError>;
+    fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError>;
 
     /// Iterates immutably over the components of this type where `bitset`
     /// indicates the indices of entities.
@@ -198,7 +198,7 @@ pub trait ComponentIterBitset<'a, T: HasSchema> {
 
 impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     /// Gets an immutable reference to the component if there is exactly one instance of it.
-    fn get_single(&self) -> Result<&T, QueryItemError> {
+    fn get_single(&self) -> Result<&T, QuerySingleError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRef) -> &T {
             unsafe { r.cast_into_unchecked() }
@@ -207,7 +207,7 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
     }
 
     /// Gets a mutable reference to the component if there is exactly one instance of it.
-    fn get_single_mut(&mut self) -> Result<&mut T, QueryItemError> {
+    fn get_single_mut(&mut self) -> Result<&mut T, QuerySingleError> {
         // SOUND: we know the schema matches.
         fn map<T>(r: SchemaRefMut) -> &mut T {
             unsafe { r.cast_into_mut_unchecked() }
@@ -345,7 +345,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Err(QueryItemError::NoEntities));
+        assert_eq!(maybe_comp, Err(QuerySingleError::NoEntities));
     }
 
     #[test]
@@ -376,7 +376,7 @@ mod tests {
 
         let maybe_comp = storage.get_single();
 
-        assert_eq!(maybe_comp, Err(QueryItemError::MultipleEntities));
+        assert_eq!(maybe_comp, Err(QuerySingleError::MultipleEntities));
     }
 
     #[test]

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,28 +492,28 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Option<SchemaRef> {
+    pub fn get_single(&self) -> Result<SchemaRef, QueryItemError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next()?;
+        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
         if iter.next().is_some() {
-            return None;
+            return Err(QueryItemError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx(i)
+        self.get_idx(i).ok_or(QueryItemError::NoEntities)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
+    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QueryItemError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next()?;
+        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
         if iter.next().is_some() {
-            return None;
+            return Err(QueryItemError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx_mut(i)
+        self.get_idx_mut(i).ok_or(QueryItemError::NoEntities)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -491,6 +491,25 @@ impl UntypedComponentStore {
         }
     }
 
+    /// Get a reference to the component store if there is exactly one instance of the component.
+    pub fn get_single(&self) -> Option<SchemaRef> {
+        if self.bitset().bit_count() == 1 {
+            self.get_idx(0)
+        } else {
+            None
+        }
+    }
+
+    /// Get a mutable reference to the component store if there is exactly one instance of the
+    /// component.
+    pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
+        if self.bitset().bit_count() == 1 {
+            self.get_idx_mut(0)
+        } else {
+            None
+        }
+    }
+
     /// Iterates immutably over all components of this type.
     ///
     /// Very fast but doesn't allow joining with other component types.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,28 +492,28 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Result<SchemaRef, QueryItemError> {
+    pub fn get_single(&self) -> Result<SchemaRef, QuerySingleError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
+        let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
-            return Err(QueryItemError::MultipleEntities);
+            return Err(QuerySingleError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx(i).ok_or(QueryItemError::NoEntities)
+        self.get_idx(i).ok_or(QuerySingleError::NoEntities)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QueryItemError> {
+    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QuerySingleError> {
         let len = self.bitset().bit_len();
         let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
-        let i = iter.next().ok_or(QueryItemError::NoEntities)?;
+        let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
-            return Err(QueryItemError::MultipleEntities);
+            return Err(QuerySingleError::MultipleEntities);
         }
         // TODO: add unchecked variant to avoid redundant validation
-        self.get_idx_mut(i).ok_or(QueryItemError::NoEntities)
+        self.get_idx_mut(i).ok_or(QuerySingleError::NoEntities)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -492,9 +492,12 @@ impl UntypedComponentStore {
     }
 
     /// Get a reference to the component store if there is exactly one instance of the component.
-    pub fn get_single(&self) -> Result<SchemaRef, QuerySingleError> {
+    pub fn get_single_with_bitset(
+        &self,
+        bitset: Rc<BitSetVec>,
+    ) -> Result<SchemaRef, QuerySingleError> {
         let len = self.bitset().bit_len();
-        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let mut iter = (0..len).filter(|&i| bitset.bit_test(i) && self.bitset().bit_test(i));
         let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
             return Err(QuerySingleError::MultipleEntities);
@@ -505,9 +508,12 @@ impl UntypedComponentStore {
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
-    pub fn get_single_mut(&mut self) -> Result<SchemaRefMut, QuerySingleError> {
+    pub fn get_single_with_bitset_mut(
+        &mut self,
+        bitset: Rc<BitSetVec>,
+    ) -> Result<SchemaRefMut, QuerySingleError> {
         let len = self.bitset().bit_len();
-        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let mut iter = (0..len).filter(|&i| bitset.bit_test(i) && self.bitset().bit_test(i));
         let i = iter.next().ok_or(QuerySingleError::NoEntities)?;
         if iter.next().is_some() {
             return Err(QuerySingleError::MultipleEntities);

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -493,21 +493,27 @@ impl UntypedComponentStore {
 
     /// Get a reference to the component store if there is exactly one instance of the component.
     pub fn get_single(&self) -> Option<SchemaRef> {
-        if self.bitset().bit_count() == 1 {
-            self.get_idx(0)
-        } else {
-            None
+        let len = self.bitset().bit_len();
+        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let i = iter.next()?;
+        if iter.next().is_some() {
+            return None;
         }
+        // TODO: add unchecked variant to avoid redundant validation
+        self.get_idx(i)
     }
 
     /// Get a mutable reference to the component store if there is exactly one instance of the
     /// component.
     pub fn get_single_mut(&mut self) -> Option<SchemaRefMut> {
-        if self.bitset().bit_count() == 1 {
-            self.get_idx_mut(0)
-        } else {
-            None
+        let len = self.bitset().bit_len();
+        let mut iter = (0..len).filter(|&i| self.bitset().bit_test(i));
+        let i = iter.next()?;
+        if iter.next().is_some() {
+            return None;
         }
+        // TODO: add unchecked variant to avoid redundant validation
+        self.get_idx_mut(i)
     }
 
     /// Iterates immutably over all components of this type.

--- a/framework_crates/bones_ecs/src/components/untyped.rs
+++ b/framework_crates/bones_ecs/src/components/untyped.rs
@@ -296,12 +296,10 @@ impl UntypedComponentStore {
         entity: Entity,
         f: impl FnOnce() -> T,
     ) -> &mut T {
-        if self.bitset.bit_test(entity.index() as usize) {
-            return self.get_mut(entity).unwrap();
-        } else {
+        if !self.bitset.bit_test(entity.index() as usize) {
             self.insert(entity, f());
-            self.get_mut(entity).unwrap()
         }
+        self.get_mut(entity).unwrap()
     }
 
     /// Get a [`SchemaRefMut`] to the component for the given [`Entity`]
@@ -601,9 +599,8 @@ impl<'a> Iterator for UntypedComponentStoreIter<'a> {
                 if let Some(ptr) = self.store.get_idx(self.idx) {
                     self.idx += 1;
                     break Some(ptr);
-                } else {
-                    self.idx += 1;
                 }
+                self.idx += 1;
             } else {
                 break None;
             }
@@ -628,9 +625,8 @@ impl<'a> Iterator for UntypedComponentStoreIterMut<'a> {
                     break Some(unsafe {
                         SchemaRefMut::from_ptr_schema(ptr.as_ptr(), ptr.schema())
                     });
-                } else {
-                    self.idx += 1;
                 }
+                self.idx += 1;
             } else {
                 break None;
             }

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -491,6 +491,40 @@ impl Entities {
             .map(|item| (entity, item))
     }
 
+    /// Get the first entity in the given bitset.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if there are no entities in the bitset.
+    pub fn first_with_bitset(&self, bitset: &BitSetVec) -> Entity {
+        self.get_first_with_bitset(bitset).unwrap()
+    }
+
+    /// Get the first entity in the given bitset.
+    pub fn get_first_with_bitset(&self, bitset: &BitSetVec) -> Option<Entity> {
+        self.iter_with_bitset(bitset).next()
+    }
+
+    /// Get the first entity and components in the given query.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if there are no entities that match the query.
+    pub fn first_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> (Entity, <<Q as QueryItem>::Iter as Iterator>::Item) {
+        self.get_first_with(query).unwrap()
+    }
+
+    /// Get the first entity and components in the given query.
+    pub fn get_first_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> Option<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item)> {
+        self.iter_with(query).next()
+    }
+
     /// Iterates over entities using the provided bitset.
     pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
         EntityIterator {

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -455,6 +455,19 @@ impl<'a, I: Iterator> Iterator for EntitiesIterWith<'a, I> {
 impl Entities {
     /// Get a single entity and components in the given query if there is exactly one entity
     /// matching the query.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the number of matching entities is not *exactly one*.
+    pub fn single_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> (Entity, <<Q as QueryItem>::Iter as Iterator>::Item) {
+        self.get_single_with(query).unwrap()
+    }
+
+    /// Get a single entity and components in the given query if there is exactly one entity
+    /// matching the query.
     pub fn get_single_with<Q: QueryItem>(
         &self,
         query: Q,

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -102,8 +102,9 @@ pub trait QueryItem {
 }
 
 /// An error that may occur when querying for a single entity. For example, via
-/// [`Entities::get_single_with`], or more directly with [`ComponentStore::get_single`] or
-/// [`ComponentStore::get_single_mut`].
+/// [`Entities::get_single_with`], or more directly with
+/// [`ComponentStore::get_single_with_bitset`] or
+/// [`ComponentStore::get_single_mut_with_bitset`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum QuerySingleError {
     /// No entity matches the query.

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -96,9 +96,17 @@ pub trait QueryItem {
     fn get_single_with_bitset(
         self,
         bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item>;
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError>;
     /// Return an iterator over the provided bitset.
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum QueryItemError {
+    /// No entity matches the query.
+    NoEntities,
+    /// More than one entity matches the query.
+    MultipleEntities,
 }
 
 /// Wrapper for the [`Comp`] [`SystemParam`] used as [`QueryItem`] to iterate
@@ -178,7 +186,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
         ComponentStore::get_single(&**self)
     }
 
@@ -197,7 +205,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
         ComponentStore::get_single(&**self)
     }
 
@@ -216,7 +224,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
         ComponentStore::get_single_mut(self)
     }
 
@@ -239,9 +247,8 @@ where
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item> {
-        // TODO: is `Option<Option<&T>>` the correct return type?
-        Some(self.0.get_single())
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+        self.0.get_single().map(Some)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -262,9 +269,9 @@ where
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Option<<Self::Iter as Iterator>::Item> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
         // TODO: is `Option<Option<&T>>` the correct return type?
-        Some(self.0.get_single_mut())
+        self.0.get_single_mut().map(Some)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -350,7 +357,7 @@ macro_rules! impl_query {
             fn get_single_with_bitset(
                 self,
                 bitset: Rc<BitSetVec>,
-            ) -> Option<<Self::Iter as Iterator>::Item> {
+            ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
                 let (
                     $(
                         $args,
@@ -366,8 +373,8 @@ macro_rules! impl_query {
                 let first = query.next();
                 let has_second = query.next().is_some();
                 match (first, has_second) {
-                    (items @ Some(_), false) => items,
-                    _ => None,
+                    (Some(items), false) => Ok(items),
+                    _ => Err(QueryItemError::MultipleEntities),
                 }
             }
 
@@ -441,15 +448,15 @@ impl Entities {
     pub fn get_single_with<Q: QueryItem>(
         &self,
         query: Q,
-    ) -> Option<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item)> {
+    ) -> Result<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item), QueryItemError> {
         let mut bitset = self.bitset().clone();
         query.apply_bitset(&mut bitset);
 
         let entity = {
             let mut ids = (0..self.next_id).filter(|&i| bitset.bit_test(i));
-            let id = ids.next()?;
+            let id = ids.next().ok_or(QueryItemError::NoEntities)?;
             if ids.next().is_some() {
-                return None;
+                return Err(QueryItemError::MultipleEntities);
             }
             Entity::new(id as u32, self.generation[id])
         };
@@ -833,7 +840,7 @@ mod tests {
         let mut state = Arc::new(AtomicCell::new(storage));
         let comp = <Comp<A> as SystemParam>::borrow(&world, &mut state);
 
-        assert_eq!(entities.get_single_with(&comp), Some((e, &a)));
+        assert_eq!(entities.get_single_with(&comp), Ok((e, &a)));
     }
 
     #[test]
@@ -866,7 +873,7 @@ mod tests {
             let comp_b = <Comp<B> as SystemParam>::borrow(&world, &mut state_b);
             assert_eq!(
                 entities.get_single_with((&comp_a, &comp_b)),
-                Some((e4, (&a4, &b4)))
+                Ok((e4, (&a4, &b4)))
             );
         }
 
@@ -875,11 +882,11 @@ mod tests {
             let mut comp_b = <CompMut<B> as SystemParam>::borrow(&world, &mut state_b);
             assert_eq!(
                 entities.get_single_with((&comp_a, &comp_b)),
-                Some((e4, (&a4, &b4)))
+                Ok((e4, (&a4, &b4)))
             );
             assert_eq!(
                 entities.get_single_with((&mut comp_a, &mut comp_b)),
-                Some((e4, (&mut a4, &mut b4)))
+                Ok((e4, (&mut a4, &mut b4)))
             );
         }
     }

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -383,8 +383,9 @@ macro_rules! impl_query {
                 let first = query.next();
                 let has_second = query.next().is_some();
                 match (first, has_second) {
+                    (None, _) => Err(QuerySingleError::NoEntities),
                     (Some(items), false) => Ok(items),
-                    _ => Err(QuerySingleError::MultipleEntities),
+                    (Some(_), true) => Err(QuerySingleError::MultipleEntities),
                 }
             }
 

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[test]
-    fn entities__get_single__with_one_required() {
+    fn entities__get_single__with_one_required__ok() {
         let mut entities = Entities::default();
         (0..3).map(|_| entities.create()).count();
         let e = entities.create();
@@ -1041,6 +1041,39 @@ mod tests {
         let comp = state.borrow();
 
         assert_eq!(entities.get_single_with(&comp), Ok((e, &a)));
+    }
+
+    #[test]
+    fn entities__get_single__with_one_required__none() {
+        let mut entities = Entities::default();
+        (0..3).map(|_| entities.create()).count();
+
+        let state = AtomicCell::new(ComponentStore::<A>::default());
+        let comp = state.borrow();
+
+        assert_eq!(
+            entities.get_single_with(&comp),
+            Err(QuerySingleError::NoEntities)
+        );
+    }
+
+    #[test]
+    fn entities__get_single__with_one_required__too_many() {
+        let mut entities = Entities::default();
+        let state = AtomicCell::new(ComponentStore::<A>::default());
+
+        for i in 0..3 {
+            let e = entities.create();
+            let a = A(i.to_string());
+            state.borrow_mut().insert(e, a.clone());
+        }
+
+        let comp = state.borrow();
+
+        assert_eq!(
+            entities.get_single_with(&comp),
+            Err(QuerySingleError::MultipleEntities)
+        );
     }
 
     #[test]

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -749,6 +749,8 @@ impl<'a> Iterator for EntityIterator<'a> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_snake_case)]
+
     use std::collections::HashSet;
 
     use crate::prelude::*;
@@ -762,7 +764,7 @@ mod tests {
     struct B(String);
 
     #[test]
-    fn create_kill_entities() {
+    fn entities__create_kill() {
         let mut entities = Entities::default();
         let e1 = entities.create();
         let e2 = entities.create();
@@ -790,7 +792,7 @@ mod tests {
     }
 
     #[test]
-    fn test_interleaved_create_kill() {
+    fn entities__interleaved_create_kill() {
         let mut entities = Entities::default();
 
         let e1 = entities.create();
@@ -814,7 +816,7 @@ mod tests {
 
     #[test]
     /// Exercise basic operations on entities to increase code coverage
-    fn clone_debug_hash() {
+    fn entities__clone_debug_hash() {
         let mut entities = Entities::default();
         let e1 = entities.create();
         // Clone
@@ -831,7 +833,7 @@ mod tests {
     ///
     /// Exercises a code path not tested according to code coverage.
     #[test]
-    fn force_generate_next_section() {
+    fn entities__force_generate_next_section() {
         let mut entities = Entities::default();
         // Create enough entities to fil up the first section of the bitset
         for _ in 0..256 {
@@ -848,7 +850,7 @@ mod tests {
     #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
-    fn force_max_entity_panic() {
+    fn entities__force_max_entity_panic() {
         let mut entities = Entities::default();
         for _ in 0..(BITSET_SIZE + 1) {
             entities.create();
@@ -858,7 +860,7 @@ mod tests {
     #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
-    fn force_max_entity_panic2() {
+    fn entities__force_max_entity_panic2() {
         let mut entities = Entities::default();
         let mut e = None;
         for _ in 0..BITSET_SIZE {
@@ -871,7 +873,7 @@ mod tests {
     }
 
     #[test]
-    fn iter_with_empty_bitset() {
+    fn entities__iter_with_empty_bitset() {
         let mut entities = Entities::default();
 
         // Create a couple entities
@@ -884,7 +886,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_one_component() {
+    fn entities__get_single__with_one_required() {
         let mut entities = Entities::default();
         (0..3).map(|_| entities.create()).count();
         let e = entities.create();
@@ -899,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_two_components() {
+    fn entities__get_single__with_multiple_required() {
         let mut entities = Entities::default();
 
         let state_a = AtomicCell::new(ComponentStore::<A>::default());
@@ -928,7 +930,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_optional_component() {
+    fn entities__get_single__with_one_optional() {
         let mut entities = Entities::default();
         let state = AtomicCell::new(ComponentStore::<A>::default());
 
@@ -969,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn get_single_with_optional_and_non_optional_components() {
+    fn entities__get_single__with_required_and_optional() {
         let mut entities = Entities::default();
         let state_a = AtomicCell::new(ComponentStore::<A>::default());
         let state_b = AtomicCell::new(ComponentStore::<B>::default());

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -277,7 +277,7 @@ where
         self,
         bitset: Rc<BitSetVec>,
     ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
-        match self.0.get_single_with_bitset_mut(bitset) {
+        match self.0.get_single_mut_with_bitset(bitset) {
             Ok(x) => Ok(Some(x)),
             Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -363,6 +363,17 @@ impl<'a, I: Iterator> Iterator for EntitiesIterWith<'a, I> {
 }
 
 impl Entities {
+    /// Iterates over entities using the provided bitset.
+    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
+        EntityIterator {
+            current_id: 0,
+            next_id: self.next_id,
+            entities: &self.alive,
+            generations: &self.generation,
+            bitset,
+        }
+    }
+
     /// Iterate over the entities and components in the given query.
     ///
     /// The [`QueryItem`] trait is automatically implemented for references to [`Comp`] and
@@ -529,17 +540,6 @@ impl Entities {
     /// Useful for joining over [`Entity`] and [`ComponentStore<T>`] at the same time.
     pub fn bitset(&self) -> &BitSetVec {
         &self.alive
-    }
-
-    /// Iterates over entities using the provided bitset.
-    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
-        EntityIterator {
-            current_id: 0,
-            next_id: self.next_id,
-            entities: &self.alive,
-            generations: &self.generation,
-            bitset,
-        }
     }
 
     /// Iterates over all alive entities.

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -171,8 +171,16 @@ where
 
 impl<'a> QueryItem for &'a Ref<'a, UntypedComponentStore> {
     type Iter = UntypedComponentBitsetIterator<'a>;
+
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
         bitset.bit_and(self.bitset());
+    }
+
+    fn get_single_with_bitset(
+        self,
+        bitset: Rc<BitSetVec>,
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
+        UntypedComponentStore::get_single_with_bitset(self, bitset)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -91,6 +91,12 @@ pub trait QueryItem {
     type Iter: Iterator;
     /// Modify the iteration bitset
     fn apply_bitset(&self, bitset: &mut BitSetVec);
+    /// Return the item that matches the query within the given bitset if there is exactly one
+    /// entity that matches this query item.
+    fn get_single_with_bitset(
+        self,
+        bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item>;
     /// Return an iterator over the provided bitset.
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter;
 }
@@ -164,8 +170,16 @@ impl<'a> QueryItem for &'a Ref<'a, UntypedComponentStore> {
 
 impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
     type Iter = ComponentBitsetIterator<'a, T>;
+
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
         bitset.bit_and(self.bitset());
+    }
+
+    fn get_single_with_bitset(
+        self,
+        _bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item> {
+        ComponentStore::get_single(&**self)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -175,8 +189,16 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
 
 impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
     type Iter = ComponentBitsetIterator<'a, T>;
+
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
         bitset.bit_and(self.bitset());
+    }
+
+    fn get_single_with_bitset(
+        self,
+        _bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item> {
+        ComponentStore::get_single(&**self)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -186,8 +208,16 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
 
 impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
     type Iter = ComponentBitsetIteratorMut<'a, T>;
+
     fn apply_bitset(&self, bitset: &mut BitSetVec) {
         bitset.bit_and(self.bitset());
+    }
+
+    fn get_single_with_bitset(
+        self,
+        _bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item> {
+        ComponentStore::get_single_mut(self)
     }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
@@ -203,7 +233,16 @@ where
     S: std::ops::Deref<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIterator<'a, T>;
+
     fn apply_bitset(&self, _bitset: &mut BitSetVec) {}
+
+    fn get_single_with_bitset(
+        self,
+        _bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item> {
+        // TODO: is `Option<Option<&T>>` the correct return type?
+        Some(self.0.get_single())
+    }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
         self.0.iter_with_bitset_optional(bitset)
@@ -217,7 +256,16 @@ where
     S: std::ops::DerefMut<Target = C> + 'a,
 {
     type Iter = ComponentBitsetOptionalIteratorMut<'a, T>;
+
     fn apply_bitset(&self, _bitset: &mut BitSetVec) {}
+
+    fn get_single_with_bitset(
+        self,
+        _bitset: Rc<BitSetVec>,
+    ) -> Option<<Self::Iter as Iterator>::Item> {
+        // TODO: is `Option<Option<&T>>` the correct return type?
+        Some(self.0.get_single_mut())
+    }
 
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
         self.0.iter_mut_with_bitset_optional(bitset)
@@ -299,6 +347,31 @@ macro_rules! impl_query {
             }
 
             #[allow(non_snake_case)]
+            fn get_single_with_bitset(
+                self,
+                bitset: Rc<BitSetVec>,
+            ) -> Option<<Self::Iter as Iterator>::Item> {
+                let (
+                    $(
+                        $args,
+                    )*
+                ) = self;
+                let mut query = MultiQueryIter {
+                    data: (
+                        $(
+                            $args.iter_with_bitset(bitset.clone()),
+                        )*
+                    )
+                };
+                let first = query.next();
+                let has_second = query.next().is_some();
+                match (first, has_second) {
+                    (items @ Some(_), false) => items,
+                    _ => None,
+                }
+            }
+
+            #[allow(non_snake_case)]
             fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter {
                 let (
                     $(
@@ -363,6 +436,31 @@ impl<'a, I: Iterator> Iterator for EntitiesIterWith<'a, I> {
 }
 
 impl Entities {
+    /// Get a single entity and components in the given query if there is exactly one entity
+    /// matching the query.
+    pub fn get_single_with<Q: QueryItem>(
+        &self,
+        query: Q,
+    ) -> Option<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item)> {
+        let mut bitset = self.bitset().clone();
+        query.apply_bitset(&mut bitset);
+
+        let entity = {
+            let mut ids = (0..self.next_id).filter(|&i| bitset.bit_test(i));
+            let id = ids.next()?;
+            if ids.next().is_some() {
+                return None;
+            }
+            Entity::new(id as u32, self.generation[id])
+        };
+
+        let bitset = Rc::new(bitset);
+
+        query
+            .get_single_with_bitset(bitset)
+            .map(|item| (entity, item))
+    }
+
     /// Iterates over entities using the provided bitset.
     pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
         EntityIterator {

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -96,13 +96,16 @@ pub trait QueryItem {
     fn get_single_with_bitset(
         self,
         bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError>;
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError>;
     /// Return an iterator over the provided bitset.
     fn iter_with_bitset(self, bitset: Rc<BitSetVec>) -> Self::Iter;
 }
 
+/// An error that may occur when querying for a single entity. For example, via
+/// [`Entities::get_single_with`], or more directly with [`ComponentStore::get_single`] or
+/// [`ComponentStore::get_single_mut`].
 #[derive(Debug, PartialEq, Eq)]
-pub enum QueryItemError {
+pub enum QuerySingleError {
     /// No entity matches the query.
     NoEntities,
     /// More than one entity matches the query.
@@ -186,7 +189,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a Comp<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
         ComponentStore::get_single(&**self)
     }
 
@@ -205,7 +208,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a CompMut<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
         ComponentStore::get_single(&**self)
     }
 
@@ -224,7 +227,7 @@ impl<'a, 'q, T: HasSchema> QueryItem for &'a mut CompMut<'q, T> {
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
         ComponentStore::get_single_mut(self)
     }
 
@@ -247,10 +250,10 @@ where
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
         match self.0.get_single() {
             Ok(single) => Ok(Some(single)),
-            Err(QueryItemError::NoEntities) => Ok(None),
+            Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -273,10 +276,10 @@ where
     fn get_single_with_bitset(
         self,
         _bitset: Rc<BitSetVec>,
-    ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+    ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
         match self.0.get_single_mut() {
             Ok(x) => Ok(Some(x)),
-            Err(QueryItemError::NoEntities) => Ok(None),
+            Err(QuerySingleError::NoEntities) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -364,7 +367,7 @@ macro_rules! impl_query {
             fn get_single_with_bitset(
                 self,
                 bitset: Rc<BitSetVec>,
-            ) -> Result<<Self::Iter as Iterator>::Item, QueryItemError> {
+            ) -> Result<<Self::Iter as Iterator>::Item, QuerySingleError> {
                 let (
                     $(
                         $args,
@@ -381,7 +384,7 @@ macro_rules! impl_query {
                 let has_second = query.next().is_some();
                 match (first, has_second) {
                     (Some(items), false) => Ok(items),
-                    _ => Err(QueryItemError::MultipleEntities),
+                    _ => Err(QuerySingleError::MultipleEntities),
                 }
             }
 
@@ -455,15 +458,15 @@ impl Entities {
     pub fn get_single_with<Q: QueryItem>(
         &self,
         query: Q,
-    ) -> Result<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item), QueryItemError> {
+    ) -> Result<(Entity, <<Q as QueryItem>::Iter as Iterator>::Item), QuerySingleError> {
         let mut bitset = self.bitset().clone();
         query.apply_bitset(&mut bitset);
 
         let entity = {
             let mut ids = (0..self.next_id).filter(|&i| bitset.bit_test(i));
-            let id = ids.next().ok_or(QueryItemError::NoEntities)?;
+            let id = ids.next().ok_or(QuerySingleError::NoEntities)?;
             if ids.next().is_some() {
-                return Err(QueryItemError::MultipleEntities);
+                return Err(QuerySingleError::MultipleEntities);
             }
             Entity::new(id as u32, self.generation[id])
         };

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -751,7 +751,7 @@ impl<'a> Iterator for EntityIterator<'a> {
 mod tests {
     #![allow(non_snake_case)]
 
-    use std::collections::HashSet;
+    use std::{collections::HashSet, rc::Rc};
 
     use crate::prelude::*;
 
@@ -762,6 +762,119 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
     #[repr(C)]
     struct B(String);
+
+    #[test]
+    fn query_item__get_single_with_one_required() {
+        let mut entities = Entities::default();
+        let state = AtomicCell::new(ComponentStore::<A>::default());
+
+        {
+            let comp = state.borrow_mut();
+            let query = &comp;
+
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Err(QuerySingleError::NoEntities));
+        }
+
+        {
+            let mut comp = state.borrow_mut();
+
+            let e = entities.create();
+            let a = A("e".to_string());
+            comp.insert(e, a.clone());
+
+            let query = &comp;
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Ok(&a));
+
+            entities.kill(e);
+        }
+
+        {
+            let mut comp = state.borrow_mut();
+
+            let e1 = entities.create();
+            comp.insert(e1, A("e1".to_string()));
+
+            let e2 = entities.create();
+            comp.insert(e2, A("e2".to_string()));
+
+            let query = &comp;
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Err(QuerySingleError::MultipleEntities));
+
+            entities.kill(e1);
+            entities.kill(e2);
+        }
+    }
+
+    #[test]
+    fn query_item__get_single_with_multiple_required() {
+        let mut entities = Entities::default();
+        let state_a = AtomicCell::new(ComponentStore::<A>::default());
+        let state_b = AtomicCell::new(ComponentStore::<B>::default());
+
+        {
+            let query = (&state_a.borrow(), &state_b.borrow());
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Err(QuerySingleError::NoEntities));
+        }
+
+        {
+            let e = entities.create();
+            let a = A("e".to_string());
+            let b = B("e".to_string());
+            state_a.borrow_mut().insert(e, a.clone());
+            state_b.borrow_mut().insert(e, b.clone());
+
+            let query = (&state_a.borrow(), &state_b.borrow());
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Ok((&a, &b)));
+
+            entities.kill(e);
+        }
+
+        {
+            let e1 = entities.create();
+            state_a.borrow_mut().insert(e1, A("e1".to_string()));
+            state_b.borrow_mut().insert(e1, B("e1".to_string()));
+
+            let e2 = entities.create();
+            state_a.borrow_mut().insert(e2, A("e2".to_string()));
+            state_b.borrow_mut().insert(e2, B("e2".to_string()));
+
+            let query = (&state_a.borrow(), &state_b.borrow());
+            let mut bitset = entities.bitset().clone();
+            query.apply_bitset(&mut bitset);
+
+            let maybe_comps = query.get_single_with_bitset(Rc::new(bitset));
+
+            assert_eq!(maybe_comps, Err(QuerySingleError::MultipleEntities));
+
+            entities.kill(e1);
+            entities.kill(e2);
+        }
+    }
 
     #[test]
     fn entities__create_kill() {


### PR DESCRIPTION
Closes #289

Hello :wave: it's been a long while. This is take 2 of #386 which was reverted in cfce040 due to CI failures.

## Changes

- Add `Entities::(get_)single_with` methods to get a single entity by a query
- Add `Entities::(get_)first_with_bitset` methods to get the first entity in the given bitset
- Add `Entities::(get_)first_with` methods to get the first entity in the given query

## Summary

Add convenience methods to get a single entity (and one or more of its components) when there should only be one of the thing you're looking for. This could be useful, for example, to check if there is only one player alive in the game. You could use `Entities::get_single_with` which would allow you to detect when there is only one player (`Ok`) or when there are none/multiple (`Err`).

All methods have a panicking and non-panicking variant -- e.g. `get_single_with` returns a `Result<_, QuerySingleError>`, while `single_with` panics if the return value is an `Err`. The `*first_with*` methods either return an `Option` or panic.