### PR TITLE
fix: reorganize ECS tests

### DIFF
--- a/framework_crates/bones_schema/tests/tests.rs
+++ b/framework_crates/bones_schema/tests/tests.rs
@@ -274,8 +274,8 @@ fn eq_hash() {
     assert_eq!(b1, b2);
     assert_ne!(b3, b2);
     assert_ne!(b3, b1);
-    assert_eq!(dbg!(b1.hash()), b2.hash());
-    assert_ne!(dbg!(b3.hash()), b1.hash());
+    assert_eq!(b1.hash(), b2.hash());
+    assert_ne!(b3.hash(), b1.hash());
 
     let s_hash_fn = b1.schema().hash_fn.as_ref().unwrap();
     assert_eq!(


### PR DESCRIPTION
Follow-up on #468.

## Changes

*This PR makes changes exclusively within `*::tests` modules, there are no changes to lib code.*

- Move tests out of the `entities` module that don't belong
- Add more edge cases to help capture the similar but very different logic for all of the ways you can iterate component stores & bitsets