### PR TITLE
feat: derive `Clone` for `ComponentStore`.

### DIFF
--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -5,6 +5,7 @@ use crate::prelude::*;
 use super::untyped::UntypedComponentStore;
 
 /// A typed wrapper around [`UntypedComponentStore`].
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct ComponentStore<T: HasSchema> {
     untyped: UntypedComponentStore,


### PR DESCRIPTION
It was just an oversight that it wasn't already derived, because the inner untyped store is already `Clone`.