### PR TITLE
fix: disable system param tests in miri

### DIFF
--- a/.github/miri-test.sh
+++ b/.github/miri-test.sh
@@ -37,10 +37,15 @@ get_default_workspace_members() {
 # The crates to test
 declare -a CRATES
 
+if (( $# > 0 )); then
+CRATES=( "$@" )
+else
+CRATES=( $(get_default_workspace_members) )
+fi
+
 # Extra flags to pass to `cargo test` for crates
 declare -A FLAGS
 
-CRATES=( $(get_default_workspace_members) )
 FLAGS[bones_ecs]='--no-default-features -F miri'
 
 # Try multiple seeds to catch possible alignment issues

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,7 +1,7 @@
 name: ⏮️ Pull Requests
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/framework_crates/bones_framework/tests/system_param.rs
+++ b/framework_crates/bones_framework/tests/system_param.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::PathBuf;
 
 use bones_framework::prelude::*;
@@ -59,6 +61,7 @@ fn init() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn core_root_data() {
     init();
     let world = create_world();
@@ -67,6 +70,7 @@ fn core_root_data() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn supplementary_packs_root_data() {
     init();
 
@@ -88,6 +92,7 @@ fn supplementary_packs_root_data() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn all_packs_root_data() {
     init();
 

--- a/framework_crates/bones_framework/tests/system_param.rs
+++ b/framework_crates/bones_framework/tests/system_param.rs
@@ -20,15 +20,13 @@ fn create_world() -> World {
     let mut asset_server = world.init_resource::<AssetServer>();
     asset_server.set_io(io);
 
-    {
-        let scope = async move {
-            asset_server.load_assets().await.expect("load test assets");
-            while !asset_server.load_progress.is_finished() {
-                yield_now().await;
-            }
-        };
-        block_on(scope.boxed());
-    }
+    let scope = async move {
+        asset_server.load_assets().await.expect("load test assets");
+        while !asset_server.load_progress.is_finished() {
+            yield_now().await;
+        }
+    };
+    block_on(scope.boxed());
 
     world
 }


### PR DESCRIPTION
The new system param integration tests added in #482 [fail in miri](https://github.com/fishfolk/bones/actions/runs/11285906933/job/31389426144) due to features unavailable in isolation mode. Disable those tests since there isn't a good way to fix this.