### PR TITLE
feat: RNG Generator in bones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "tracing-tracy",
  "tracing-wasm",
  "ttf-parser",
+ "turborand",
  "unic-langid",
 ]
 

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -153,6 +153,7 @@ smallvec               = "1.10"
 iroh-quinn             = "0.10"
 iroh-net               = "0.22"
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
+turborand              = { version = "0.10.0", features = ["atomic"] }
 
 directories = "5.0"
 

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -4,7 +4,7 @@ use self::{
     input::{DenseInput, NetworkInputConfig, NetworkPlayerControl, NetworkPlayerControls},
     socket::Socket,
 };
-use crate::networking::online::OnlineMatchmakerResponse;
+use crate::networking::{online::OnlineMatchmakerResponse, random::RngGenerator};
 use crate::prelude::*;
 use bones_matchmaker_proto::{MATCH_ALPN, PLAY_ALPN};
 use ggrs::P2PSession;
@@ -27,6 +27,7 @@ pub mod online;
 pub mod online_lobby;
 pub mod online_matchmaking;
 pub mod proto;
+pub mod random;
 pub mod socket;
 
 #[cfg(feature = "net-debug")]
@@ -895,6 +896,12 @@ where
                                                     *handle, stats,
                                                 );
                                         }
+                                    }
+
+                                    // Create and insert the RngGenerator resource if it doesn't exist
+                                    if world.resources.get::<RngGenerator>().is_none() {
+                                        let rng_generator = RngGenerator::new(self.random_seed);
+                                        world.insert_resource(rng_generator);
                                     }
 
                                     // TODO: Make sure SyncingInfo is initialized immediately when session is created,

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -60,7 +60,7 @@ impl From<ggrs::InputStatus> for NetworkInputStatus {
 
 /// Module prelude.
 pub mod prelude {
-    pub use super::{input, lan, online, proto, DisconnectedPlayers, SyncingInfo, RUNTIME};
+    pub use super::{input, lan, online, proto, DisconnectedPlayers, SyncingInfo, RUNTIME, random};
 
     #[cfg(feature = "net-debug")]
     pub use super::debug::prelude::*;

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -4,7 +4,8 @@ use self::{
     input::{DenseInput, NetworkInputConfig, NetworkPlayerControl, NetworkPlayerControls},
     socket::Socket,
 };
-use crate::networking::{online::OnlineMatchmakerResponse, random::RngGenerator};
+use crate::networking::online::OnlineMatchmakerResponse;
+pub use crate::networking::random::RngGenerator;
 use crate::prelude::*;
 use bones_matchmaker_proto::{MATCH_ALPN, PLAY_ALPN};
 use ggrs::P2PSession;
@@ -60,7 +61,7 @@ impl From<ggrs::InputStatus> for NetworkInputStatus {
 
 /// Module prelude.
 pub mod prelude {
-    pub use super::{input, lan, online, proto, DisconnectedPlayers, SyncingInfo, RUNTIME, random};
+    pub use super::{input, lan, online, proto, DisconnectedPlayers, SyncingInfo, RUNTIME, random, RngGenerator};
 
     #[cfg(feature = "net-debug")]
     pub use super::debug::prelude::*;

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -61,7 +61,9 @@ impl From<ggrs::InputStatus> for NetworkInputStatus {
 
 /// Module prelude.
 pub mod prelude {
-    pub use super::{input, lan, online, proto, DisconnectedPlayers, SyncingInfo, RUNTIME, random, RngGenerator};
+    pub use super::{
+        input, lan, online, proto, random, DisconnectedPlayers, RngGenerator, SyncingInfo, RUNTIME,
+    };
 
     #[cfg(feature = "net-debug")]
     pub use super::debug::prelude::*;

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -8,6 +8,7 @@ use crate::{
         piccolo::{self as lua, Callback},
     },
 };
+use core::ops::RangeBounds;
 pub use turborand::prelude::*;
 
 /// Resource that produces deterministic pseudo-random numbers/strings.
@@ -36,129 +37,169 @@ impl RngGenerator {
         }
     }
 
+    /// Generate a random u8
+    pub fn gen_u8(&mut self) -> u8 {
+        self.internal_generator.gen_u8()
+    }
+
+    /// Generate a random u8 within the given range
+    pub fn gen_u8_range<R: RangeBounds<u8>>(&mut self, range: R) -> u8 {
+        self.internal_generator.u8(range)
+    }
+
+    /// Generate a random i8
+    pub fn gen_i8(&mut self) -> i8 {
+        self.internal_generator.gen_i8()
+    }
+
+    /// Generate a random i8 within the given range
+    pub fn gen_i8_range<R: RangeBounds<i8>>(&mut self, range: R) -> i8 {
+        self.internal_generator.i8(range)
+    }
+
+    /// Generate a random u16
+    pub fn gen_u16(&mut self) -> u16 {
+        self.internal_generator.gen_u16()
+    }
+
+    /// Generate a random u16 within the given range
+    pub fn gen_u16_range<R: RangeBounds<u16>>(&mut self, range: R) -> u16 {
+        self.internal_generator.u16(range)
+    }
+
+    /// Generate a random i16
+    pub fn gen_i16(&mut self) -> i16 {
+        self.internal_generator.gen_i16()
+    }
+
+    /// Generate a random i16 within the given range
+    pub fn gen_i16_range<R: RangeBounds<i16>>(&mut self, range: R) -> i16 {
+        self.internal_generator.i16(range)
+    }
+
+    /// Generate a random u32
+    pub fn gen_u32(&mut self) -> u32 {
+        self.internal_generator.gen_u32()
+    }
+
+    /// Generate a random u32 within the given range
+    pub fn gen_u32_range<R: RangeBounds<u32>>(&mut self, range: R) -> u32 {
+        self.internal_generator.u32(range)
+    }
+
+    /// Generate a random i32
+    pub fn gen_i32(&mut self) -> i32 {
+        self.internal_generator.gen_i32()
+    }
+
+    /// Generate a random i32 within the given range
+    pub fn gen_i32_range<R: RangeBounds<i32>>(&mut self, range: R) -> i32 {
+        self.internal_generator.i32(range)
+    }
+
+    /// Generate a random u64
+    pub fn gen_u64(&mut self) -> u64 {
+        self.internal_generator.gen_u64()
+    }
+
+    /// Generate a random u64 within the given range
+    pub fn gen_u64_range<R: RangeBounds<u64>>(&mut self, range: R) -> u64 {
+        self.internal_generator.u64(range)
+    }
+
+    /// Generate a random i64
+    pub fn gen_i64(&mut self) -> i64 {
+        self.internal_generator.gen_i64()
+    }
+
+    /// Generate a random i64 within the given range
+    pub fn gen_i64_range<R: RangeBounds<i64>>(&mut self, range: R) -> i64 {
+        self.internal_generator.i64(range)
+    }
+
+    /// Generate a random usize
+    pub fn gen_usize(&mut self) -> usize {
+        self.internal_generator.gen_usize()
+    }
+
+    /// Generate a random usize within the given range
+    pub fn gen_usize_range<R: RangeBounds<usize>>(&mut self, range: R) -> usize {
+        self.internal_generator.usize(range)
+    }
+
+    /// Generate a random isize
+    pub fn gen_isize(&mut self) -> isize {
+        self.internal_generator.gen_isize()
+    }
+
+    /// Generate a random isize within the given range
+    pub fn gen_isize_range<R: RangeBounds<isize>>(&mut self, range: R) -> isize {
+        self.internal_generator.isize(range)
+    }
+
+    /// Generate a random f32
+    pub fn gen_f32(&mut self) -> f32 {
+        self.internal_generator.f32()
+    }
+
+    /// Generate a random f32 within the given range
+    pub fn gen_f32_range<R: RangeBounds<f32>>(&mut self, range: R) -> f32 {
+        let start = match range.start_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n,
+            std::ops::Bound::Unbounded => 0.0,
+        };
+        let end = match range.end_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n,
+            std::ops::Bound::Unbounded => 1.0,
+        };
+        loop {
+            let n = self.gen_f32();
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random f64
+    pub fn gen_f64(&mut self) -> f64 {
+        self.internal_generator.f64()
+    }
+
+    /// Generate a random f64 within the given range
+    pub fn gen_f64_range<R: RangeBounds<f64>>(&mut self, range: R) -> f64 {
+        let start = match range.start_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n,
+            std::ops::Bound::Unbounded => 0.0,
+        };
+        let end = match range.end_bound() {
+            std::ops::Bound::Included(&n) => n,
+            std::ops::Bound::Excluded(&n) => n,
+            std::ops::Bound::Unbounded => 1.0,
+        };
+        loop {
+            let n = self.gen_f64();
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random bool
+    pub fn gen_bool(&mut self) -> bool {
+        self.internal_generator.bool()
+    }
+
     /// Generate a random printable ASCII character
     pub fn gen_random_ascii_char(&mut self) -> char {
-        self.gen_u8_range(33, 126) as char
+        self.gen_u8_range(33..=126) as char
     }
 
     /// Generate a random ASCII string of the specified length
     pub fn gen_random_ascii_string(&mut self, length: u64) -> String {
         (0..length).map(|_| self.gen_random_ascii_char()).collect()
-    }
-
-    /// Generate a random u8 within the given range (inclusive)
-    pub fn gen_u8_range(&mut self, start: u8, end: u8) -> u8 {
-        loop {
-            let n = self.gen_u64() as u8;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random i8 within the given range (inclusive)
-    pub fn gen_i8_range(&mut self, start: i8, end: i8) -> i8 {
-        loop {
-            let n = self.gen_i64() as i8;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random u16 within the given range (inclusive)
-    pub fn gen_u16_range(&mut self, start: u16, end: u16) -> u16 {
-        loop {
-            let n = self.gen_u64() as u16;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random i16 within the given range (inclusive)
-    pub fn gen_i16_range(&mut self, start: i16, end: i16) -> i16 {
-        loop {
-            let n = self.gen_i64() as i16;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random u32 within the given range (inclusive)
-    pub fn gen_u32_range(&mut self, start: u32, end: u32) -> u32 {
-        loop {
-            let n = self.gen_u64() as u32;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random i32 within the given range (inclusive)
-    pub fn gen_i32_range(&mut self, start: i32, end: i32) -> i32 {
-        loop {
-            let n = self.gen_i64() as i32;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random u64 within the given range (inclusive)
-    pub fn gen_u64_range(&mut self, start: u64, end: u64) -> u64 {
-        loop {
-            let n = self.gen_u64();
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random i64 within the given range (inclusive)
-    pub fn gen_i64_range(&mut self, start: i64, end: i64) -> i64 {
-        loop {
-            let n = self.gen_i64();
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random usize within the given range (inclusive)
-    pub fn gen_usize_range(&mut self, start: usize, end: usize) -> usize {
-        loop {
-            let n = self.gen_u64() as usize;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-
-    /// Generate a random isize within the given range (inclusive)
-    pub fn gen_isize_range(&mut self, start: isize, end: isize) -> isize {
-        loop {
-            let n = self.gen_i64() as isize;
-            if n >= start && n <= end {
-                return n;
-            }
-        }
-    }
-}
-
-// Implement Deref and DerefMut to allow direct access to AtomicRng methods
-impl std::ops::Deref for RngGenerator {
-    type Target = AtomicRng;
-
-    fn deref(&self) -> &Self::Target {
-        &self.internal_generator
-    }
-}
-
-impl std::ops::DerefMut for RngGenerator {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.internal_generator
     }
 }
 

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use core::ops::RangeBounds;
+use std::collections::VecDeque;
 pub use turborand::prelude::*;
 
 /// Resource that produces deterministic pseudo-random numbers/strings.
@@ -233,6 +234,31 @@ impl RngGenerator {
             self.gen_f32_range(y_range),
             self.gen_f32_range(z_range),
         )
+    }
+
+    /// Shuffle a Vec in place
+    pub fn shuffle_vec<T>(&mut self, vec: &mut Vec<T>) {
+        for i in (1..vec.len()).rev() {
+            let j = self.gen_usize_range(0..=i);
+            vec.swap(i, j);
+        }
+    }
+
+    /// Shuffle an SVec in place
+    pub fn shuffle_svec<T: HasSchema>(&mut self, svec: &mut SVec<T>) {
+        for i in (1..svec.len()).rev() {
+            let j = self.gen_usize_range(0..=i);
+            svec.swap(i, j);
+        }
+    }
+
+    /// Shuffle a VecDeque in place
+    pub fn shuffle_vecdeque<T>(&mut self, deque: &mut VecDeque<T>) {
+        let len = deque.len();
+        for i in (1..len).rev() {
+            let j = self.gen_usize_range(0..=i);
+            deque.swap(i, j);
+        }
     }
 }
 

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -13,7 +13,7 @@ pub use turborand::prelude::*;
 /// Resource that produces deterministic pseudo-random numbers/strings.
 ///
 /// Access in a system with [`Res<RngGenerator>`].
-#[derive(Clone, HasSchema, Deref, DerefMut)]
+#[derive(Clone, HasSchema)]
 #[type_data(SchemaLuaEcsRefMetatable(lua_metatable))]
 pub struct RngGenerator {
     internal_generator: AtomicRng,
@@ -34,6 +34,121 @@ impl RngGenerator {
         Self {
             internal_generator: AtomicRng::with_seed(seed),
         }
+    }
+
+    /// Generate a random u8 within the given range (inclusive)
+    pub fn gen_u8_range(&mut self, start: u8, end: u8) -> u8 {
+        loop {
+            let n = self.gen_u64() as u8;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random i8 within the given range (inclusive)
+    pub fn gen_i8_range(&mut self, start: i8, end: i8) -> i8 {
+        loop {
+            let n = self.gen_i64() as i8;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random u16 within the given range (inclusive)
+    pub fn gen_u16_range(&mut self, start: u16, end: u16) -> u16 {
+        loop {
+            let n = self.gen_u64() as u16;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random i16 within the given range (inclusive)
+    pub fn gen_i16_range(&mut self, start: i16, end: i16) -> i16 {
+        loop {
+            let n = self.gen_i64() as i16;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random u32 within the given range (inclusive)
+    pub fn gen_u32_range(&mut self, start: u32, end: u32) -> u32 {
+        loop {
+            let n = self.gen_u64() as u32;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random i32 within the given range (inclusive)
+    pub fn gen_i32_range(&mut self, start: i32, end: i32) -> i32 {
+        loop {
+            let n = self.gen_i64() as i32;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random u64 within the given range (inclusive)
+    pub fn gen_u64_range(&mut self, start: u64, end: u64) -> u64 {
+        loop {
+            let n = self.gen_u64();
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random i64 within the given range (inclusive)
+    pub fn gen_i64_range(&mut self, start: i64, end: i64) -> i64 {
+        loop {
+            let n = self.gen_i64();
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random usize within the given range (inclusive)
+    pub fn gen_usize_range(&mut self, start: usize, end: usize) -> usize {
+        loop {
+            let n = self.gen_u64() as usize;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+
+    /// Generate a random isize within the given range (inclusive)
+    pub fn gen_isize_range(&mut self, start: isize, end: isize) -> isize {
+        loop {
+            let n = self.gen_i64() as isize;
+            if n >= start && n <= end {
+                return n;
+            }
+        }
+    }
+}
+
+// Implement Deref and DerefMut to allow direct access to AtomicRng methods
+impl std::ops::Deref for RngGenerator {
+    type Target = AtomicRng;
+
+    fn deref(&self) -> &Self::Target {
+        &self.internal_generator
+    }
+}
+
+impl std::ops::DerefMut for RngGenerator {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.internal_generator
     }
 }
 

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -1,0 +1,74 @@
+//! Global, deterministic RNG generation resource.
+
+use crate::prelude::*;
+use crate::{
+    prelude::bindings::EcsRef,
+    scripting::lua::{
+        bindings::SchemaLuaEcsRefMetatable,
+        piccolo::{self as lua, Callback},
+    },
+};
+pub use turborand::prelude::*;
+
+/// Resource that produces deterministic pseudo-random numbers/strings.
+///
+/// Access in a system with [`Res<RngGenerator>`].
+#[derive(Clone, HasSchema, Deref, DerefMut)]
+#[type_data(SchemaLuaEcsRefMetatable(lua_metatable))]
+pub struct RngGenerator {
+    internal_generator: AtomicRng,
+}
+
+impl Default for RngGenerator {
+    /// Creates a new `RngGenerator`, initializing it with a harcoded seed
+    fn default() -> Self {
+        Self {
+            internal_generator: AtomicRng::with_seed(7),
+        }
+    }
+}
+
+impl RngGenerator {
+    /// Creates a new `RngGenerator`, initializing it with the provided seed
+    pub fn new(seed: u64) -> Self {
+        Self {
+            internal_generator: AtomicRng::with_seed(seed),
+        }
+    }
+}
+
+fn lua_metatable(ctx: lua::Context) -> lua::Table {
+    let metatable = lua::Table::new(&ctx);
+
+    let f32_fn = ctx.registry().stash(
+        &ctx,
+        Callback::from_fn(&ctx, |ctx, _fuel, mut stack| {
+            let this: &EcsRef = stack.consume(ctx)?;
+            let mut b = this.borrow_mut();
+            let rng_generator = b.schema_ref_mut()?.cast_into_mut::<RngGenerator>();
+            let n = rng_generator.internal_generator.f32();
+            stack.replace(ctx, n);
+            Ok(lua::CallbackReturn::Return)
+        }),
+    );
+    metatable
+        .set(
+            ctx,
+            "__index",
+            Callback::from_fn(&ctx, move |ctx, _fuel, mut stack| {
+                let (_this, key): (lua::Value, lua::String) = stack.consume(ctx)?;
+
+                #[allow(clippy::single_match)]
+                match key.as_bytes() {
+                    b"f32" => {
+                        stack.push_front(ctx.registry().fetch(&f32_fn).into());
+                    }
+                    _ => (),
+                }
+                Ok(lua::CallbackReturn::Return)
+            }),
+        )
+        .unwrap();
+
+    metatable
+}

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -36,6 +36,16 @@ impl RngGenerator {
         }
     }
 
+    /// Generate a random printable ASCII character
+    pub fn gen_random_ascii_char(&mut self) -> char {
+        self.gen_u8_range(33, 126) as char
+    }
+
+    /// Generate a random ASCII string of the specified length
+    pub fn gen_random_ascii_string(&mut self, length: u64) -> String {
+        (0..length).map(|_| self.gen_random_ascii_char()).collect()
+    }
+
     /// Generate a random u8 within the given range (inclusive)
     pub fn gen_u8_range(&mut self, start: u8, end: u8) -> u8 {
         loop {

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -201,6 +201,39 @@ impl RngGenerator {
     pub fn gen_random_ascii_string(&mut self, length: u64) -> String {
         (0..length).map(|_| self.gen_random_ascii_char()).collect()
     }
+
+    /// Generate a random Vec2
+    pub fn gen_vec2(&mut self) -> Vec2 {
+        Vec2::new(self.gen_f32(), self.gen_f32())
+    }
+
+    /// Generate a random Vec2 within the given ranges for each component
+    pub fn gen_vec2_range<R1: RangeBounds<f32>, R2: RangeBounds<f32>>(
+        &mut self,
+        x_range: R1,
+        y_range: R2,
+    ) -> Vec2 {
+        Vec2::new(self.gen_f32_range(x_range), self.gen_f32_range(y_range))
+    }
+
+    /// Generate a random Vec3
+    pub fn gen_vec3(&mut self) -> Vec3 {
+        Vec3::new(self.gen_f32(), self.gen_f32(), self.gen_f32())
+    }
+
+    /// Generate a random Vec3 within the given ranges for each component
+    pub fn gen_vec3_range<R1: RangeBounds<f32>, R2: RangeBounds<f32>, R3: RangeBounds<f32>>(
+        &mut self,
+        x_range: R1,
+        y_range: R2,
+        z_range: R3,
+    ) -> Vec3 {
+        Vec3::new(
+            self.gen_f32_range(x_range),
+            self.gen_f32_range(y_range),
+            self.gen_f32_range(z_range),
+        )
+    }
 }
 
 fn lua_metatable(ctx: lua::Context) -> lua::Table {

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -227,11 +227,8 @@ impl RngGenerator {
     }
 
     /// Shuffle a Vec in place
-    pub fn shuffle_vec<T>(&mut self, vec: &mut Vec<T>) {
-        for i in (1..vec.len()).rev() {
-            let j = self.gen_usize_range(0..=i);
-            vec.swap(i, j);
-        }
+    pub fn shuffle_vec<T>(&mut self, vec: &mut [T]) {
+        self.internal_generator.shuffle(vec);
     }
 
     /// Shuffle an SVec in place

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -193,16 +193,6 @@ impl RngGenerator {
         self.internal_generator.bool()
     }
 
-    /// Generate a random printable ASCII character
-    pub fn gen_random_ascii_char(&mut self) -> char {
-        self.gen_u8_range(33..=126) as char
-    }
-
-    /// Generate a random ASCII string of the specified length
-    pub fn gen_random_ascii_string(&mut self, length: u64) -> String {
-        (0..length).map(|_| self.gen_random_ascii_char()).collect()
-    }
-
     /// Generate a random Vec2
     pub fn gen_vec2(&mut self) -> Vec2 {
         Vec2::new(self.gen_f32(), self.gen_f32())
@@ -259,6 +249,124 @@ impl RngGenerator {
             let j = self.gen_usize_range(0..=i);
             deque.swap(i, j);
         }
+    }
+
+    /// Generates a random `char` in ranges a-z and A-Z.
+    pub fn gen_alphabetic(&mut self) -> char {
+        self.internal_generator.alphabetic()
+    }
+
+    /// Generates a random `char` in ranges a-z, A-Z and 0-9.
+    pub fn gen_alphanumeric(&mut self) -> char {
+        self.internal_generator.alphanumeric()
+    }
+
+    /// Generates a random `char` in the range a-z.
+    pub fn gen_lowercase(&mut self) -> char {
+        self.internal_generator.lowercase()
+    }
+
+    /// Generates a random `char` in the range A-Z.
+    pub fn gen_uppercase(&mut self) -> char {
+        self.internal_generator.uppercase()
+    }
+
+    /// Generate a random digit in the given `radix`.
+    /// Digits are represented by `char`s in ranges 0-9 and a-z.
+    ///
+    /// # Panics
+    /// Panics if the `radix` is zero or greater than 36.
+    pub fn gen_digit(&mut self, radix: u8) -> char {
+        self.internal_generator.digit(radix)
+    }
+
+    /// Generates a random `char` in the given range.
+    ///
+    /// # Panics
+    /// Panics if the range is empty.
+    pub fn gen_char<R: RangeBounds<char>>(&mut self, bounds: R) -> char {
+        self.internal_generator.char(bounds)
+    }
+
+    /// Generate a random printable ASCII character
+    pub fn gen_random_ascii_char(&mut self) -> char {
+        self.gen_u8_range(33..=126) as char
+    }
+
+    /// Generate a random ASCII string of the specified length
+    pub fn gen_random_ascii_string(&mut self, length: u64) -> String {
+        (0..length).map(|_| self.gen_random_ascii_char()).collect()
+    }
+
+    /// Returns a boolean, where `success_rate` represents the chance to return a true value,
+    /// with 0.0 being no chance and 1.0 will always return true.
+    pub fn gen_chance(&mut self, success_rate: f64) -> bool {
+        let clamped_rate = success_rate.clamp(0.0, 1.0);
+        self.internal_generator.chance(clamped_rate)
+    }
+
+    /// Samples a random item from a slice of values.
+    pub fn gen_sample<'a, T>(&mut self, list: &'a [T]) -> Option<&'a T> {
+        self.internal_generator.sample(list)
+    }
+
+    /// Samples a random item from an iterator of values.
+    pub fn gen_sample_iter<T: Iterator>(&mut self, list: T) -> Option<T::Item> {
+        self.internal_generator.sample_iter(list)
+    }
+
+    /// Samples a random &mut item from a slice of values.
+    pub fn gen_sample_mut<'a, T>(&mut self, list: &'a mut [T]) -> Option<&'a mut T> {
+        self.internal_generator.sample_mut(list)
+    }
+
+    /// Samples multiple unique items from a slice of values.
+    pub fn gen_sample_multiple<'a, T>(&mut self, list: &'a [T], amount: usize) -> Vec<&'a T> {
+        self.internal_generator.sample_multiple(list, amount)
+    }
+
+    /// Samples multiple unique items from a mutable slice of values.
+    pub fn gen_sample_multiple_mut<'a, T>(
+        &mut self,
+        list: &'a mut [T],
+        amount: usize,
+    ) -> Vec<&'a mut T> {
+        self.internal_generator.sample_multiple_mut(list, amount)
+    }
+
+    /// Samples multiple unique items from an iterator of values.
+    pub fn gen_sample_multiple_iter<T: Iterator>(
+        &mut self,
+        list: T,
+        amount: usize,
+    ) -> Vec<T::Item> {
+        self.internal_generator.sample_multiple_iter(list, amount)
+    }
+
+    /// Stochastic Acceptance implementation of Roulette Wheel weighted selection.
+    pub fn gen_weighted_sample<'a, T, F>(
+        &mut self,
+        list: &'a [T],
+        weight_sampler: F,
+    ) -> Option<&'a T>
+    where
+        F: Fn((&T, usize)) -> f64,
+    {
+        self.internal_generator
+            .weighted_sample(list, weight_sampler)
+    }
+
+    /// Stochastic Acceptance implementation of Roulette Wheel weighted selection for mutable references.
+    pub fn gen_weighted_sample_mut<'a, T, F>(
+        &mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn((&T, usize)) -> f64,
+    {
+        self.internal_generator
+            .weighted_sample_mut(list, weight_sampler)
     }
 }
 

--- a/framework_crates/bones_framework/src/networking/random.rs
+++ b/framework_crates/bones_framework/src/networking/random.rs
@@ -1,6 +1,7 @@
 //! Global, deterministic RNG generation resource.
 
 use crate::prelude::*;
+#[cfg(feature = "scripting")]
 use crate::{
     prelude::bindings::EcsRef,
     scripting::lua::{
@@ -10,7 +11,7 @@ use crate::{
 };
 use core::ops::RangeBounds;
 use std::collections::VecDeque;
-pub use turborand::prelude::*;
+use turborand::prelude::*;
 
 /// Resource that produces deterministic pseudo-random numbers/strings.
 ///
@@ -367,6 +368,7 @@ impl RngGenerator {
     }
 }
 
+#[cfg(feature = "scripting")]
 fn lua_metatable(ctx: lua::Context) -> lua::Table {
     let metatable = lua::Table::new(&ctx);
 


### PR DESCRIPTION
This PR focused on finally linking the random seed generated by the matchmaker (pushing it to client was implemented in previous PR) into the GgrsSessionRunner + SyncingInfo, and then using it to create and insert a `RngGenerator` resource automatically for the developer to use easily.

Additionally, I created reworked the previous flow, now having a new interface that both re-wraps all of the Turborand methods (a few functions were inconsistent naming-wise, and gives us more flexibility to change stuff in the future), and also implements a number of missing functionality that will be helpful to devs. This new `RngGenerator` struct now supports:

1. Basic Number Generation: Methods for integers, floats, and booleans.
2. Range-based Generation: Methods for numbers within specified ranges.
3. Character/String Generation: Methods for various character types and ASCII strings.
4. Collection Manipulation: Methods for shuffling and sampling from collections (Vec/SVec/Vecdeque)
5. Probability/Weighted Selection: Methods for chance-based and weighted random selection.
6. Vector Generation: Methods for random Vec2 and Vec3 values.