### PR TITLE
refactor!: SessionBuilder makes systems + world immutable during session build + Add a rollback-safe world reset utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ version = "0.4.0"
 dependencies = [
  "bones_ecs",
  "instant",
+ "tracing",
  "ustr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,7 @@ dependencies = [
  "paste",
  "serde",
  "thiserror 1.0.63",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ parking_lot  = "0.12"
 smallvec     = "1.11"
 ustr         = "0.10"
 iroh         = "0.29"
+tracing      = "0.1"
 
 [profile.release]
 lto = true

--- a/demos/asset_packs/src/main.rs
+++ b/demos/asset_packs/src/main.rs
@@ -46,12 +46,13 @@ fn main() {
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.
-    let menu_session = game.sessions.create("menu");
-    menu_session
+    game.sessions.create_with("menu", |builder| {
         // Install the default bones_framework plugin for this session
-        .install_plugin(DefaultSessionPlugin)
-        // Add our menu system to the update stage
-        .add_system_to_stage(Update, menu_system);
+        builder
+            .install_plugin(DefaultSessionPlugin)
+            // Add our menu system to the update stage
+            .add_system_to_stage(Update, menu_system);
+    });
 
     BonesBevyRenderer::new(game).app().run();
 }

--- a/demos/assets_minimal/src/main.rs
+++ b/demos/assets_minimal/src/main.rs
@@ -36,12 +36,16 @@ fn main() {
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.
-    let menu_session = game.sessions.create("menu");
-    menu_session
-        // Install the default bones_framework plugin for this session
+    let mut menu_session_builder = SessionBuilder::new("menu");
+
+    // Install the default bones_framework plugin for this session
+    menu_session_builder
         .install_plugin(DefaultSessionPlugin)
         // Add our menu system to the update stage
         .add_system_to_stage(Update, menu_system);
+
+    // Finalize session and register with game sessions.
+    menu_session_builder.finish_and_add(&mut game.sessions);
 
     BonesBevyRenderer::new(game).app().run();
 }

--- a/demos/features/src/main.rs
+++ b/demos/features/src/main.rs
@@ -125,7 +125,7 @@ pub fn create_game() -> Game {
     TilemapDemoMeta::register_schema();
 
     // Create our menu session
-    game.sessions.create("menu").install_plugin(menu_plugin);
+    game.sessions.create_with("menu", menu_plugin);
 
     game
 }
@@ -139,12 +139,11 @@ struct MenuData {
 }
 
 /// Menu plugin
-pub fn menu_plugin(session: &mut Session) {
+pub fn menu_plugin(session: &mut SessionBuilder) {
     // Register our menu system
     session
         // Install the bones_framework default plugins for this session
         .install_plugin(DefaultSessionPlugin)
-        .world
         // Initialize our menu data resource
         .init_resource::<MenuData>();
 
@@ -198,9 +197,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("sprite_demo")
-                            .install_plugin(sprite_demo_plugin);
+                        sessions.create_with("sprite_demo", sprite_demo_plugin);
                     }
 
                     if BorderedButton::themed(&meta.button_style, localization.get("atlas-demo"))
@@ -211,9 +208,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("atlas_demo")
-                            .install_plugin(atlas_demo_plugin);
+                        sessions.create_with("atlas_demo", atlas_demo_plugin);
                     }
 
                     if BorderedButton::themed(&meta.button_style, localization.get("tilemap-demo"))
@@ -224,9 +219,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("tilemap_demo")
-                            .install_plugin(tilemap_demo_plugin);
+                        sessions.create_with("tilemap_demo", tilemap_demo_plugin);
                     }
 
                     if BorderedButton::themed(&meta.button_style, localization.get("audio-demo"))
@@ -237,9 +230,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("audio_demo")
-                            .install_plugin(audio_demo_plugin);
+                        sessions.create_with("audio_demo", audio_demo_plugin);
                     }
 
                     if BorderedButton::themed(&meta.button_style, localization.get("storage-demo"))
@@ -250,9 +241,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("storage_demo")
-                            .install_plugin(storage_demo_plugin);
+                        sessions.create_with("storage_demo", storage_demo_plugin);
                     }
 
                     if BorderedButton::themed(&meta.button_style, localization.get("path2d-demo"))
@@ -263,9 +252,7 @@ fn menu_system(
                         session_options.delete = true;
 
                         // Create a session for the match
-                        sessions
-                            .create("path2d_demo")
-                            .install_plugin(path2d_demo_plugin);
+                        sessions.create_with("path2d_demo", path2d_demo_plugin);
                     }
 
                     if let Some(exit_bones) = &mut exit_bones {
@@ -293,7 +280,7 @@ fn menu_system(
 }
 
 /// Plugin for running the sprite demo.
-fn sprite_demo_plugin(session: &mut Session) {
+fn sprite_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_startup_system(sprite_demo_startup)
@@ -357,7 +344,7 @@ fn move_sprite(
 }
 
 /// Plugin for running the tilemap demo.
-fn tilemap_demo_plugin(session: &mut Session) {
+fn tilemap_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_startup_system(tilemap_startup_system)
@@ -403,7 +390,7 @@ fn tilemap_startup_system(
 }
 
 /// Plugin for running the atlas demo.
-fn atlas_demo_plugin(session: &mut Session) {
+fn atlas_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_startup_system(atlas_demo_startup)
@@ -451,7 +438,7 @@ fn atlas_demo_startup(
     );
 }
 
-fn audio_demo_plugin(session: &mut Session) {
+fn audio_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_system_to_stage(Update, back_to_menu_ui)
@@ -477,7 +464,7 @@ fn audio_demo_ui(
         });
 }
 
-fn storage_demo_plugin(session: &mut Session) {
+fn storage_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_system_to_stage(Update, storage_demo_ui)
@@ -507,7 +494,7 @@ fn storage_demo_ui(
     });
 }
 
-fn path2d_demo_plugin(session: &mut Session) {
+fn path2d_demo_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(DefaultSessionPlugin)
         .add_startup_system(path2d_demo_startup)
@@ -558,7 +545,7 @@ fn back_to_menu_ui(
                 ui.add_space(20.0);
                 if ui.button(localization.get("back-to-menu")).clicked() {
                     session_options.delete = true;
-                    sessions.create("menu").install_plugin(menu_plugin);
+                    sessions.create_with("menu", menu_plugin);
                 }
             });
         });

--- a/demos/hello_world/src/main.rs
+++ b/demos/hello_world/src/main.rs
@@ -10,12 +10,13 @@ fn main() {
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.
-    let menu_session = game.sessions.create("menu");
-    menu_session
-        // Install the default bones_framework plugin for this session
-        .install_plugin(DefaultSessionPlugin)
-        // Add our menu system to the update stage
-        .add_system_to_stage(Update, menu_system);
+    game.sessions.create_with("menu", |session| {
+        session
+            // Install the default bones_framework plugin for this session
+            .install_plugin(DefaultSessionPlugin)
+            // Add our menu system to the update stage
+            .add_system_to_stage(Update, menu_system);
+    });
 
     BonesBevyRenderer::new(game).app().run();
 }

--- a/framework_crates/bones_asset/Cargo.toml
+++ b/framework_crates/bones_asset/Cargo.toml
@@ -40,7 +40,7 @@ serde           = { version = "1.0", features = ["derive"] }
 serde_json      = "1.0"
 serde_yaml      = "0.9"
 sha2            = "0.10"
-tracing         = "0.1"
+tracing         = { workspace = true }
 ulid            = "1.0"
 ustr            = { workspace = true }
 

--- a/framework_crates/bones_ecs/Cargo.toml
+++ b/framework_crates/bones_ecs/Cargo.toml
@@ -40,6 +40,7 @@ atomicell   = "0.2"
 bitset-core = "0.1"
 once_map    = "0.4.12"
 thiserror   = "1.0"
+tracing     = { workspace = true }
 
 [dev-dependencies]
 glam = "0.24"

--- a/framework_crates/bones_ecs/examples/pos_vel.rs
+++ b/framework_crates/bones_ecs/examples/pos_vel.rs
@@ -22,14 +22,17 @@ fn main() {
     // Initialize an empty world
     let mut world = World::new();
 
-    // Create a SystemStages to store the systems that we will run more than once.
-    let mut stages = SystemStages::with_core_stages();
+    // Build SystemStages to store the systems that we will run more than once.
+    let mut stages_builder = SystemStagesBuilder::with_core_stages();
 
     // Add our systems to the system stages
-    stages
+    stages_builder
         .add_startup_system(startup_system)
         .add_system_to_stage(CoreStage::Update, pos_vel_system)
         .add_system_to_stage(CoreStage::PostUpdate, print_system);
+
+    // Finish build to get `SystemStages`.
+    let mut stages = stages_builder.finish();
 
     // Run our game loop for 10 frames
     for _ in 0..10 {

--- a/framework_crates/bones_ecs/src/resources.rs
+++ b/framework_crates/bones_ecs/src/resources.rs
@@ -229,7 +229,7 @@ impl Resources {
     ///
     /// See [get()][Self::get]
     pub fn contains<T: HasSchema>(&self) -> bool {
-        self.untyped.resources.contains_key(&T::schema().id())
+        self.untyped.contains(T::schema().id())
     }
 
     /// Remove a resource from the store, if it is present.

--- a/framework_crates/bones_ecs/src/stage.rs
+++ b/framework_crates/bones_ecs/src/stage.rs
@@ -11,77 +11,29 @@ use crate::prelude::*;
 #[derive(Deref, DerefMut, Clone, Copy, HasSchema, Default)]
 pub struct CurrentSystemStage(pub Ulid);
 
-/// An ordered collection of [`SystemStage`]s.
-pub struct SystemStages {
+/// Builder for [`SystemStages`]. It is immutable once created,
+pub struct SystemStagesBuilder {
     /// The stages in the collection, in the order that they will be run.
-    pub stages: Vec<Box<dyn SystemStage>>,
+    stages: Vec<Box<dyn SystemStage>>,
     /// The systems that should run at startup.
     /// They will be executed next step based on if [`SessionStarted`] resource in world says session has not started, or if resource does not exist.
-    pub startup_systems: Vec<StaticSystem<(), ()>>,
+    startup_systems: Vec<StaticSystem<(), ()>>,
+
+    /// Resources installed during session plugin installs. Copied to world as first step on startup of stages' execution.
+    startup_resources: Vec<UntypedResource>,
+
     /// Systems that are continously run until they succeed(return Some). These run before all stages. Uses Option to allow for easy usage of `?`.
-    pub single_success_systems: Vec<StaticSystem<(), Option<()>>>,
+    single_success_systems: Vec<StaticSystem<(), Option<()>>>,
 }
 
-impl std::fmt::Debug for SystemStages {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SystemStages")
-            // TODO: Add list of stages to the debug render for `SystemStages`.
-            // We can at least list the names of each stage for `SystemStages` debug
-            // implementation.
-            .finish()
-    }
-}
-
-impl Default for SystemStages {
+impl Default for SystemStagesBuilder {
     fn default() -> Self {
         Self::with_core_stages()
     }
 }
 
-impl SystemStages {
-    /// Execute the systems on the given `world`.
-    pub fn run(&mut self, world: &mut World) {
-        // If we haven't run our startup systems yet
-        if !Self::has_session_started(world) {
-            // Set the current stage resource
-            world.insert_resource(CurrentSystemStage(Ulid(0)));
-
-            // For each startup system
-            for system in &mut self.startup_systems {
-                // Run the system
-                system.run(world, ());
-            }
-
-            // Don't run startup systems again
-            Self::set_session_started(true, world);
-        }
-
-        // Run single success systems
-        for (index, system) in self.single_success_systems.iter_mut().enumerate() {
-            let should_run = !Self::has_single_success_system_succeeded(index, world);
-
-            if should_run && system.run(world, ()).is_some() {
-                Self::mark_single_success_system_succeeded(index, world);
-            }
-        }
-
-        // Run each stage
-        for stage in &mut self.stages {
-            // Set the current stage resource
-            world.insert_resource(CurrentSystemStage(stage.id()));
-
-            // Run the stage
-            stage.run(world);
-        }
-
-        // Cleanup killed entities
-        world.maintain();
-
-        // Remove the current system stage resource
-        world.resources.remove::<CurrentSystemStage>();
-    }
-
-    /// Create a [`SystemStages`] collection, initialized with a stage for each [`CoreStage`].
+impl SystemStagesBuilder {
+    /// Create a [`SystemStagesBuilder`] for [`SystemStages`] collection, initialized with a stage for each [`CoreStage`].
     pub fn with_core_stages() -> Self {
         Self {
             stages: vec![
@@ -91,8 +43,19 @@ impl SystemStages {
                 Box::new(SimpleSystemStage::new(CoreStage::PostUpdate)),
                 Box::new(SimpleSystemStage::new(CoreStage::Last)),
             ],
+            startup_resources: default(),
             startup_systems: default(),
             single_success_systems: Vec::new(),
+        }
+    }
+
+    /// Finish building and convert to [`SystemStages`]
+    pub fn finish(self) -> SystemStages {
+        SystemStages {
+            stages: self.stages,
+            startup_systems: self.startup_systems,
+            startup_resources: self.startup_resources,
+            single_success_systems: self.single_success_systems,
         }
     }
 
@@ -173,24 +136,142 @@ impl SystemStages {
         self
     }
 
-    /// Remove all systems from all stages, including startup and single success systems. Resets has_started as well, allowing for startup systems to run once again.
-    pub fn reset_remove_all_systems(&mut self) {
-        // Reset the has_started flag
-        self.remove_all_systems();
+    /// Insert a startup resource. On stage / session startup (first step), will be inserted into [`World`].
+    ///
+    /// If already exists, will be overwritten.
+    pub fn insert_startup_resource<T: HasSchema>(&mut self, resource: T) {
+        // Update an existing resource of the same type.
+        for r in &mut self.startup_resources {
+            if r.schema() == T::schema() {
+                let mut borrow = r.borrow_mut();
+
+                if let Some(b) = borrow.as_mut() {
+                    *b.cast_mut() = resource;
+                } else {
+                    *borrow = Some(SchemaBox::new(resource))
+                }
+                return;
+            }
+        }
+
+        // Or insert a new resource if we couldn't find one
+        self.startup_resources
+            .push(UntypedResource::new(SchemaBox::new(resource)));
     }
 
-    /// Remove all systems from all stages, including startup and single success systems. Does not reset has_started.
-    pub fn remove_all_systems(&mut self) {
-        // Clear startup systems
-        self.startup_systems.clear();
-
-        // Clear single success systems
-        self.single_success_systems.clear();
-
-        // Clear systems from each stage
-        for stage in &mut self.stages {
-            stage.remove_all_systems();
+    /// Init startup resource with default, and return mutable ref for modification.
+    /// If already exists, returns mutable ref to existing resource.
+    pub fn init_startup_resource<T: HasSchema + Default>(&mut self) -> RefMut<T> {
+        if !self
+            .startup_resources
+            .iter()
+            .any(|x| x.schema() == T::schema())
+        {
+            self.insert_startup_resource(T::default());
         }
+        self.startup_resource_mut::<T>().unwrap()
+    }
+
+    /// Get mutable reference to startup resource if found.
+    #[track_caller]
+    pub fn startup_resource_mut<T: HasSchema>(&self) -> Option<RefMut<T>> {
+        let res = self
+            .startup_resources
+            .iter()
+            .find(|x| x.schema() == T::schema())?;
+        let borrow = res.borrow_mut();
+
+        if borrow.is_some() {
+            // SOUND: We know the type matches T
+            Some(RefMut::map(borrow, |b| unsafe {
+                b.as_mut().unwrap().as_mut().cast_into_mut_unchecked()
+            }))
+        } else {
+            None
+        }
+    }
+}
+
+/// An ordered collection of [`SystemStage`]s.
+pub struct SystemStages {
+    /// The stages in the collection, in the order that they will be run.
+    stages: Vec<Box<dyn SystemStage>>,
+
+    /// The systems that should run at startup.
+    /// They will be executed next step based on if [`SessionStarted`] resource in world says session has not started, or if resource does not exist.
+    startup_systems: Vec<StaticSystem<(), ()>>,
+
+    /// Resources installed during session plugin installs. Copied to world as first step on startup of stages' execution.
+    startup_resources: Vec<UntypedResource>,
+
+    /// Systems that are continously run until they succeed(return Some). These run before all stages. Uses Option to allow for easy usage of `?`.
+    single_success_systems: Vec<StaticSystem<(), Option<()>>>,
+}
+
+impl std::fmt::Debug for SystemStages {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SystemStages")
+            // TODO: Add list of stages to the debug render for `SystemStages`.
+            // We can at least list the names of each stage for `SystemStages` debug
+            // implementation.
+            .finish()
+    }
+}
+
+impl Default for SystemStages {
+    fn default() -> Self {
+        SystemStagesBuilder::default().finish()
+    }
+}
+
+impl SystemStages {
+    /// Create builder for construction of [`SystemStages`].
+    pub fn builder() -> SystemStagesBuilder {
+        SystemStagesBuilder::default()
+    }
+
+    /// Execute the systems on the given `world`.
+    pub fn run(&mut self, world: &mut World) {
+        // If we haven't run our startup systems yet
+        if !Self::has_session_started(world) {
+            self.insert_startup_resources(world);
+
+            // Set the current stage resource
+            world.insert_resource(CurrentSystemStage(Ulid(0)));
+
+            // For each startup system
+            for system in &mut self.startup_systems {
+                // Run the system
+                system.run(world, ());
+            }
+
+            // Don't run startup systems again
+            Self::set_session_started(true, world);
+        }
+
+        // Run single success systems
+        for (index, system) in self.single_success_systems.iter_mut().enumerate() {
+            let should_run = !Self::has_single_success_system_succeeded(index, world);
+
+            if should_run && system.run(world, ()).is_some() {
+                Self::mark_single_success_system_succeeded(index, world);
+            }
+        }
+
+        // Run each stage
+        for stage in &mut self.stages {
+            // Set the current stage resource
+            world.insert_resource(CurrentSystemStage(stage.id()));
+
+            // Run the stage
+            stage.run(world);
+        }
+
+        // Cleanup killed entities
+        world.maintain();
+
+        // Remove the current system stage resource
+        world.resources.remove::<CurrentSystemStage>();
     }
 
     /// Has session started and startup systems been executed?
@@ -227,6 +308,23 @@ impl SystemStages {
         world
             .init_resource::<SingleSuccessSystems>()
             .set_system_completed(system_index);
+    }
+
+    /// Insert the startup resources that [`SystemStages`] and session were built with into [`World`].
+    fn insert_startup_resources(&self, world: &mut World) {
+        for resource in self.startup_resources.iter() {
+            // Deep copy startup resource and insert into world.
+            let resource_copy = resource.clone_data().unwrap();
+            let resource_cell = world.resources.untyped().get_cell(resource.schema());
+            let prev_val = resource_cell.insert(resource_copy).unwrap();
+
+            // Warn on already existing resource
+            if prev_val.is_some() {
+                let schema_name = resource.schema().full_name;
+                tracing::warn!("SystemStages` attempted to inserted resource {schema_name} on startup that already exists in world - startup resource not inserted.
+                    When building new session, startup resources should be initialized on `SessionBuilder`.");
+            }
+        }
     }
 }
 
@@ -400,21 +498,22 @@ impl<'a> SystemParam for Commands<'a> {
 /// If reset to false, startup systems should be re-triggered.
 /// If resource is not present, assumed to have not started (and will be initialized upon execution).
 #[derive(Copy, Clone, HasSchema, Default)]
-struct SessionStarted {
+pub struct SessionStarted {
     /// Has the session started, and startup systems executed?
     pub has_started: bool,
 }
 
-/// Resource tracking which of single success systems in [`Session`]'s [`SystemStages`] have completed.
+/// Resource tracking which of single success systems in `Session`'s [`SystemStages`] have completed.
 /// Success is tracked to
 #[derive(HasSchema, Clone, Default)]
-struct SingleSuccessSystems {
+pub struct SingleSuccessSystems {
     /// Set of indices of [`SystemStages`]'s single success systems that have succeeded.
     pub systems_succeeded: HashSet<usize>,
 }
 
 impl SingleSuccessSystems {
     /// Reset single success systems completion status. so they run again until success.
+    #[allow(dead_code)]
     pub fn reset(&mut self) {
         self.systems_succeeded.clear();
     }

--- a/framework_crates/bones_ecs/src/stage.rs
+++ b/framework_crates/bones_ecs/src/stage.rs
@@ -59,6 +59,16 @@ impl SystemStagesBuilder {
         }
     }
 
+    /// Create [`SystemStagesBuilder`] by taking existing [`SystemStages`].
+    pub fn from_stages(stages: SystemStages) -> Self {
+        Self {
+            stages: stages.stages,
+            startup_systems: stages.startup_systems,
+            startup_resources: stages.startup_resources,
+            single_success_systems: stages.single_success_systems,
+        }
+    }
+
     /// Add a system that will run only once, before all of the other non-startup systems.
     /// If wish to reset session and run again, can modify [`SessionStarted`] resource in world.
     pub fn add_startup_system<Args, S>(&mut self, system: S) -> &mut Self

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -214,6 +214,12 @@ impl World {
         // Always maintain to clean up any killed entities
         self.maintain();
     }
+
+    /// Load snapshot of [`World`] into self.
+    pub fn load_snapshot(&mut self, snapshot: World) {
+        self.components = snapshot.components;
+        self.resources = snapshot.resources;
+    }
 }
 
 /// Creates an instance of the type this trait is implemented for

--- a/framework_crates/bones_ecs/src/world.rs
+++ b/framework_crates/bones_ecs/src/world.rs
@@ -199,22 +199,6 @@ impl World {
         self.components.get::<T>().borrow_mut()
     }
 
-    /// Provides an interface for resetting entities, and components.
-    pub fn reset_internals(&mut self, reset_components: bool, reset_entities: bool) {
-        if reset_entities {
-            let mut entities = self.resource_mut::<Entities>();
-            entities.kill_all();
-        }
-
-        if reset_components {
-            // Clear all component stores
-            self.components = ComponentStores::default();
-        }
-
-        // Always maintain to clean up any killed entities
-        self.maintain();
-    }
-
     /// Load snapshot of [`World`] into self.
     pub fn load_snapshot(&mut self, snapshot: World) {
         self.components = snapshot.components;

--- a/framework_crates/bones_framework/Cargo.toml
+++ b/framework_crates/bones_framework/Cargo.toml
@@ -106,7 +106,7 @@ send_wrapper  = "0.6.0"
 
 
 # Tracing
-tracing            = "0.1"
+tracing            = { workspace = true }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 tracing-appender   = { version = "0.2", optional = true, features = ["parking_lot"] }
 tracing-tracy      = { version = "0.11.0", optional = true, default-features = false }

--- a/framework_crates/bones_framework/src/animation.rs
+++ b/framework_crates/bones_framework/src/animation.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 /// Install animation utilities into the given [`SystemStages`].
-pub fn animation_plugin(core: &mut Session) {
+pub fn animation_plugin(core: &mut SessionBuilder) {
     core.stages
         .add_system_to_stage(CoreStage::Last, update_animation_banks)
         .add_system_to_stage(CoreStage::Last, animate_sprites);

--- a/framework_crates/bones_framework/src/audio.rs
+++ b/framework_crates/bones_framework/src/audio.rs
@@ -20,13 +20,13 @@ pub fn game_plugin(game: &mut Game) {
     game.insert_shared_resource(AudioManager::default());
     game.init_shared_resource::<AssetServer>();
 
-    let session = game.sessions.create(DEFAULT_BONES_AUDIO_SESSION);
+    let mut session = SessionBuilder::new(DEFAULT_BONES_AUDIO_SESSION);
     // Audio doesn't do any rendering
     session.visible = false;
     session
-        .stages
         .add_system_to_stage(First, _process_audio_events)
         .add_system_to_stage(Last, _kill_finished_audios);
+    session.finish_and_add(&mut game.sessions);
 }
 
 /// Holds the handles and the volume to be played for a piece of Audio.

--- a/framework_crates/bones_framework/src/debug.rs
+++ b/framework_crates/bones_framework/src/debug.rs
@@ -51,7 +51,7 @@ pub struct FrameTimeWindowState {
 
 /// If installed, allows opening egui window with [`FrameTimeWindowState`] in [`EguiCtx`] state
 /// to get frame time information.
-pub fn frame_time_diagnostics_plugin(core: &mut Session) {
+pub fn frame_time_diagnostics_plugin(core: &mut SessionBuilder) {
     core.stages
         .add_system_to_stage(CoreStage::Last, frame_diagnostic_window);
 }

--- a/framework_crates/bones_framework/src/lib.rs
+++ b/framework_crates/bones_framework/src/lib.rs
@@ -91,7 +91,7 @@ pub mod external {
 /// Default plugins for bones framework sessions.
 pub struct DefaultSessionPlugin;
 impl lib::SessionPlugin for DefaultSessionPlugin {
-    fn install(self, session: &mut lib::Session) {
+    fn install(self, session: &mut lib::SessionBuilder) {
         session
             .install_plugin(animation::animation_plugin)
             .install_plugin(render::render_plugin);

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -871,20 +871,7 @@ where
                                     cell.save(frame, Some(world.clone()), None)
                                 }
                                 ggrs::GgrsRequest::LoadGameState { cell, .. } => {
-                                    // Swap out sessions to preserve them after world save.
-                                    // Sessions clone makes empty copy, so saved snapshots do not include sessions.
-                                    // Sessions are borrowed from Game for execution of this session,
-                                    // they are not like other resources and should not be preserved.
-                                    let mut sessions = Sessions::default();
-                                    std::mem::swap(
-                                        &mut sessions,
-                                        &mut world.resource_mut::<Sessions>(),
-                                    );
-                                    *world = cell.load().unwrap_or_default();
-                                    std::mem::swap(
-                                        &mut sessions,
-                                        &mut world.resource_mut::<Sessions>(),
-                                    );
+                                    world.load_snapshot(cell.load().unwrap_or_default());
                                 }
                                 ggrs::GgrsRequest::AdvanceFrame {
                                     inputs: network_inputs,

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -955,10 +955,15 @@ where
                                         let rng = world
                                             .get_resource::<RngGenerator>()
                                             .map(|r| (*r).clone());
-                                        world.handle_world_reset(stages);
                                         if let Some(rng) = rng {
-                                            world.resources.insert(rng);
+                                            if let Some(mut reset) =
+                                                world.get_resource_mut::<ResetWorld>()
+                                            {
+                                                reset.insert_reset_resource(rng);
+                                            }
                                         }
+
+                                        world.handle_world_reset(stages);
                                     }
                                 }
                             }

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -955,7 +955,7 @@ where
                                         let rng = world
                                             .get_resource::<RngGenerator>()
                                             .map(|r| (*r).clone());
-                                        world.handle_world_reset();
+                                        world.handle_world_reset(stages);
                                         if let Some(rng) = rng {
                                             world.resources.insert(rng);
                                         }

--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -949,6 +949,17 @@ where
 
                                     // Run game session stages, advancing simulation
                                     stages.run(world);
+
+                                    // Handle any triggered resets of world + preserve runner's managed resources like RngGenerator.
+                                    if world.reset_triggered() {
+                                        let rng = world
+                                            .get_resource::<RngGenerator>()
+                                            .map(|r| (*r).clone());
+                                        world.handle_world_reset();
+                                        if let Some(rng) = rng {
+                                            world.resources.insert(rng);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/framework_crates/bones_framework/src/networking/debug.rs
+++ b/framework_crates/bones_framework/src/networking/debug.rs
@@ -25,7 +25,7 @@ pub mod prelude {
 /// Session plugin for network debug window. Is not installed by default.
 /// After installing plugin, [`NetworkDebugMenuState`] on [`EguiCtx`] state
 /// may be modified to open menu.
-pub fn network_debug_session_plugin(session: &mut Session) {
+pub fn network_debug_session_plugin(session: &mut SessionBuilder) {
     session.add_system_to_stage(CoreStage::First, network_debug_window);
 }
 

--- a/framework_crates/bones_framework/src/render.rs
+++ b/framework_crates/bones_framework/src/render.rs
@@ -24,7 +24,7 @@ pub mod transform;
 pub mod ui;
 
 /// Bones framework rendering plugin.
-pub fn render_plugin(session: &mut Session) {
+pub fn render_plugin(session: &mut SessionBuilder) {
     session
         .install_plugin(sprite::sprite_plugin)
         .install_plugin(camera::plugin);

--- a/framework_crates/bones_framework/src/render/camera.rs
+++ b/framework_crates/bones_framework/src/render/camera.rs
@@ -92,7 +92,7 @@ pub fn spawn_default_camera(
 }
 
 /// Install the camera utilities on the given [`SystemStages`].
-pub fn plugin(session: &mut Session) {
+pub fn plugin(session: &mut SessionBuilder) {
     session
         .stages
         .add_system_to_stage(CoreStage::Last, apply_shake)

--- a/framework_crates/bones_framework/src/render/sprite.rs
+++ b/framework_crates/bones_framework/src/render/sprite.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 /// Sprite session plugin.
-pub fn sprite_plugin(_session: &mut Session) {
+pub fn sprite_plugin(_session: &mut SessionBuilder) {
     Sprite::register_schema();
     AtlasSprite::register_schema();
 }

--- a/framework_crates/bones_framework/src/render/ui.rs
+++ b/framework_crates/bones_framework/src/render/ui.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 pub mod widgets;
 
 /// The Bones Framework UI plugin.
-pub fn ui_plugin(_session: &mut Session) {
+pub fn ui_plugin(_session: &mut SessionBuilder) {
     // TODO: remove this plugin if it remains unused.
 }
 

--- a/framework_crates/bones_framework/tests/reset.rs
+++ b/framework_crates/bones_framework/tests/reset.rs
@@ -1,0 +1,122 @@
+use bones_framework::prelude::*;
+
+#[derive(HasSchema, Default, Clone)]
+struct Counter(u32);
+
+/// Verify that startup systems run again after a world reset
+#[test]
+pub fn startup_system_reset() {
+    let mut game = Game::new();
+    // Shared resource, should survive reset
+    game.init_shared_resource::<Counter>();
+
+    // Session startup increments counter by 1
+    game.sessions.create_with("game", |builder| {
+        builder.add_startup_system(|mut counter: ResMut<Counter>| {
+            // Increment to 1
+            counter.0 += 1;
+        });
+    });
+
+    // Step twice, startup system should only run once
+    game.step(Instant::now());
+    game.step(Instant::now());
+
+    // Verify startup system ran and incremented only once
+    assert_eq!(game.shared_resource::<Counter>().unwrap().0, 1);
+
+    // Add command that will trigger reset on next step
+    {
+        let game_session = game.sessions.get_mut("game").unwrap();
+        game_session.world.init_resource::<CommandQueue>().add(
+            |mut reset: ResMutInit<ResetWorld>| {
+                reset.reset = true;
+            },
+        );
+    }
+
+    // step again, world should be reset. Startup doesn't run until next step though.
+    game.step(Instant::now());
+
+    // step again to trigger startup
+    game.step(Instant::now());
+
+    // Shared resource is not included in reset, should be incremented 2nd time
+    assert_eq!(game.shared_resource::<Counter>().unwrap().0, 2);
+}
+
+/// Verify that single success systems run again (until success condition)
+/// after a world reset
+#[test]
+pub fn single_success_system_reset() {
+    let mut game = Game::new();
+
+    // Session startup increments counter by 1
+    game.sessions.create_with("game", |builder| {
+        builder.init_resource::<Counter>();
+        {
+            let res = builder.resource_mut::<Counter>().unwrap();
+            assert_eq!(res.0, 0);
+        }
+        // system
+        builder.add_single_success_system(|mut counter: ResMut<Counter>| -> Option<()> {
+            // Increment until 2
+            counter.0 += 1;
+            if counter.0 >= 2 {
+                return Some(());
+            }
+
+            None
+        });
+    });
+
+    // Step three times, single success should've incremented counter to 2 and completed.
+    game.step(Instant::now());
+    game.step(Instant::now());
+    game.step(Instant::now());
+
+    // Verify startup system ran and incremented only once
+    {
+        let session = game.sessions.get("game").unwrap();
+        let counter = session.world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 2);
+    }
+
+    // Add command that will trigger reset on next step
+    {
+        let game_session = game.sessions.get_mut("game").unwrap();
+        game_session.world.init_resource::<CommandQueue>().add(
+            |mut reset: ResMutInit<ResetWorld>| {
+                reset.reset = true;
+            },
+        );
+    }
+
+    // step again, world should be reset after step. The Counter resource will not be present
+    // until next step re-inits startup resources.
+    // (at 0.unwrap())
+    game.step(Instant::now());
+    {
+        let session = game.sessions.get("game").unwrap();
+        assert!(session.world.get_resource::<Counter>().is_none());
+    }
+
+    // Startup resource should be re-initialized, and completion status of single single success system reset.
+    // It will run incrementing to 1.
+    game.step(Instant::now());
+    {
+        let session = game.sessions.get("game").unwrap();
+        let counter = session.world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 1);
+    }
+
+    // Run a few more times, single success system should stop at 2:
+    game.step(Instant::now());
+    game.step(Instant::now());
+    game.step(Instant::now());
+    {
+        let session = game.sessions.get("game").unwrap();
+        let counter = session.world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 2);
+    }
+}

--- a/framework_crates/bones_framework/tests/reset.rs
+++ b/framework_crates/bones_framework/tests/reset.rs
@@ -92,13 +92,13 @@ pub fn single_success_system_reset() {
         );
     }
 
-    // step again, world should be reset after step. The Counter resource will not be present
-    // until next step re-inits startup resources.
-    // (at 0.unwrap())
+    // step again, world should be reset after this step. Counter should be back at default state of 0,
+    // single successs system not yet run until beginning of next step.
     game.step(Instant::now());
     {
         let session = game.sessions.get("game").unwrap();
-        assert!(session.world.get_resource::<Counter>().is_none());
+        let counter = session.world.get_resource::<Counter>().unwrap();
+        assert_eq!(counter.0, 0);
     }
 
     // Startup resource should be re-initialized, and completion status of single single success system reset.

--- a/framework_crates/bones_lib/Cargo.toml
+++ b/framework_crates/bones_lib/Cargo.toml
@@ -17,4 +17,5 @@ glam    = ["bones_ecs/glam"]
 [dependencies]
 bones_ecs = { version = "0.4.0", path = "../bones_ecs" }
 instant   = "0.1.12"
+tracing   = { workspace = true }
 ustr      = { workspace = true }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -201,7 +201,6 @@ impl SessionRunner for DefaultSessionRunner {
 /// Games are made up of one or more [`Session`]s, each of which contains it's own [`World`] and
 /// [`SystemStages`]. These different sessions can be used for parts of the game with independent
 /// states, such as the main menu and the gameplay.
-#[derive(Default)]
 pub struct Game {
     /// The sessions that make up the game.
     pub sessions: Sessions,
@@ -216,6 +215,22 @@ pub struct Game {
     /// Collection of resources that will have a shared instance of each be inserted into each
     /// session automatically.
     pub shared_resources: Vec<AtomicUntypedResource>,
+}
+
+impl Default for Game {
+    fn default() -> Self {
+        let mut game = Self {
+            sessions: default(),
+            systems: default(),
+            sorted_session_keys: default(),
+            shared_resources: default(),
+        };
+
+        // Init Sessions shared resource so it exists for game step.
+        // (Game's sessions temporarily moved to this resource during execution)
+        game.init_shared_resource::<Sessions>();
+        game
+    }
 }
 
 impl Game {

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -313,7 +313,7 @@ pub trait SessionRunner: Sync + Send + 'static {
     ///
     ///     // Not required for runner - but calling this allows [`ResetWorld`] resource to
     ///     // reset world state from gameplay.
-    ///     world.handle_world_reset();
+    ///     world.handle_world_reset(stages);
     ///
     /// }
     /// fn restart_session(&mut self) {}
@@ -341,7 +341,7 @@ impl SessionRunner for DefaultSessionRunner {
         stages.run(world);
 
         // Checks if reset of world has been triggered by [`ResetWorld`] and handles a reset.
-        world.handle_world_reset();
+        world.handle_world_reset(stages);
     }
 
     // This is a no-op as no state, but implemented this way in case that changes later.

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -99,20 +99,6 @@ impl Session {
     pub fn set_session_runner(&mut self, runner: Box<dyn SessionRunner>) {
         self.runner = runner;
     }
-
-    /// Provides an interface for resetting various internal parts of the Session.
-    /// Note this does not fully reset the entire Session.
-    pub fn reset_internals(
-        &mut self,
-        reset_components: bool,
-        reset_entities: bool,
-        reset_systems: bool,
-    ) {
-        self.world.reset_internals(reset_components, reset_entities);
-        if reset_systems {
-            self.reset_remove_all_systems();
-        }
-    }
 }
 
 impl Default for Session {

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -179,7 +179,7 @@ impl SessionBuilder {
     ///
     /// Alternatively, you may directly pass a [`SessionBuilder`] to [`Sessions::create`] to add and finalize.
     pub fn finish_and_add(mut self, sessions: &mut Sessions) -> &mut Session {
-        let session = Session {
+        let mut session = Session {
             world: {
                 let mut w = World::default();
                 w.init_resource::<Time>();
@@ -194,6 +194,13 @@ impl SessionBuilder {
 
         // mark guard as finished to avoid warning on drop of SessionBuilder.
         self.finish_guard.finished = true;
+
+        // Insert startup resources so if other sessions look for them, they are present.
+        // Startup systems are deferred until first step of stages.
+        let only_insert_startup_resources = true;
+        session
+            .stages
+            .handle_startup(&mut session.world, only_insert_startup_resources);
 
         sessions.add(self.name, session)
     }

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -197,10 +197,7 @@ impl SessionBuilder {
 
         // Insert startup resources so if other sessions look for them, they are present.
         // Startup systems are deferred until first step of stages.
-        let only_insert_startup_resources = true;
-        session
-            .stages
-            .handle_startup(&mut session.world, only_insert_startup_resources);
+        session.stages.handle_startup_resources(&mut session.world);
 
         sessions.add(self.name, session)
     }

--- a/framework_crates/bones_lib/src/reset.rs
+++ b/framework_crates/bones_lib/src/reset.rs
@@ -101,7 +101,7 @@ impl WorldExt for World {
         }
 
         // Immediately run startup tasks, ensuring startup resources are present and run startup systems.
-        stages.handle_startup(self);
+        stages.handle_startup(self, false);
 
         // Apply any reset resources to world, overwriting startup resources.
         if let Some(resources) = post_reset_resources {

--- a/framework_crates/bones_lib/src/reset.rs
+++ b/framework_crates/bones_lib/src/reset.rs
@@ -1,0 +1,67 @@
+//! Extensions of bones_ecs for utility functions in resetting a World
+use crate::prelude::*;
+
+/// Resource that allows user to trigger a reset of world, clearing entities, components, and resources.
+/// This is supported in bone's default session runners - but if implementing custom runner, must call `world.handle_world_reset` inside step.
+///
+/// `reset_world: ResMutInit<ResetWorld>` and setting `reset_world.reset = true;` may be used to trigger a reset from system execution.
+#[derive(Copy, Clone, HasSchema, Default)]
+pub struct ResetWorld {
+    /// Set to true to trigger reset of [`World`].
+    pub reset: bool,
+}
+
+/// Extension of [`World`]
+pub trait WorldExt {
+    /// May be called by [`SessionRunner`] before or after [`SystemStages::run`] to allow triggering reset
+    /// of world with the [`ResetWorld`] resource.
+    fn handle_world_reset(&mut self);
+
+    /// Check if reset has been triggered by [`ResetWorld`] resource. If [`SessionRunner`] needs to do anything special
+    /// for a world reset (preserve managed resources, etc) - can check this before calling `handle_world_reset` to see
+    /// if a rese will occur.
+    fn reset_triggered(&self) -> bool;
+
+    /// Provides a low-level interface for resetting entities, components, and resources.
+    ///
+    /// Waring: Calling this function on World in a [`Session`] using network session runner is likely to introduce non-determinism.
+    /// It is strongly recommended to use the [`ResetWorld`] Resource to trigger this in manner compatible with net rollback.
+    fn reset_internals(&mut self);
+}
+
+impl WorldExt for World {
+    fn handle_world_reset(&mut self) {
+        if self.reset_triggered() {
+            self.reset_internals();
+        }
+    }
+
+    fn reset_triggered(&self) -> bool {
+        self.get_resource::<ResetWorld>().map_or(false, |r| r.reset)
+    }
+
+    fn reset_internals(&mut self) {
+        // Clear all component stores
+        self.components = ComponentStores::default();
+
+        // save copy of special resources that should always remain in session / managed by bones
+        let time = self.get_resource::<Time>().map(|t| *t);
+        let session_opts = self.get_resource::<SessionOptions>().map(|x| *x);
+
+        // Remove any owned resources (preserves shared resources)
+        // This allows world resources to be reset inside session run safely, as shared resources are only injected
+        // outside of session run, and a runner may take another step after the reset.
+        self.resources.clear_owned_resources();
+
+        // Entities were cleared with resources - ensure is present.
+        self.init_resource::<Entities>();
+
+        // Re-insert preserved resources
+        if let Some(time) = time {
+            self.insert_resource(time);
+        }
+        if let Some(session_opts) = session_opts {
+            self.insert_resource(session_opts);
+        }
+    }
+}

--- a/framework_crates/bones_scripting/Cargo.toml
+++ b/framework_crates/bones_scripting/Cargo.toml
@@ -21,7 +21,7 @@ gc-arena-derive = "0.5"
 parking_lot     = { workspace = true }
 piccolo         = "0.3"
 send_wrapper    = "0.6.0"
-tracing         = "0.1"
+tracing         = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"

--- a/framework_crates/bones_scripting/src/lua.rs
+++ b/framework_crates/bones_scripting/src/lua.rs
@@ -47,8 +47,8 @@ pub struct LuaPluginLoaderSessionPlugin(pub Arc<Vec<Handle<LuaPlugin>>>);
 pub struct LuaPlugins(pub Arc<Vec<Handle<LuaPlugin>>>);
 
 impl SessionPlugin for LuaPluginLoaderSessionPlugin {
-    fn install(self, session: &mut Session) {
-        session.world.insert_resource(LuaPlugins(self.0));
+    fn install(self, session: &mut SessionBuilder) {
+        session.insert_resource(LuaPlugins(self.0));
 
         for lua_stage in [
             CoreStage::First,

--- a/other_crates/bones_matchmaker/Cargo.toml
+++ b/other_crates/bones_matchmaker/Cargo.toml
@@ -14,7 +14,7 @@ either                 = "1.8"
 once_cell              = "1.15"
 scc                    = "1.0"
 rcgen                  = "0.12"
-tracing                = "0.1"
+tracing                = { workspace = true }
 rand                   = "0.8"
 bones_matchmaker_proto = { version = "0.4.0", path = "../bones_matchmaker_proto" }
 clap                   = { version = "4.0", features = ["derive", "env"] }

--- a/other_crates/bones_matchmaker/src/matchmaking.rs
+++ b/other_crates/bones_matchmaker/src/matchmaking.rs
@@ -215,7 +215,7 @@ async fn send_matchmaking_updates(
     })?;
 
     // Send first update and check active connections
-    for (_index, conn) in connections.into_iter().enumerate() {
+    for conn in connections.into_iter() {
         if let Ok(mut send) = conn.open_uni().await {
             if send.write_all(&first_update_message).await.is_ok()
                 && send.finish().is_ok()


### PR DESCRIPTION
# Goals
Allow the world to be reset safely for network rollback:

## Systems + Resources and Rollback Safety
- Systems (stage-based, single success, and startup) are immutable once session is created.
- Reset-safe initialization of Resources: World is not available during session build, resources must be set on `SessionBuilder`. (They are captured so that on initial startup, or after reset, can be set to initial state).
- Completion status of "startup" and single success systems is stored in a world resource. (`SessionStarted`, `SingleSuccessSystems`). 
  - This makes them rollback safe, if rollback before single success completed, it will run again. If rollback before a reset, startup systems will run again.
  
## Triggering World Reset
This may be done with the `ResetWorld` resource. `SessionRunner` is responsible for calling `world.handle_world_reset`. It is called right after stage exec in default/ggrs session runner, so these mutations to world are coupled to a ggrs frame.

## Resetting Resources
During a reset, resources and components are all reset (including `Entities` resource). Because the initial resources are captured and saved during session build, after reset on next step during `SystemStages` startup, the initial resources will be re-inserted. 

### "Special" Resources
It turns out we have a lot of special resources, I handled a few of them to make sure they do the right thing (or what I think makes sense atm...)
- Shared resources are not removed during reset (just FYI).
- `Sessions`: Behind the scenes this is now inserted as a 'shared resource', and is not wiped out during reset.
- `Time`: This is preserved. (It is assumed to exist/required by bones, and I think resetting this may have negative side effects).
- `SessionOptions`: This is consumed by bones core loop and expected to exist, so preserved.
- `RngGenerator`: GgrsSessionRunner is preserving this on reset, I think resetting to initial seed after a reset may make things feel less random, so opted to preserve. 
- `SyncingInfo`: This is re-inserted by ggrs runner before each step, this should not be impacted, no special care needed by reset.


## Session Initialization Changes (`SessionBuilder`)
Changes were made to how sessions are built to enforce system immutability after creation, and restrict access to `World` while building session.  This has some impact (breaking changes) to API, but I tried to make it not too painful.

`Sessions` may no longer be constructed directly. Don't want world resources to be modified in session plugin installs, as that resource change is then not captured in startup resources for a reset. There are a couple different ways to make a new session outlined below.

1) `create_with` uses a closure to contain session init, this is nice as it ensures `SessionBuilder` is finished + added to `Sessions`:
```rust
    game.sessions.create_with("menu", |builder| {
        builder
            .install_plugin(DefaultSessionPlugin)
            .add_system_to_stage(Update, menu_system);
    });
 ```
 or if just installing one plugin:
 ```rust
 game.sessions.create_with("menu", menu_plugin_function);
 ```
 2) Use `SessionBuilder` directly:
 ```rust
    let mut menu_session_builder = SessionBuilder::new("menu");

    menu_session_builder
        .install_plugin(DefaultSessionPlugin)
        .add_system_to_stage(Update, menu_system);

    // Finalize session and register with `Sessions`.
    let finished_session_ref = menu_session_builder.finish_and_add(&mut game.sessions);
 ```
 or
  ```rust
    let mut menu_session_builder = SessionBuilder::new("menu");

    menu_session_builder
        .install_plugin(DefaultSessionPlugin)
        .add_system_to_stage(Update, menu_system);

    // Finalize session and register with `Sessions`.
    // (`create` is the same as `finish_and_add`)
    let finished_session_ref = game.sessions.create(menu_session_builder);
```

### Risk of forgetting to finish `SessionBuilder`
I don't love this API - by using `SessionBuilder` to restrict mutability of resources/systems + disabling ability directly construction a `Session`, we have a risk of configuring a `SessionBuilder` and forgetting to "finish" or add to `Sessions` and do anything useful with it. I added a guard (`FinishGuard`) to builder that if dropped (builder not consumed/finished), will print a warning.

The other option is changing the `SessionBuilder` functions to move builder and return it, instead of `&mut SessionBuilder` as it is now. This could be combined with #[must_use] to lint if it isn't consumed/finished. I had a hard time deciding which route to go - I decided against the move-semantics / linear approach as it means if you are not chaining all calls on builder, you have to rebind it with `let` again, IMO it is not a pleasant experience for more complicated stuff. I think the run-time warning on Drop hopefully is enough.

# Syntax Change (how to fix compilation)
Session plugins now take `&mut SessionBuilder` instead of `&mut Session`:
```rust
    // old:
    fn install(self, session: &mut: Session);
    
    // new
    fn install(self, session: &mut SessionBuilder);
```

World is no longer on session builder, the functions used on world for resource init now are available on builder directly.
```rust
    // old:
    session.world.init_resource::<MyResource>();
    
    // new
    session.init_resource::<MyResource>();
```