### PR TITLE
feat: Direct Gilrs integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,22 +698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_gilrs"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f4d79c55829f8016014593a42453f61a564ffb06ef79460d25696ccdfac67b"
-dependencies = [
- "bevy_app",
- "bevy_ecs 0.11.3",
- "bevy_input",
- "bevy_log",
- "bevy_time",
- "bevy_utils 0.11.3",
- "gilrs 0.10.9",
- "thiserror",
-]
-
-[[package]]
 name = "bevy_gizmos"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +759,6 @@ dependencies = [
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs 0.11.3",
- "bevy_gilrs",
  "bevy_gizmos",
  "bevy_hierarchy",
  "bevy_input",
@@ -1480,7 +1463,7 @@ dependencies = [
  "fluent-langneg",
  "futures-lite 2.3.0",
  "ggrs",
- "gilrs 0.11.0",
+ "gilrs",
  "glam 0.24.2",
  "hex",
  "image 0.24.9",
@@ -3207,49 +3190,15 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb8c78963a8856a5b10015c9349176ff5edbc8095384d52aada467a848bc03a"
-dependencies = [
- "fnv",
- "gilrs-core 0.5.15",
- "log",
- "uuid",
- "vec_map",
-]
-
-[[package]]
-name = "gilrs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb2c998745a3c1ac90f64f4f7b3a54219fd3612d7705e7798212935641ed18f"
 dependencies = [
  "fnv",
- "gilrs-core 0.6.0",
+ "gilrs-core",
  "log",
  "uuid",
  "vec_map",
-]
-
-[[package]]
-name = "gilrs-core"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732dadc05170599ddec9a89653f10d7a2af54da9181b3fa6e2bd49907ec8f7e4"
-dependencies = [
- "core-foundation 0.9.4",
- "inotify 0.10.2",
- "io-kit-sys",
- "js-sys",
- "libc",
- "libudev-sys",
- "log",
- "nix 0.29.0",
- "uuid",
- "vec_map",
- "wasm-bindgen",
- "web-sys",
- "windows 0.58.0",
 ]
 
 [[package]]
@@ -3895,17 +3844,6 @@ name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
  "bevy_log",
  "bevy_time",
  "bevy_utils 0.11.3",
- "gilrs",
+ "gilrs 0.10.9",
  "thiserror",
 ]
 
@@ -1480,6 +1480,7 @@ dependencies = [
  "fluent-langneg",
  "futures-lite 2.3.0",
  "ggrs",
+ "gilrs 0.11.0",
  "glam 0.24.2",
  "hex",
  "image 0.24.9",
@@ -1934,6 +1935,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +1957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types 0.3.2",
  "libc",
@@ -1959,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types 0.5.0",
  "libc",
@@ -1972,7 +1983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -3201,7 +3212,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb8c78963a8856a5b10015c9349176ff5edbc8095384d52aada467a848bc03a"
 dependencies = [
  "fnv",
- "gilrs-core",
+ "gilrs-core 0.5.15",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb2c998745a3c1ac90f64f4f7b3a54219fd3612d7705e7798212935641ed18f"
+dependencies = [
+ "fnv",
+ "gilrs-core 0.6.0",
  "log",
  "uuid",
  "vec_map",
@@ -3213,8 +3237,29 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732dadc05170599ddec9a89653f10d7a2af54da9181b3fa6e2bd49907ec8f7e4"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.9.4",
  "inotify 0.10.2",
+ "io-kit-sys",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.29.0",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495af945e45efd6386227613cd9fb7bd7c43d3c095040e30c5304c489e6abed5"
+dependencies = [
+ "core-foundation 0.10.0",
+ "inotify 0.11.0",
  "io-kit-sys",
  "js-sys",
  "libc",
@@ -3863,6 +3908,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
 dependencies = [
  "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.6.0",
  "inotify-sys",
  "libc",
 ]
@@ -6462,7 +6518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7148,7 +7204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -8000,7 +8056,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.9.4",
  "home",
  "jni",
  "log",
@@ -8581,7 +8637,7 @@ dependencies = [
  "android-activity",
  "bitflags 1.3.2",
  "cfg_aliases 0.1.1",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics 0.22.3",
  "dispatch",
  "instant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "postcard",
  "rcgen",
  "rustls 0.21.12",
+ "send_wrapper",
  "serde",
  "serde_yaml",
  "smallvec",

--- a/framework_crates/bones_bevy_renderer/Cargo.toml
+++ b/framework_crates/bones_bevy_renderer/Cargo.toml
@@ -26,7 +26,7 @@ anyhow              = "1.0"
 
 [dependencies.bevy]
 default-features = false
-features         = ["bevy_render", "bevy_core_pipeline", "bevy_sprite", "x11", "bevy_gilrs"]
+features         = ["bevy_render", "bevy_core_pipeline", "bevy_sprite", "x11"]
 version          = "0.11"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/framework_crates/bones_bevy_renderer/src/input.rs
+++ b/framework_crates/bones_bevy_renderer/src/input.rs
@@ -1,5 +1,3 @@
-// framework_crates/bones_bevy_renderer/src/input.rs
-
 use super::*;
 use bevy::{
     input::{

--- a/framework_crates/bones_bevy_renderer/src/input.rs
+++ b/framework_crates/bones_bevy_renderer/src/input.rs
@@ -1,13 +1,15 @@
+// framework_crates/bones_bevy_renderer/src/input.rs
+
 use super::*;
 use bevy::{
     input::{
-        gamepad::GamepadEvent,
         keyboard::KeyboardInput,
         mouse::{MouseButtonInput, MouseMotion, MouseWheel},
     },
     window::PrimaryWindow,
 };
 use bones::{MouseScreenPosition, MouseWorldPosition};
+use bones_framework::input::gilrs::process_gamepad_events;
 
 pub fn insert_bones_input(
     In((mouse_inputs, keyboard_inputs, gamepad_inputs)): In<(
@@ -28,7 +30,6 @@ pub fn get_bones_input(
     mut mouse_motion_events: EventReader<MouseMotion>,
     mut mouse_wheel_events: EventReader<MouseWheel>,
     mut keyboard_events: EventReader<KeyboardInput>,
-    mut gamepad_events: EventReader<GamepadEvent>,
 ) -> (
     bones::MouseInputs,
     bones::KeyboardInputs,
@@ -67,35 +68,7 @@ pub fn get_bones_input(
                 })
                 .collect(),
         },
-        bones::GamepadInputs {
-            gamepad_events: gamepad_events
-                .iter()
-                .map(|event| match event {
-                    GamepadEvent::Connection(c) => {
-                        bones::GamepadEvent::Connection(bones::GamepadConnectionEvent {
-                            gamepad: c.gamepad.id as u32,
-                            event: if c.connected() {
-                                bones::GamepadConnectionEventKind::Connected
-                            } else {
-                                bones::GamepadConnectionEventKind::Disconnected
-                            },
-                        })
-                    }
-                    GamepadEvent::Button(b) => {
-                        bones::GamepadEvent::Button(bones::GamepadButtonEvent {
-                            gamepad: b.gamepad.id as u32,
-                            button: b.button_type.into_bones(),
-                            value: b.value,
-                        })
-                    }
-                    GamepadEvent::Axis(a) => bones::GamepadEvent::Axis(bones::GamepadAxisEvent {
-                        gamepad: a.gamepad.id as u32,
-                        axis: a.axis_type.into_bones(),
-                        value: a.value,
-                    }),
-                })
-                .collect(),
-        },
+        process_gamepad_events(),
     )
 }
 

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -102,6 +102,8 @@ noise         = "0.9"
 once_cell     = "1.17"
 thiserror     = "1.0"
 gilrs         = "0.11.0"
+send_wrapper  = "0.6.0"
+
 
 # Tracing
 tracing            = "0.1"

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -101,6 +101,7 @@ instant       = { version = "0.1", features = ["wasm-bindgen"] }
 noise         = "0.9"
 once_cell     = "1.17"
 thiserror     = "1.0"
+gilrs         = "0.11.0"
 
 # Tracing
 tracing            = "0.1"
@@ -154,7 +155,6 @@ iroh-quinn             = "0.10"
 iroh-net               = "0.22"
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
 turborand              = { version = "0.10.0", features = ["atomic"] }
-gilrs                  = "0.11.0"
 
 directories = "5.0"
 

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -154,6 +154,7 @@ iroh-quinn             = "0.10"
 iroh-net               = "0.22"
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
 turborand              = { version = "0.10.0", features = ["atomic"] }
+gilrs                  = "0.11.0"
 
 directories = "5.0"
 

--- a/framework_crates/bones_framework/src/input.rs
+++ b/framework_crates/bones_framework/src/input.rs
@@ -5,6 +5,7 @@ use bones_schema::HasSchema;
 use self::prelude::{GamepadInputs, KeyboardInputs};
 
 pub mod gamepad;
+pub mod gilrs;
 pub mod keyboard;
 pub mod mouse;
 pub mod window;

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -1,3 +1,4 @@
+//! Gilrs integration.
 use crate::prelude::*;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsContext};
 use once_cell::sync::Lazy;

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -2,13 +2,14 @@
 use crate::prelude::*;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsContext};
 use once_cell::sync::Lazy;
+use send_wrapper::SendWrapper;
 use std::sync::{Arc, Mutex};
 
 /// Lazy-initialized GilrsContext
-static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
-    Arc::new(Mutex::new(
+static GILRS_CONTEXT: Lazy<Arc<Mutex<SendWrapper<GilrsContext>>>> = Lazy::new(|| {
+    Arc::new(Mutex::new(SendWrapper::new(
         GilrsContext::new().expect("Failed to initialize GilrsContext"),
-    ))
+    )))
 });
 
 /// Processes gilrs gamepad events into Bones-native GamepadInputs
@@ -17,7 +18,7 @@ pub fn process_gamepad_events() -> GamepadInputs {
     let mut gilrs = GILRS_CONTEXT.lock().unwrap();
     while let Some(gilrs_event) = gilrs
         .next_event()
-        .filter_ev(&axis_dpad_to_button, &mut gilrs)
+        .filter_ev(&axis_dpad_to_button, &mut *gilrs)
     {
         gilrs.update(&gilrs_event);
 

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -1,4 +1,3 @@
-// framework_crates/bones_framework/src/input/gilrs.rs
 use crate::prelude::*;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsContext};
 use once_cell::sync::Lazy;
@@ -11,6 +10,7 @@ static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
     ))
 });
 
+/// Processes gilrs gamepad events into Bones-native GamepadInputs
 pub fn process_gamepad_events() -> GamepadInputs {
     let mut gamepad_inputs = GamepadInputs::default();
     let mut gilrs = GILRS_CONTEXT.lock().unwrap();
@@ -67,6 +67,7 @@ pub fn process_gamepad_events() -> GamepadInputs {
     gamepad_inputs
 }
 
+/// Converts a gilrs button to a bones-native button
 fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {
     match button {
         gilrs::Button::South => Some(GamepadButton::South),
@@ -92,6 +93,7 @@ fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {
     }
 }
 
+/// Converts a gilrs axis to a bones-native axis
 fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxis> {
     match axis {
         gilrs::Axis::LeftStickX => Some(GamepadAxis::LeftStickX),

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -18,7 +18,7 @@ pub fn process_gamepad_events() -> GamepadInputs {
     let mut gilrs = GILRS_CONTEXT.lock().unwrap();
     while let Some(gilrs_event) = gilrs
         .next_event()
-        .filter_ev(&axis_dpad_to_button, &mut *gilrs)
+        .filter_ev(&axis_dpad_to_button, &mut gilrs)
     {
         gilrs.update(&gilrs_event);
 

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -1,12 +1,8 @@
-//! Gamepad input session, systems, and resources.
-
+// framework_crates/bones_framework/src/input/gilrs.rs
 use crate::prelude::*;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsContext};
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
-
-/// Name of the default bones input session
-pub const DEFAULT_BONES_INPUT_SESSION: &str = "BONES_INPUT";
 
 /// Lazy-initialized GilrsContext
 static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
@@ -15,17 +11,8 @@ static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
     ))
 });
 
-/// Sets up gamepad-related resources and the default bones input session
-pub fn game_plugin(game: &mut Game) {
-    let session = game.sessions.create(DEFAULT_BONES_INPUT_SESSION);
-    // Input doesn't do any rendering
-    session.visible = false;
-    session
-        .stages
-        .add_system_to_stage(CoreStage::First, process_gamepad_events);
-}
-
-fn process_gamepad_events(mut gamepad_inputs: ResMut<GamepadInputs>) {
+pub fn process_gamepad_events() -> GamepadInputs {
+    let mut gamepad_inputs = GamepadInputs::default();
     let mut gilrs = GILRS_CONTEXT.lock().unwrap();
     while let Some(gilrs_event) = gilrs
         .next_event()
@@ -77,6 +64,7 @@ fn process_gamepad_events(mut gamepad_inputs: ResMut<GamepadInputs>) {
             _ => (),
         };
     }
+    gamepad_inputs
 }
 
 fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {


### PR DESCRIPTION
Replaces being tied to bevy for gamepad support (which is on an old version). Directly imports and orchestrates Gilrs in bones itself, while fitting into the existing input flow to not cause any issues until keyboard/mouse are also brought into bones.