### PR TITLE
fix(input): Remove SendWrapper from GILRS_CONTEXT (unless on wasm)

### DIFF
--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -2,14 +2,13 @@
 use crate::prelude::*;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsContext};
 use once_cell::sync::Lazy;
-use send_wrapper::SendWrapper;
 use std::sync::{Arc, Mutex};
 
 /// Lazy-initialized GilrsContext
-static GILRS_CONTEXT: Lazy<Arc<Mutex<SendWrapper<GilrsContext>>>> = Lazy::new(|| {
-    Arc::new(Mutex::new(SendWrapper::new(
+static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
+    Arc::new(Mutex::new(
         GilrsContext::new().expect("Failed to initialize GilrsContext"),
-    )))
+    ))
 });
 
 /// Processes gilrs gamepad events into Bones-native GamepadInputs

--- a/framework_crates/bones_framework/src/input/gilrs.rs
+++ b/framework_crates/bones_framework/src/input/gilrs.rs
@@ -4,11 +4,26 @@ use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, Gilrs as GilrsCo
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
 
+#[cfg(target_arch = "wasm32")]
+use send_wrapper::SendWrapper;
+
 /// Lazy-initialized GilrsContext
+#[cfg(not(target_arch = "wasm32"))]
 static GILRS_CONTEXT: Lazy<Arc<Mutex<GilrsContext>>> = Lazy::new(|| {
     Arc::new(Mutex::new(
         GilrsContext::new().expect("Failed to initialize GilrsContext"),
     ))
+});
+
+// Use SendWrapper when on wasm - GilrsContext is not Sync/Send on wasm,
+// this is ok because bevy is single threaded on wasm, it will only be
+// accessed from one thread.
+/// Lazy-initialized GilrsContext
+#[cfg(target_arch = "wasm32")]
+static GILRS_CONTEXT: Lazy<Arc<Mutex<SendWrapper<GilrsContext>>>> = Lazy::new(|| {
+    Arc::new(Mutex::new(SendWrapper::new(
+        GilrsContext::new().expect("Failed to initialize GilrsContext"),
+    )))
 });
 
 /// Processes gilrs gamepad events into Bones-native GamepadInputs


### PR DESCRIPTION
I don't think we want SendWrapper here - this will panic if accessed from a different thread than it was initialized with, was panicking on start updating bones in jumpy. Bevy systems may be scheduled to other threads.

Arc + Mutex should make us sync + send here anyway. Lmk if any concerns with this @RockasMockas 