### PR TITLE
fix: reduce `bones_schema` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,9 +1370,11 @@ dependencies = [
  "elsa",
  "erased-serde 0.4.5",
  "event-listener 4.0.3",
+ "futures-lite 2.3.0",
  "glam 0.24.2",
  "notify",
  "once_cell",
+ "parking_lot",
  "paste",
  "path-absolutize",
  "semver",
@@ -1382,6 +1384,7 @@ dependencies = [
  "sha2",
  "tracing",
  "ulid",
+ "ustr",
  "web-sys",
 ]
 
@@ -1411,6 +1414,7 @@ dependencies = [
  "bones_ecs_macros",
  "bones_schema",
  "bones_utils",
+ "branches",
  "glam 0.24.2",
  "once_map",
  "paste",
@@ -1461,6 +1465,7 @@ dependencies = [
  "either",
  "fluent",
  "fluent-langneg",
+ "futures-lite 2.3.0",
  "ggrs",
  "glam 0.24.2",
  "hex",
@@ -1499,6 +1504,7 @@ version = "0.4.0"
 dependencies = [
  "bones_ecs",
  "instant",
+ "ustr",
 ]
 
 [[package]]
@@ -1540,14 +1546,18 @@ dependencies = [
  "bones_schema_macros",
  "bones_utils",
  "erased-serde 0.4.5",
+ "fxhash",
  "glam 0.24.2",
+ "hashbrown 0.14.5",
  "humantime",
+ "parking_lot",
  "paste",
  "serde",
  "serde_yaml",
  "sptr",
  "stable_deref_trait",
  "ulid",
+ "ustr",
 ]
 
 [[package]]
@@ -1567,8 +1577,10 @@ dependencies = [
  "bevy_tasks 0.11.3",
  "bones_asset",
  "bones_lib",
+ "futures-lite 2.3.0",
  "gc-arena",
  "gc-arena-derive",
+ "parking_lot",
  "piccolo",
  "send_wrapper",
  "tracing",
@@ -1580,19 +1592,13 @@ name = "bones_utils"
 version = "0.4.0"
 dependencies = [
  "bones_utils_macros",
- "branches",
- "futures-lite 2.3.0",
  "fxhash",
  "getrandom",
  "hashbrown 0.14.5",
  "instant",
- "maybe-owned",
- "parking_lot",
  "serde",
- "smallvec",
  "turborand",
  "ulid",
- "ustr",
 ]
 
 [[package]]
@@ -4446,12 +4452,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md5"
@@ -7788,7 +7788,6 @@ dependencies = [
  "byteorder",
  "lazy_static",
  "parking_lot",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,6 @@ dependencies = [
  "serde_yaml",
  "sptr",
  "stable_deref_trait",
- "ulid",
  "ustr",
 ]
 
@@ -7672,7 +7671,6 @@ checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
  "getrandom",
  "rand",
- "serde",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,15 @@ keywords      = ["bones", "bevy", "scripting", "ecs", "framework"]
 [workspace.lints.clippy]
 correctness = "warn"
 
+[workspace.dependencies]
+branches     = "0.1"
+futures-lite = "2.3"
+fxhash       = "0.2"
+hashbrown    = "0.14"
+maybe-owned  = "0.3"
+parking_lot  = "0.12"
+smallvec     = "1.11"
+ustr         = "0.10"
+
 [profile.release]
 lto = true

--- a/framework_crates/bones_asset/Cargo.toml
+++ b/framework_crates/bones_asset/Cargo.toml
@@ -20,26 +20,29 @@ cid_debug_trace = []
 bones_utils  = { version = "0.4.0", path = "../bones_utils", features = ["serde"] }
 bones_schema = { version = "0.4.0", path = "../bones_schema", features = ["serde"] }
 
-serde           = { version = "1.0", features = ["derive"] }
-sha2            = "0.10"
-bs58            = "0.5"
 anyhow          = "1.0"
-serde_yaml      = "0.9"
-serde_json      = "1.0"
-erased-serde    = "0.4"
-paste           = "1.0"
-ulid            = { version = "1.0" }
-semver          = { version = "1.0", features = ["serde"] }
-async-channel   = "1.9"
-once_cell       = "1.18"
-path-absolutize = { version = "3.1", features = ["use_unix_paths_on_wasm"] }
-ehttp           = "0.3"
-tracing         = "0.1"
-bevy_tasks      = "0.11"
-dashmap         = "5.5"
-event-listener  = "4.0"
-elsa            = "1.9"
 append-only-vec = "0.1.3"
+async-channel   = "1.9"
+bevy_tasks      = "0.11"
+bs58            = "0.5"
+dashmap         = "5.5"
+ehttp           = "0.3"
+elsa            = "1.9"
+erased-serde    = "0.4"
+event-listener  = "4.0"
+futures-lite    = { workspace = true }
+once_cell       = "1.18"
+parking_lot     = { workspace = true }
+paste           = "1.0"
+path-absolutize = { version = "3.1", features = ["use_unix_paths_on_wasm"] }
+semver          = { version = "1.0", features = ["serde"] }
+serde           = { version = "1.0", features = ["derive"] }
+serde_json      = "1.0"
+serde_yaml      = "0.9"
+sha2            = "0.10"
+tracing         = "0.1"
+ulid            = "1.0"
+ustr            = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify = "6.0"

--- a/framework_crates/bones_asset/examples/tutorial.rs
+++ b/framework_crates/bones_asset/examples/tutorial.rs
@@ -1,6 +1,5 @@
 use bevy_tasks::{IoTaskPool, TaskPool};
 use bones_asset::prelude::*;
-use bones_utils::futures;
 use glam::{UVec2, Vec2};
 
 use std::path::PathBuf;
@@ -103,11 +102,7 @@ struct Image {
 /// Our custom loader for image assets.
 struct ImageAssetLoader;
 impl AssetLoader for ImageAssetLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         // We're not going to bother actually loading the image.
         let data = bytes.to_vec();
         Box::pin(async move {

--- a/framework_crates/bones_asset/src/asset.rs
+++ b/framework_crates/bones_asset/src/asset.rs
@@ -8,9 +8,11 @@ use std::{
 };
 
 use append_only_vec::AppendOnlyVec;
-use bones_utils::{parking_lot::Mutex, prelude::*};
+use bones_utils::prelude::*;
 use dashmap::DashMap;
 use event_listener::{Event, EventListener};
+use futures_lite::future::Boxed as BoxedFuture;
+use parking_lot::Mutex;
 use semver::VersionReq;
 
 use crate::prelude::*;
@@ -309,11 +311,7 @@ impl AssetLoadCtx {
 /// A custom assset loader.
 pub trait AssetLoader: Sync + Send + 'static {
     /// Load the asset from raw bytes.
-    fn load(
-        &self,
-        ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>>;
+    fn load(&self, ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>>;
 }
 
 /// A custom asset loader implementation for a metadata asset.
@@ -399,7 +397,6 @@ pub fn metadata_asset(extension: &str) -> AssetKind {
 ///
 /// ```
 /// # use bones_asset::prelude::*;
-/// # use bones_utils::prelude::*;
 /// #[derive(HasSchema, Default, Clone)]
 /// #[type_data(asset_loader("png", PngLoader))]
 /// #[repr(C)]
@@ -411,7 +408,7 @@ pub fn metadata_asset(extension: &str) -> AssetKind {
 ///
 /// struct PngLoader;
 /// impl AssetLoader for PngLoader {
-///     fn load(&self, ctx: AssetLoadCtx, data: &[u8]) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+///     fn load(&self, ctx: AssetLoadCtx, data: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
 ///         Box::pin(async move {
 ///             todo!("Load PNG from data");
 ///         })

--- a/framework_crates/bones_asset/src/cid.rs
+++ b/framework_crates/bones_asset/src/cid.rs
@@ -41,7 +41,8 @@ mod cid_debug_trace {
     use crate::{AssetLoc, Cid};
     use std::path::Path;
 
-    use bones_utils::{default, Ustr};
+    use bones_utils::default;
+    use ustr::Ustr;
 
     pub(crate) struct CidDebugTrace<'a> {
         pub schema_full_name: Ustr,

--- a/framework_crates/bones_asset/src/handle.rs
+++ b/framework_crates/bones_asset/src/handle.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use bones_schema::{prelude::*, raw_fns::*};
-use bones_utils::{parking_lot::RwLock, HashMap};
+use bones_utils::HashMap;
+use parking_lot::RwLock;
 use ulid::Ulid;
 
 use crate::{AssetServer, NetworkHandle};

--- a/framework_crates/bones_asset/src/io.rs
+++ b/framework_crates/bones_asset/src/io.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use async_channel::Sender;
-use bones_utils::{default, futures::future::Boxed as BoxedFuture, HashMap};
+use bones_utils::{default, HashMap};
+use futures_lite::future::Boxed as BoxedFuture;
 use path_absolutize::Absolutize;
 
 use crate::{AssetLocRef, ChangedAsset};
@@ -40,7 +41,7 @@ pub struct FileAssetIo {
     /// The directory to load the asset packs from.
     pub packs_dir: PathBuf,
     /// Filesystem watcher if enabled.
-    pub watcher: bones_utils::parking_lot::Mutex<Option<Box<dyn notify::Watcher + Sync + Send>>>,
+    pub watcher: parking_lot::Mutex<Option<Box<dyn notify::Watcher + Sync + Send>>>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -53,7 +54,7 @@ impl FileAssetIo {
         Self {
             core_dir: core_dir.clone(),
             packs_dir: packs_dir.clone(),
-            watcher: bones_utils::parking_lot::Mutex::new(None),
+            watcher: parking_lot::Mutex::new(None),
         }
     }
 }

--- a/framework_crates/bones_asset/src/lib.rs
+++ b/framework_crates/bones_asset/src/lib.rs
@@ -14,6 +14,7 @@ macro_rules! pub_use {
         pub use anyhow;
         pub use bones_schema::prelude::*;
         pub use dashmap;
+        pub use futures_lite::future::Boxed as BoxedFuture;
         pub use path_absolutize::Absolutize;
         pub use semver::Version;
     };

--- a/framework_crates/bones_asset/src/server.rs
+++ b/framework_crates/bones_asset/src/server.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use append_only_vec::AppendOnlyVec;
 use async_channel::{Receiver, Sender};
 use bevy_tasks::IoTaskPool;
+use bones_utils::{default, Deref, DerefMut, UlidExt};
 use dashmap::{
     mapref::one::{
         MappedRef as MappedMapRef, MappedRefMut as MappedMapRefMut, Ref as MapRef,
@@ -15,19 +16,14 @@ use dashmap::{
     DashMap,
 };
 use once_cell::sync::Lazy;
+use parking_lot::{MappedMutexGuard, MutexGuard};
 use semver::VersionReq;
 use serde::{de::DeserializeSeed, Deserialize};
-use ulid::Ulid;
-
 #[allow(unused_imports)]
 use tracing::info;
+use ulid::Ulid;
 
 use crate::prelude::*;
-
-use bones_utils::{
-    parking_lot::{MappedMutexGuard, MutexGuard},
-    *,
-};
 
 mod schema_loader;
 
@@ -1025,7 +1021,9 @@ fn path_is_metadata(path: &Path) -> bool {
 
 pub use metadata::*;
 mod metadata {
+    use bones_utils::LabeledId;
     use serde::de::{DeserializeSeed, Error, Unexpected, VariantAccess, Visitor};
+    use ustr::{ustr, Ustr};
 
     use super::*;
 

--- a/framework_crates/bones_asset/src/server/schema_loader.rs
+++ b/framework_crates/bones_asset/src/server/schema_loader.rs
@@ -1,8 +1,8 @@
 use std::ffi::c_void;
 
 use bones_schema::alloc::TypeDatas;
-use bones_utils::ustr;
 use serde::Deserialize;
+use ustr::ustr;
 
 use crate::prelude::*;
 

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -30,15 +30,16 @@ bones_schema = { version = "0.4.0", path = "../bones_schema" }
 
 # Optional deps
 bones_ecs_macros = { version = "0.4.0", path = "./macros", optional = true }
+glam             = { version = "0.24", optional = true }
+paste            = { version = "1.0", optional = true }
+serde            = { version = "1", features = ["derive"], optional = true }
 
 anyhow      = "1.0"
+branches    = { workspace = true }
 atomicell   = "0.2"
 bitset-core = "0.1"
-thiserror   = "1.0"
-glam        = { version = "0.24", optional = true }
-paste       = { version = "1.0", optional = true }
-serde       = { version = "1", features = ["derive"], optional = true }
 once_map    = "0.4.12"
+thiserror   = "1.0"
 
 [dev-dependencies]
 glam = "0.24"

--- a/framework_crates/bones_ecs/src/lib.rs
+++ b/framework_crates/bones_ecs/src/lib.rs
@@ -26,9 +26,11 @@ pub use world::{FromWorld, World};
 
 /// The prelude.
 pub mod prelude {
-    pub use {
-        atomicell::*, bitset_core::BitSet, bones_schema::prelude::*, bones_utils::prelude::*,
-    };
+    pub use atomicell::*;
+    pub use bitset_core::BitSet;
+    pub use bones_schema::prelude::*;
+    pub use bones_utils::prelude::*;
+    pub use branches::{likely, unlikely};
 
     pub use crate::{
         bitset::*,

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -94,6 +94,7 @@ async-channel = "1.9"
 bevy_tasks    = "0.11"
 bytemuck      = "1.12"
 either        = "1.8"
+futures-lite  = { workspace = true }
 glam          = "0.24"
 hex           = "0.4"
 instant       = { version = "0.1", features = ["wasm-bindgen"] }
@@ -149,10 +150,9 @@ postcard               = { version = "1.0", features = ["alloc"] }
 rcgen                  = "0.12"
 rustls                 = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 smallvec               = "1.10"
-iroh-quinn             = { version = "0.10" }
-iroh-net               = { version = "0.22" }
+iroh-quinn             = "0.10"
+iroh-net               = "0.22"
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
-
 
 directories = "5.0"
 

--- a/framework_crates/bones_framework/src/audio/audio_manager.rs
+++ b/framework_crates/bones_framework/src/audio/audio_manager.rs
@@ -78,11 +78,7 @@ impl SoundData for &AudioSource {
 /// The audio file asset loader.
 pub struct AudioLoader;
 impl AssetLoader for AudioLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let data = StaticSoundData::from_cursor(Cursor::new(bytes))?;

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -24,6 +24,8 @@ pub mod prelude {
         utils::*, AssetServerExt, DefaultGamePlugin, DefaultSessionPlugin, ExitBones,
     };
 
+    pub use futures_lite::future::Boxed as BoxedFuture;
+
     #[cfg(feature = "ui")]
     pub use crate::debug;
 

--- a/framework_crates/bones_framework/src/localization.rs
+++ b/framework_crates/bones_framework/src/localization.rs
@@ -157,11 +157,7 @@ impl<T: HasSchema> SystemParam for Localization<'_, T> {
 
 struct FluentResourceLoader;
 impl AssetLoader for FluentResourceLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let string = String::from_utf8(bytes).context("Error loading fluent resource file.")?;
@@ -182,11 +178,7 @@ impl AssetLoader for FluentResourceLoader {
 
 struct FluentBundleLoader;
 impl AssetLoader for FluentBundleLoader {
-    fn load(
-        &self,
-        mut ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, mut ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let self_path = ctx.loc.path.clone();
@@ -225,11 +217,7 @@ impl AssetLoader for FluentBundleLoader {
 
 struct LocalizationLoader;
 impl AssetLoader for LocalizationLoader {
-    fn load(
-        &self,
-        mut ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, mut ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let self_path = ctx.loc.path.clone();

--- a/framework_crates/bones_framework/src/render/sprite.rs
+++ b/framework_crates/bones_framework/src/render/sprite.rs
@@ -21,11 +21,7 @@ pub enum Image {
 
 struct ImageAssetLoader;
 impl AssetLoader for ImageAssetLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             Ok(SchemaBox::new(Image::Data(image::load_from_memory(

--- a/framework_crates/bones_framework/src/render/ui.rs
+++ b/framework_crates/bones_framework/src/render/ui.rs
@@ -117,11 +117,7 @@ fn deserialize_arc_str<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Arc<str
 /// The [`Font`] asset loader.
 pub struct FontLoader;
 impl AssetLoader for FontLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let (family_name, monospace) = {

--- a/framework_crates/bones_lib/Cargo.toml
+++ b/framework_crates/bones_lib/Cargo.toml
@@ -17,3 +17,4 @@ glam    = ["bones_ecs/glam"]
 [dependencies]
 bones_ecs = { version = "0.4.0", path = "../bones_ecs" }
 instant   = "0.1.12"
+ustr      = { workspace = true }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
         ecs::prelude::*, instant::Instant, time::*, Game, GamePlugin, Session, SessionCommand,
         SessionOptions, SessionPlugin, SessionRunner, Sessions,
     };
+    pub use ustr::{ustr, Ustr, UstrMap, UstrSet};
 }
 
 pub use instant;
@@ -22,6 +23,7 @@ pub mod time;
 use std::{collections::VecDeque, fmt::Debug, sync::Arc};
 
 use crate::prelude::*;
+
 /// A bones game. This includes all of the game worlds, and systems.
 #[derive(Deref, DerefMut)]
 pub struct Session {

--- a/framework_crates/bones_schema/Cargo.toml
+++ b/framework_crates/bones_schema/Cargo.toml
@@ -12,21 +12,20 @@ keywords.workspace      = true
 
 [features]
 default   = ["derive", "serde"]
-serde     = ["dep:serde", "dep:erased-serde", "ulid/serde", "bones_utils/serde"]
+serde     = ["dep:serde", "dep:erased-serde", "bones_utils/serde"]
 derive    = ["bones_schema_macros"]
 glam      = ["dep:glam"]
 humantime = ["dep:humantime", "serde"]
 
 [dependencies]
 append-only-vec    = "0.1.3"
-bones_utils        = { version = "0.4.0", path = "../bones_utils" }
+bones_utils        = { version = "0.4.0", path = "../bones_utils", default-features = false }
 fxhash             = { workspace = true }
 hashbrown          = { workspace = true }
 parking_lot        = { workspace = true }
 paste              = "1.0"
 sptr               = "0.3"
 stable_deref_trait = "1.2.0"
-ulid               = "1.0"
 ustr               = { workspace = true }
 
 # Optional deps

--- a/framework_crates/bones_schema/Cargo.toml
+++ b/framework_crates/bones_schema/Cargo.toml
@@ -18,10 +18,16 @@ glam      = ["dep:glam"]
 humantime = ["dep:humantime", "serde"]
 
 [dependencies]
-bones_utils = { version = "0.4.0", path = "../bones_utils" }
-ulid        = { version = "1.0" }
-paste       = "1.0"
-sptr        = "0.3"
+append-only-vec    = "0.1.3"
+bones_utils        = { version = "0.4.0", path = "../bones_utils" }
+fxhash             = { workspace = true }
+hashbrown          = { workspace = true }
+parking_lot        = { workspace = true }
+paste              = "1.0"
+sptr               = "0.3"
+stable_deref_trait = "1.2.0"
+ulid               = "1.0"
+ustr               = { workspace = true }
 
 # Optional deps
 bones_schema_macros = { version = "0.4.0", path = "./macros", optional = true }
@@ -29,8 +35,6 @@ glam                = { version = "0.24", optional = true }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 erased-serde        = { version = "0.4", optional = true }
 humantime           = { version = "2.1", optional = true }
-stable_deref_trait  = "1.2.0"
-append-only-vec     = "0.1.3"
 
 [[test]]
 name              = "tests"
@@ -38,3 +42,7 @@ required-features = ["glam"]
 
 [dev-dependencies]
 serde_yaml = "0.9"
+
+[[example]]
+name = "schema_derive"
+required-features = ["glam"]

--- a/framework_crates/bones_schema/macros/src/lib.rs
+++ b/framework_crates/bones_schema/macros/src/lib.rs
@@ -379,7 +379,8 @@ pub fn derive_has_schema(input: TokenStream) -> TokenStream {
                 fn schema() -> &'static #schema_mod::Schema {
                     use ::std::sync::{OnceLock};
                     use ::std::any::TypeId;
-                    use bones_utils::{HashMap, parking_lot::RwLock};
+                    use bones_utils::HashMap;
+                    use parking_lot::RwLock;
                     static S: OnceLock<RwLock<HashMap<TypeId, &'static Schema>>> = OnceLock::new();
                     let schema = {
                         S.get_or_init(Default::default)

--- a/framework_crates/bones_schema/src/alloc/map.rs
+++ b/framework_crates/bones_schema/src/alloc/map.rs
@@ -6,7 +6,9 @@ use std::{
     sync::OnceLock,
 };
 
-use bones_utils::{default, hashbrown::hash_map, parking_lot::RwLock, HashMap};
+use bones_utils::{default, HashMap};
+use hashbrown::hash_map;
+use parking_lot::RwLock;
 
 use crate::{
     prelude::*,

--- a/framework_crates/bones_schema/src/alloc/vec.rs
+++ b/framework_crates/bones_schema/src/alloc/vec.rs
@@ -8,7 +8,9 @@ use std::{
     sync::OnceLock,
 };
 
-use bones_utils::{default, fxhash::FxHasher, parking_lot::RwLock, HashMap};
+use bones_utils::{default, HashMap};
+use fxhash::FxHasher;
+use parking_lot::RwLock;
 
 use crate::{prelude::*, raw_fns::*};
 

--- a/framework_crates/bones_schema/src/lib.rs
+++ b/framework_crates/bones_schema/src/lib.rs
@@ -27,7 +27,6 @@ pub mod prelude {
     #[cfg(feature = "derive")]
     pub use bones_schema_macros::*;
     pub use bones_utils;
-    pub use ulid::Ulid;
 }
 
 mod schema;

--- a/framework_crates/bones_schema/src/ptr.rs
+++ b/framework_crates/bones_schema/src/ptr.rs
@@ -13,11 +13,14 @@ use std::{
     sync::OnceLock,
 };
 
+use bones_utils::prelude::*;
+use parking_lot::RwLock;
+use ustr::Ustr;
+
 use crate::{
     prelude::*,
     raw_fns::{RawClone, RawDefault, RawDrop},
 };
-use bones_utils::{parking_lot::RwLock, prelude::*};
 
 /// An untyped reference that knows the [`Schema`] of the pointee and that can be cast to a matching
 /// type.

--- a/framework_crates/bones_schema/src/raw_fns.rs
+++ b/framework_crates/bones_schema/src/raw_fns.rs
@@ -6,7 +6,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use bones_utils::fxhash::FxHasher;
+use fxhash::FxHasher;
 
 use crate::Unsafe;
 

--- a/framework_crates/bones_schema/src/registry.rs
+++ b/framework_crates/bones_schema/src/registry.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use append_only_vec::AppendOnlyVec;
-use bones_utils::*;
+use bones_utils::prelude::*;
 
 use crate::prelude::*;
 

--- a/framework_crates/bones_schema/src/registry.rs
+++ b/framework_crates/bones_schema/src/registry.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use append_only_vec::AppendOnlyVec;
-use bones_utils::prelude::*;
+use bones_utils::Deref;
 
 use crate::prelude::*;
 
@@ -145,6 +145,8 @@ pub static SCHEMA_REGISTRY: SchemaRegistry = SchemaRegistry {
 
 #[cfg(test)]
 mod test {
+    use bones_utils::default;
+
     use super::*;
 
     #[test]

--- a/framework_crates/bones_schema/src/schema.rs
+++ b/framework_crates/bones_schema/src/schema.rs
@@ -2,7 +2,7 @@
 
 use std::{alloc::Layout, any::TypeId, borrow::Cow, ffi::c_void};
 
-use bones_utils::Ustr;
+use ustr::Ustr;
 
 use crate::{alloc::TypeDatas, prelude::*};
 

--- a/framework_crates/bones_schema/src/ser_de.rs
+++ b/framework_crates/bones_schema/src/ser_de.rs
@@ -10,11 +10,11 @@ use crate::prelude::*;
 
 pub use serializer_deserializer::*;
 mod serializer_deserializer {
-    use bones_utils::{ustr, Ustr};
     use serde::{
         de::{Unexpected, VariantAccess, Visitor},
         ser::{SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant},
     };
+    use ustr::{ustr, Ustr};
 
     use super::*;
 

--- a/framework_crates/bones_schema/src/std_impls.rs
+++ b/framework_crates/bones_schema/src/std_impls.rs
@@ -1,14 +1,13 @@
-#[cfg(feature = "serde")]
-use crate::ser_de::SchemaDeserialize;
-use bones_utils::{fxhash::FxHasher, Ustr};
+use std::{alloc::Layout, any::TypeId, ffi::c_void, hash::Hasher, sync::OnceLock, time::Duration};
+
+use fxhash::FxHasher;
 #[cfg(feature = "serde")]
 use serde::{de::Error, Deserialize};
+use ustr::Ustr;
 
-use std::ffi::c_void;
-
+#[cfg(feature = "serde")]
+use crate::ser_de::SchemaDeserialize;
 use crate::{alloc::TypeDatas, prelude::*, raw_fns::*};
-
-use std::{alloc::Layout, any::TypeId, hash::Hasher, sync::OnceLock, time::Duration};
 
 macro_rules! impl_primitive {
     ($t:ty, $prim:expr ) => {

--- a/framework_crates/bones_scripting/Cargo.toml
+++ b/framework_crates/bones_scripting/Cargo.toml
@@ -12,17 +12,19 @@ keywords.workspace      = true
 
 [dependencies]
 async-channel   = "1.9"
-tracing         = "0.1"
 bevy_tasks      = { version = "0.11", features = ["multi-threaded"] }
-bones_lib       = { version = "0.4.0", path = "../bones_lib" }
 bones_asset     = { version = "0.4.0", path = "../bones_asset" }
-piccolo         = { version = "0.3" }
-gc-arena        = { version = "0.5" }
-gc-arena-derive = { version = "0.5" }
+bones_lib       = { version = "0.4.0", path = "../bones_lib" }
+futures-lite    = { workspace = true }
+gc-arena        = "0.5"
+gc-arena-derive = "0.5"
+parking_lot     = { workspace = true }
+piccolo         = "0.3"
 send_wrapper    = "0.6.0"
+tracing         = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-piccolo = { version = "0.3" }
+piccolo = "0.3"

--- a/framework_crates/bones_scripting/src/lua/asset.rs
+++ b/framework_crates/bones_scripting/src/lua/asset.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bevy_tasks::ThreadExecutor;
+use futures_lite::future::Boxed as BoxedFuture;
 use piccolo::{
     Callback, CallbackReturn, Closure, Context, Executor, StashedClosure, Table, UserData,
 };
@@ -22,11 +23,7 @@ pub struct LuaScript {
 /// Asset loader for [`LuaScript`].
 struct LuaScriptLoader;
 impl AssetLoader for LuaScriptLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let script = LuaScript {
@@ -245,11 +242,7 @@ pub struct LuaPluginSystems {
 
 struct LuaPluginLoader;
 impl AssetLoader for LuaPluginLoader {
-    fn load(
-        &self,
-        _ctx: AssetLoadCtx,
-        bytes: &[u8],
-    ) -> futures::future::Boxed<anyhow::Result<SchemaBox>> {
+    fn load(&self, _ctx: AssetLoadCtx, bytes: &[u8]) -> BoxedFuture<anyhow::Result<SchemaBox>> {
         let bytes = bytes.to_vec();
         Box::pin(async move {
             let script = LuaPlugin {

--- a/framework_crates/bones_utils/Cargo.toml
+++ b/framework_crates/bones_utils/Cargo.toml
@@ -11,18 +11,20 @@ categories.workspace    = true
 keywords.workspace      = true
 
 [features]
+default = ["ulid"]
 serde = ["dep:serde", "hashbrown/serde"]
+ulid = ["dep:ulid", "instant", "turborand"]
 
 [dependencies]
 bones_utils_macros = { version = "0.4", path = "./macros" }
 fxhash             = { workspace = true }
 hashbrown          = { workspace = true }
-instant            = { version = "0.1", features = ["wasm-bindgen"] }
-turborand          = "0.10"
-ulid               = "1.0"
 
 # Optional
-serde = { version = "1.0", optional = true }
+instant   = { version = "0.1", features = ["wasm-bindgen"], optional = true }
+serde     = { version = "1.0", optional = true }
+turborand = { version = "0.10", optional = true }
+ulid      = { version = "1.0", optional = true }
 
 # Make sure that the getrandom package, used in `ulid` works on web
 # when compiling for WASM.

--- a/framework_crates/bones_utils/Cargo.toml
+++ b/framework_crates/bones_utils/Cargo.toml
@@ -11,22 +11,18 @@ categories.workspace    = true
 keywords.workspace      = true
 
 [features]
-serde = ["dep:serde", "hashbrown/serde", "ustr/serde"]
+serde = ["dep:serde", "hashbrown/serde"]
 
 [dependencies]
 bones_utils_macros = { version = "0.4", path = "./macros" }
-smallvec           = "1.11"
-fxhash             = "0.2"
-hashbrown          = { version = "0.14" }
-ulid               = "1.0"
-parking_lot        = "0.12"
-serde              = { version = "1.0", optional = true }
-maybe-owned        = "0.3"
-branches           = "0.1"
-ustr               = "0.10"
-futures-lite       = "2.3"
-turborand          = "0.10"
+fxhash             = { workspace = true }
+hashbrown          = { workspace = true }
 instant            = { version = "0.1", features = ["wasm-bindgen"] }
+turborand          = "0.10"
+ulid               = "1.0"
+
+# Optional
+serde = { version = "1.0", optional = true }
 
 # Make sure that the getrandom package, used in `ulid` works on web
 # when compiling for WASM.

--- a/framework_crates/bones_utils/src/lib.rs
+++ b/framework_crates/bones_utils/src/lib.rs
@@ -18,15 +18,6 @@ macro_rules! pub_use {
     () => {
         pub use crate::{collections::*, default::*, labeled_id::*, names::*, random::*, ulid::*};
         pub use bones_utils_macros::*;
-        pub use branches::{likely, unlikely};
-        pub use futures_lite as futures;
-        pub use fxhash;
-        pub use hashbrown;
-        pub use maybe_owned::*;
-        pub use parking_lot;
-        pub use smallvec::*;
-        pub use turborand::*;
-        pub use ustr::{ustr, Ustr, UstrMap, UstrSet};
     };
 }
 pub_use!();

--- a/framework_crates/bones_utils/src/lib.rs
+++ b/framework_crates/bones_utils/src/lib.rs
@@ -8,15 +8,22 @@
 
 mod collections;
 mod default;
+#[cfg(feature = "ulid")]
 mod labeled_id;
 mod names;
+#[cfg(feature = "turborand")]
 mod random;
+#[cfg(feature = "ulid")]
 mod ulid;
 
 /// Helper to export the same types in the crate root and in the prelude.
 macro_rules! pub_use {
     () => {
-        pub use crate::{collections::*, default::*, labeled_id::*, names::*, random::*, ulid::*};
+        #[cfg(feature = "turborand")]
+        pub use crate::random::*;
+        pub use crate::{collections::*, default::*, names::*};
+        #[cfg(feature = "ulid")]
+        pub use crate::{labeled_id::*, ulid::*};
         pub use bones_utils_macros::*;
     };
 }


### PR DESCRIPTION
Closes #419 

## Changes

- Move all dependencies that are only re-exported (those not used directly) from `bones_utils` to the workspace
    - Other crates that used those re-exported modules now inherit the dependency from the workspace and use it directly
- Feature-flagged some modules in `bones_utils` that aren't needed by `bones_schema`
    - `ulid` was the main transitive dependency not needed by `bones_schema`
    - `instant` and `turborand` where only needed by the `ulid` module, so those were gated too
    - The rest of the utils modules could be gated as well, but the schema crate is the focus of these change

## Dependency Graph

I created a blank lib crate and took a path dependency on `bones_schema`. Then used [cargo-depgraph](https://crates.io/crates/cargo-depgraph/) to visualize the resulting dependencies of these changes.

### Before

![deps-before](https://github.com/user-attachments/assets/70d766b5-d6a9-4ba1-8548-687c3091df96)

### After

![deps-after](https://github.com/user-attachments/assets/50172a6c-3c00-4671-95bd-1cbd9e771b4e)
