### PR TITLE
fix(miri): slow tests & bitset sizes

### DIFF
--- a/.github/miri-test.sh
+++ b/.github/miri-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Run workspace tests with miri.
+#
+# This script is executed by the CI workflow in `.github/workflows/ci.yml`. Miri
+# must be run with a nightly toolchain, but the workflow configures this with a
+# rustup override rather than using rustup's `+toolchain` on the CLI. To run
+# this script locally use the rustup env var:
+#
+#     RUSTUP_TOOLCHAIN=nightly ./github/miri-test.sh
+#
+# The number of seed runs can also be configured with the `NUM_SEEDS` env var:
+#
+#     NUM_SEEDS=1 RUSTUP_TOOLCHAIN=nightly ./github/miri-test.sh
+#
+
+line() {
+    printf -- "${1}%0.s" $(seq "$2")
+    printf '\n'
+}
+
+header() {
+    line "$1" "$2"
+    echo "$3"
+    line "$1" "$2"
+}
+
+get_default_workspace_members() {
+    cargo metadata --quiet --no-deps \
+      | sed -nE 's/.*"workspace_default_members":\[([^]]+)\].*/\1/p' \
+      | tr ',' '\n' | awk -F/ '{print gensub(/([^#]+).*/, "\\1", 1, $NF)}'
+}
+
+# The maximum number of seeds with which to run the tests
+[ -z "$NUM_SEEDS" ] && NUM_SEEDS=10
+
+# The crates to test
+declare -a CRATES
+
+# Extra flags to pass to `cargo test` for crates
+declare -A FLAGS
+
+CRATES=( $(get_default_workspace_members) )
+FLAGS[bones_ecs]='--no-default-features -F miri'
+
+# Try multiple seeds to catch possible alignment issues
+for SEED in $(seq "$NUM_SEEDS"); do
+    export MIRIFLAGS="-Zmiri-seed=$SEED"
+
+    echo
+    header '#' 80 "MIRI TEST WORKSPACE"
+    echo
+
+    for (( i=0; i<${#CRATES[@]}; i++ )); do
+        NAME="${CRATES[i]}"
+        header '-' 70 "TEST CRATE: $NAME (seed $SEED/$NUM_SEEDS, crate $(( i+1 ))/${#CRATES[@]})"
+        echo
+        eval "cargo miri test --package $NAME ${FLAGS[$NAME]}" || { echo "Failing seed: $SEED"; exit 1; };
+    done
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,7 @@ jobs:
           restore-keys: |
             ci-miri-${{ matrix.config.target }}-
       - name: 📡 Test with Miri
-        run: |
-          # Try multiple seeds to catch possible alignment issues
-          for SEED in $(seq 0 10); do
-            echo "Trying seed: $SEED"
-            MIRIFLAGS=-Zmiri-seed=$SEED cargo miri test || { echo "Failing seed: $SEED"; exit 1; };
-          done
+        shell: bash
+        run: "${GITHUB_WORKSPACE}/.github/miri-test.sh"
+        env:
+          NUM_SEEDS: 8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = ["framework_crates/*"]
 [workspace.package]
 edition       = "2021"
 version       = "0.4.0"
-rust-version  = "1.71"
+rust-version  = "1.81"
 readme        = "README.md"
 homepage      = "https://fishfolk.org/development/bones/introduction/"
 repository    = "https://github.com/fishfolk/bones"

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -12,10 +12,13 @@ keywords.workspace      = true
 
 [features]
 default = ["derive", "keysize16"]
+miri    = ["derive", "keysize10"]
 derive  = ["dep:bones_ecs_macros"]
 glam    = ["dep:glam", "dep:paste", "bones_schema/glam"]
 serde   = ["dep:serde"]
 
+keysize10 = []
+keysize12 = []
 keysize16 = []
 keysize20 = []
 keysize24 = []

--- a/framework_crates/bones_ecs/src/bitset.rs
+++ b/framework_crates/bones_ecs/src/bitset.rs
@@ -2,16 +2,37 @@
 //!
 //! Bitsets are powered by the [`bitset_core`] crate.
 //!
+//! A Bones bitset is a vector of 32-byte sectors. The size of a bitset can be controlled by the
+//! `keysize*` features (note that they are all mutually exclusive with each other). The `keysize`
+//! is exponentially correlated to the number of bits, or entities, that the set can track; where
+//! the number of bits equals two raised to the power of `keysize`. Below are the available
+//! `keysize`s and the size of their resulting bitsets.
+//!
+//! | Keysize | Bit Count  | Sectors    | Memory |
+//! | ------- | ---------- | ---------- | ------ |
+//! |      32 |  4 billion | 16 million | 512 MB |
+//! |      24 | 16 million |      65536 |   2 MB |
+//! |      20 |  1 million |       4096 | 128 KB |
+//! |      16 |      65536 |        256 |   8 KB |
+//! |      12 |       4096 |         16 | 512  B |
+//! |      10 |       1024 |          4 | 128  B |
+//!
+//! Keysize (`K`) refers to the name of the feature. A keysize of 16 refers to the `keysize16`
+//! feature.
+//!
+//! Bit Count is the total number of bits in the bitset (`2^K`). Due to the nature of binary
+//! numbers this means that a value with more than `K` bits should not be used to index into the
+//! bitset since e.g. `u16::MAX` is the index of the last bit in a `keysize16` bitset.
+//!
+//! Sectors is the number of sub-arrays within the bitset `Vec`. Sectors are 256 bits as they are
+//! comprised of 8 `u32`s. Note that SIMD instructions process 256 bits/entities at a time.
+//!
+//! Memory is the total amount of memory that the bitset will occupy.
+//!
 //! [`bitset_core`]: https://docs.rs/bitset_core
 
 use crate::prelude::*;
 
-// 2^32 gives  4 billion concurrent entities for 512MB   of ram per component
-// 2^24 gives 16 million concurrent entities for 2MB     of ram per component
-// 2^20 gives  1 million concurrent entities for 128KB   of ram per component
-// 2^16 gives 65536      concurrent entities for 8KB     of ram per component
-// 2^12 gives 4096       concurrent entities for 512B    of ram per component
-// SIMD processes 256 bits/entities (32 bytes) at once when comparing bitsets.
 #[cfg(all(
     feature = "keysize10",
     not(feature = "keysize12"),
@@ -83,8 +104,18 @@ pub const BITSET_EXP: u32 = 32;
 
 pub use bitset_core::*;
 
+/// The number of bits in a bitset.
 pub(crate) const BITSET_SIZE: usize = 2usize.saturating_pow(BITSET_EXP);
-pub(crate) const BITSET_SLICE_COUNT: usize = BITSET_SIZE / (32 * 8 / 8);
+
+/// The number of bits in a bitset "sector" (one of the sub-arrays).
+///
+/// A sector is an array of 8 `u32` values, so there are `8 * 32` bits in a sector.
+///
+/// This value is constant, as a sector is appropriately sized to fit into a vector register for
+/// SIMD instructions.
+const BITSET_SECTOR_SIZE: usize = 32 * 8;
+
+const BITSET_SECTOR_COUNT: usize = BITSET_SIZE / BITSET_SECTOR_SIZE;
 
 /// The type of bitsets used to track entities in component storages.
 /// Mostly used to create caches.
@@ -115,5 +146,5 @@ impl BitSetVec {
 /// Creates a bitset big enough to contain the index of each entity.
 /// Mostly used to create caches.
 pub fn create_bitset() -> BitSetVec {
-    BitSetVec(vec![[0u32; 8]; BITSET_SLICE_COUNT])
+    BitSetVec(vec![[0u32; 8]; BITSET_SECTOR_COUNT])
 }

--- a/framework_crates/bones_ecs/src/bitset.rs
+++ b/framework_crates/bones_ecs/src/bitset.rs
@@ -12,29 +12,74 @@ use crate::prelude::*;
 // 2^16 gives 65536      concurrent entities for 8KB     of ram per component
 // 2^12 gives 4096       concurrent entities for 512B    of ram per component
 // SIMD processes 256 bits/entities (32 bytes) at once when comparing bitsets.
-#[cfg(feature = "keysize16")]
-const BITSET_EXP: u32 = 16;
+#[cfg(all(
+    feature = "keysize10",
+    not(feature = "keysize12"),
+    not(feature = "keysize16"),
+    not(feature = "keysize20"),
+    not(feature = "keysize24"),
+    not(feature = "keysize32")
+))]
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 10;
+
+#[cfg(all(
+    feature = "keysize12",
+    not(feature = "keysize10"),
+    not(feature = "keysize16"),
+    not(feature = "keysize20"),
+    not(feature = "keysize24"),
+    not(feature = "keysize32")
+))]
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 12;
+
+// 16 is the default, if no `keysize*` features are enabled then use this one.
+#[cfg(any(
+    feature = "keysize16",
+    all(
+        not(feature = "keysize10"),
+        not(feature = "keysize12"),
+        not(feature = "keysize20"),
+        not(feature = "keysize24"),
+        not(feature = "keysize32")
+    )
+))]
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 16;
+
 #[cfg(all(
     feature = "keysize20",
+    not(feature = "keysize10"),
+    not(feature = "keysize12"),
     not(feature = "keysize16"),
     not(feature = "keysize24"),
     not(feature = "keysize32")
 ))]
-const BITSET_EXP: u32 = 20;
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 20;
+
 #[cfg(all(
     feature = "keysize24",
+    not(feature = "keysize10"),
+    not(feature = "keysize12"),
     not(feature = "keysize16"),
     not(feature = "keysize20"),
     not(feature = "keysize32")
 ))]
-const BITSET_EXP: u32 = 24;
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 24;
+
 #[cfg(all(
     feature = "keysize32",
+    not(feature = "keysize10"),
+    not(feature = "keysize12"),
     not(feature = "keysize16"),
     not(feature = "keysize20"),
     not(feature = "keysize24")
 ))]
-const BITSET_EXP: u32 = 32;
+#[allow(missing_docs)]
+pub const BITSET_EXP: u32 = 32;
 
 pub use bitset_core::*;
 

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -430,9 +430,9 @@ mod tests {
     #[test]
     fn iter_with_bitset_optional() {
         let mut entities = Entities::default();
-        let mut storage = ComponentStore::<A>::default();
 
         {
+            let mut storage = ComponentStore::<A>::default();
             let bitset = Rc::new(entities.bitset().clone());
 
             let mut comp_iter = storage.iter_with_bitset_optional(bitset.clone());
@@ -443,31 +443,45 @@ mod tests {
         }
 
         {
-            let e = entities.create();
+            let mut storage = ComponentStore::<A>::default();
+            (0..2).map(|_| entities.create()).count();
             let bitset = Rc::new(entities.bitset().clone());
 
             let mut comp_iter = storage.iter_with_bitset_optional(bitset.clone());
             assert_eq!(comp_iter.next(), Some(None));
+            assert_eq!(comp_iter.next(), Some(None));
+            assert_eq!(comp_iter.next(), None);
 
             let mut comp_mut_iter = storage.iter_mut_with_bitset_optional(bitset);
             assert_eq!(comp_mut_iter.next(), Some(None));
+            assert_eq!(comp_mut_iter.next(), Some(None));
+            assert_eq!(comp_mut_iter.next(), None);
 
-            entities.kill(e);
+            entities.kill_all();
         }
 
         {
-            let e = entities.create();
-            let mut a = A(0);
-            storage.insert(e, a);
+            let mut storage = ComponentStore::<A>::default();
+            let _e1 = entities.create();
+            let e2 = entities.create();
+            let _e3 = entities.create();
+            let mut a2 = A(2);
+            storage.insert(e2, a2);
             let bitset = Rc::new(entities.bitset().clone());
 
             let mut comp_iter = storage.iter_with_bitset_optional(bitset.clone());
-            assert_eq!(comp_iter.next(), Some(Some(&a)));
+            assert_eq!(comp_iter.next(), Some(None));
+            assert_eq!(comp_iter.next(), Some(Some(&a2)));
+            assert_eq!(comp_iter.next(), Some(None));
+            assert_eq!(comp_iter.next(), None);
 
             let mut comp_mut_iter = storage.iter_mut_with_bitset_optional(bitset);
-            assert_eq!(comp_mut_iter.next(), Some(Some(&mut a)));
+            assert_eq!(comp_mut_iter.next(), Some(None));
+            assert_eq!(comp_mut_iter.next(), Some(Some(&mut a2)));
+            assert_eq!(comp_mut_iter.next(), Some(None));
+            assert_eq!(comp_mut_iter.next(), None);
 
-            entities.kill(e);
+            entities.kill_all();
         }
     }
 }

--- a/framework_crates/bones_ecs/src/components/typed.rs
+++ b/framework_crates/bones_ecs/src/components/typed.rs
@@ -301,13 +301,13 @@ impl<'a, T: HasSchema> ComponentIterBitset<'a, T> for ComponentStore<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
+    use std::{iter, rc::Rc};
 
     use crate::prelude::*;
 
-    #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, HasSchema, Default)]
     #[repr(C)]
-    struct A(String);
+    struct A(u32);
 
     #[test]
     fn create_remove_components() {
@@ -316,15 +316,12 @@ mod tests {
         let e2 = entities.create();
 
         let mut storage = ComponentStore::<A>::default();
-        storage.insert(e1, A("hello".into()));
-        storage.insert(e2, A("world".into()));
+        storage.insert(e1, A(1));
+        storage.insert(e2, A(2));
         assert!(storage.get(e1).is_some());
         storage.remove(e1);
         assert!(storage.get(e1).is_none());
-        assert_eq!(
-            storage.iter().cloned().collect::<Vec<_>>(),
-            vec![A("world".into())]
-        )
+        assert!(storage.iter().eq(iter::once(&A(2))));
     }
 
     #[test]
@@ -335,18 +332,18 @@ mod tests {
         let mut storage = ComponentStore::<A>::default();
         {
             // Test that inserted component is correct
-            let comp = storage.get_mut_or_insert(e1, || A("Test1".to_string()));
-            assert_eq!(comp.0, "Test1");
+            let comp = storage.get_mut_or_insert(e1, || A(1));
+            assert_eq!(comp.0, 1);
 
             // Mutate component
-            comp.0 = "Test2".to_string();
+            comp.0 = 2;
         }
 
-        // Should not insert "Unexpected", but retrieve original mutated component.
-        let comp = storage.get_mut_or_insert(e1, || A("Unexpected".to_string()));
+        // Should not insert the unexpected value but retrieve original mutated component.
+        let comp = storage.get_mut_or_insert(e1, || A(u32::MAX));
 
         // Test that existing component is retrieved
-        assert_eq!(comp.0, "Test2");
+        assert_eq!(comp.0, 2);
     }
 
     #[test]
@@ -372,8 +369,8 @@ mod tests {
         (0..3).map(|_| entities.create()).count();
 
         let e = entities.create();
-        let a = A("a".to_string());
-        storage.insert(e, a.clone());
+        let a = A(1);
+        storage.insert(e, a);
 
         let bitset = Rc::new(entities.bitset().clone());
 
@@ -388,7 +385,7 @@ mod tests {
         let mut storage = ComponentStore::<A>::default();
 
         (0..3)
-            .map(|i| storage.insert(entities.create(), A(i.to_string())))
+            .map(|i| storage.insert(entities.create(), A(i)))
             .count();
 
         let bitset = Rc::new(entities.bitset().clone());
@@ -415,8 +412,8 @@ mod tests {
 
         {
             let e = entities.create();
-            let mut a = A("e".to_string());
-            storage.insert(e, a.clone());
+            let mut a = A(1);
+            storage.insert(e, a);
 
             let bitset = Rc::new(entities.bitset().clone());
 
@@ -460,8 +457,8 @@ mod tests {
 
         {
             let e = entities.create();
-            let mut a = A("e".to_string());
-            storage.insert(e, a.clone());
+            let mut a = A(0);
+            storage.insert(e, a);
             let bitset = Rc::new(entities.bitset().clone());
 
             let mut comp_iter = storage.iter_with_bitset_optional(bitset.clone());

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -765,11 +765,11 @@ mod tests {
 
     use crate::prelude::*;
 
-    #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, HasSchema, Default)]
     #[repr(C)]
     struct A(u32);
 
-    #[derive(Debug, Clone, PartialEq, Eq, HasSchema, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, HasSchema, Default)]
     #[repr(C)]
     struct B(u32);
 
@@ -795,7 +795,7 @@ mod tests {
 
             let e = entities.create();
             let a = A(1);
-            comp.insert(e, a.clone());
+            comp.insert(e, a);
 
             let query = &comp;
             let mut bitset = entities.bitset().clone();
@@ -850,8 +850,8 @@ mod tests {
             let e = entities.create();
             let a = A(1);
             let b = B(1);
-            state_a.borrow_mut().insert(e, a.clone());
-            state_b.borrow_mut().insert(e, b.clone());
+            state_a.borrow_mut().insert(e, a);
+            state_b.borrow_mut().insert(e, b);
 
             let query = (&state_a.borrow(), &state_b.borrow());
             let mut bitset = entities.bitset().clone();
@@ -1036,7 +1036,7 @@ mod tests {
         let a = A(4);
 
         let state = AtomicCell::new(ComponentStore::<A>::default());
-        state.borrow_mut().insert(e, a.clone());
+        state.borrow_mut().insert(e, a);
 
         let comp = state.borrow();
 
@@ -1065,7 +1065,7 @@ mod tests {
         for i in 0..3 {
             let e = entities.create();
             let a = A(i);
-            state.borrow_mut().insert(e, a.clone());
+            state.borrow_mut().insert(e, a);
         }
 
         let comp = state.borrow();
@@ -1094,8 +1094,8 @@ mod tests {
         let e4 = entities.create();
         let a4 = A(4);
         let b4 = B(4);
-        state_a.borrow_mut().insert(e4, a4.clone());
-        state_b.borrow_mut().insert(e4, b4.clone());
+        state_a.borrow_mut().insert(e4, a4);
+        state_b.borrow_mut().insert(e4, b4);
 
         let comp_a = state_a.borrow();
         let comp_b = state_b.borrow();
@@ -1128,7 +1128,7 @@ mod tests {
         {
             let e = entities.create();
             let mut a = A(1);
-            state.borrow_mut().insert(e, a.clone());
+            state.borrow_mut().insert(e, a);
 
             let mut comp = state.borrow_mut();
 
@@ -1155,7 +1155,7 @@ mod tests {
         {
             let e = entities.create();
             let a = A(1);
-            state_a.borrow_mut().insert(e, a.clone());
+            state_a.borrow_mut().insert(e, a);
 
             let comp_a = state_a.borrow();
             let mut comp_b = state_b.borrow_mut();
@@ -1177,8 +1177,8 @@ mod tests {
             let e = entities.create();
             let a = A(1);
             let mut b = B(1);
-            state_a.borrow_mut().insert(e, a.clone());
-            state_b.borrow_mut().insert(e, b.clone());
+            state_a.borrow_mut().insert(e, a);
+            state_b.borrow_mut().insert(e, b);
 
             let comp_a = state_a.borrow();
             let mut comp_b = state_b.borrow_mut();

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -1050,7 +1050,7 @@ mod tests {
         #[allow(clippy::clone_on_copy)]
         let _ = e1.clone();
         // Debug
-        println!("{e1:?}");
+        assert_eq!(format!("{e1:?}"), "Entity(0, 0)");
         // Hash
         let mut h = HashSet::new();
         h.insert(e1);

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -1074,7 +1074,6 @@ mod tests {
         entities.create();
     }
 
-    #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
     fn entities__force_max_entity_panic() {
@@ -1084,7 +1083,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(miri))] // This test is very slow on miri and not critical to test for.
     #[test]
     #[should_panic(expected = "Exceeded maximum amount")]
     fn entities__force_max_entity_panic2() {

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -536,7 +536,7 @@ impl Entities {
     }
 
     /// Iterates over entities using the provided bitset.
-    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator {
+    pub fn iter_with_bitset<'a>(&'a self, bitset: &'a BitSetVec) -> EntityIterator<'a> {
         EntityIterator {
             current_id: 0,
             next_id: self.next_id,

--- a/framework_crates/bones_ecs/src/entities.rs
+++ b/framework_crates/bones_ecs/src/entities.rs
@@ -637,12 +637,13 @@ impl Entities {
             self.alive.bit_set(i);
             Entity::new(i as u32, self.generation[i])
         } else {
+            // Skip over sections where all bits are enabled
             let mut section = 0;
-            // Find section where at least one bit isn't set
             while self.alive[section].bit_all() {
                 section += 1;
             }
-            // Start at the beginning of the section with unset bits
+
+            // Start at the beginning of the first section with at least 1 unset bit
             let mut i = section * (32 * 8);
             // Find the first bit that is not used by an alive or dead entity
             while i < BITSET_SIZE
@@ -653,6 +654,8 @@ impl Entities {
             if i >= BITSET_SIZE {
                 panic!("Exceeded maximum amount of concurrent entities.");
             }
+
+            // Create the entity
             self.alive.bit_set(i);
             if i >= self.next_id {
                 self.next_id = i + 1;

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -307,7 +307,6 @@ mod tests {
         let mut i = 0;
         for (entity, (pos, vel)) in entities.iter_with((&pos, &vel)) {
             let marker = marker.get(entity);
-            dbg!(i, entity);
             match (i, pos, vel, marker) {
                 (0, Pos(0, 99), Vel(0, -1), None) | (1, Pos(1, 1), Vel(1, 1), Some(Marker)) => (),
                 x => unreachable!("{:?}", x),

--- a/framework_crates/bones_framework/src/logging.rs
+++ b/framework_crates/bones_framework/src/logging.rs
@@ -6,7 +6,7 @@
 use std::{
     backtrace::{Backtrace, BacktraceStatus},
     error::Error,
-    panic::PanicInfo,
+    panic::PanicHookInfo,
     path::PathBuf,
 };
 
@@ -456,7 +456,7 @@ pub mod macros {
 /// Panic hook that sends panic payload to [`tracing::error`], and backtrace if available.
 ///
 /// This hook is enabled in [`setup_logging`] to make sure panics are traced.
-pub fn tracing_panic_hook(panic_info: &PanicInfo) {
+pub fn tracing_panic_hook(panic_info: &PanicHookInfo) {
     let payload = panic_info.payload();
 
     let payload = if let Some(s) = payload.downcast_ref::<&str>() {

--- a/framework_crates/bones_framework/src/time/timer.rs
+++ b/framework_crates/bones_framework/src/time/timer.rs
@@ -414,7 +414,7 @@ pub enum TimerMode {
 }
 
 // To speed up CI, only do these on miri, where they complete without waiting for time to pass.
-#[cfg(miri)]
+#[cfg(all(test, miri))]
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;

--- a/framework_crates/bones_schema/src/alloc/map.rs
+++ b/framework_crates/bones_schema/src/alloc/map.rs
@@ -665,7 +665,7 @@ impl<K: HasSchema, V: HasSchema> SMap<K, V> {
     pub fn iter(&self) -> SMapIter<K, V> {
         fn map_fn<'a, K: HasSchema, V: HasSchema>(
             (key, value): (&'a SchemaBox, &'a SchemaBox),
-        ) -> (&K, &V) {
+        ) -> (&'a K, &'a V) {
             // SOUND: SMap ensures K and V schemas always match.
             unsafe {
                 (
@@ -711,7 +711,7 @@ impl<K: HasSchema, V: HasSchema> SMap<K, V> {
     #[allow(clippy::type_complexity)]
     pub fn values(
         &self,
-    ) -> std::iter::Map<hash_map::Values<SchemaBox, SchemaBox>, for<'a> fn(&'a SchemaBox) -> &V>
+    ) -> std::iter::Map<hash_map::Values<SchemaBox, SchemaBox>, for<'a> fn(&'a SchemaBox) -> &'a V>
     {
         fn map_fn<V: HasSchema>(value: &SchemaBox) -> &V {
             // SOUND: SMap ensures value schema always matches.
@@ -726,7 +726,7 @@ impl<K: HasSchema, V: HasSchema> SMap<K, V> {
         &mut self,
     ) -> std::iter::Map<
         hash_map::ValuesMut<SchemaBox, SchemaBox>,
-        for<'a> fn(&'a mut SchemaBox) -> &mut V,
+        for<'a> fn(&'a mut SchemaBox) -> &'a mut V,
     > {
         fn map_fn<V>(value: &mut SchemaBox) -> &mut V {
             // SOUND: SMap ensures value schema always matches


### PR DESCRIPTION
Closes #466 

## Changes

- Fix: Bitsets are now correctly-sized (were x8 larger than expected)
- Fix: Unexpected panic when calling `Entities::create()` with a maxed-out bitset
- Fix: Reduce Miri CI job runtime to <30 minutes
- Fix: Warnings emitted by Miri
- Fix: Update the workspace `rust-version` to match the `rust-toolchain.toml` file at 1.81
- Add: More bitset iterator tests (there will be a follow-up PR on this to organize them and simplify some that involve `Entities` unnecessarily)
- Fix: Simplify test data, remove prints & `dbg!`s

## Explanation

**Fix: Bitsets are now correctly-sized (were x8 larger than expected)**

- Bitsets are `2^K` bits, and the number of `u32` arrays within them (which the docs now call "sectors") was previously calculated as `2^K / (32 * 8 / 8)`. The arrays are `32 * 8` bits meaning the array count should be calculated as `2^K / (32 * 8)`.
- Added more docs to the `bitset` module.

**Fix: Unexpected panic when calling `Entities::create()` with a maxed-out bitset**

- Unexpected panic on `bit_set` when all bits are set in `alive` except for some in the last sector, but those all belong to killed entities.
- It attempts to `bit_test` at index `BITSET_BITSIZE` which is an overflow. This was not noticed before due to the bitset actually being larger than the size const.

**Fix: Reduce Miri CI job runtime to <30 minutes**

- A full run pre-fix would likely take 12+ hours since it usually stops during seed 5/11, but it times-out at 6hrs.
- Add a new feature set `miri` which is the same as `default` but with `keysize10` (where bitsets are 128 bytes).
- Unfortunately this complicates the script that runs miri because the new feature is not usable when running the whole workspace (`cargo +nightly miri test --no-default-features -F miri` does not work).
- The bash script now runs each crate separately with `-p`, and adds `--no-default-features -F miri` only for `bones_ecs`.
- Moved bash script into its own file since it's now more complex.