### PR TITLE
refactor: change Sessions::create_with to take SessionPlugin

### DIFF
--- a/demos/asset_packs/src/main.rs
+++ b/demos/asset_packs/src/main.rs
@@ -46,13 +46,14 @@ fn main() {
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.
-    game.sessions.create_with("menu", |builder| {
-        // Install the default bones_framework plugin for this session
-        builder
-            .install_plugin(DefaultSessionPlugin)
-            // Add our menu system to the update stage
-            .add_system_to_stage(Update, menu_system);
-    });
+    game.sessions
+        .create_with("menu", |builder: &mut SessionBuilder| {
+            // Install the default bones_framework plugin for this session
+            builder
+                .install_plugin(DefaultSessionPlugin)
+                // Add our menu system to the update stage
+                .add_system_to_stage(Update, menu_system);
+        });
 
     BonesBevyRenderer::new(game).app().run();
 }

--- a/demos/hello_world/src/main.rs
+++ b/demos/hello_world/src/main.rs
@@ -10,13 +10,14 @@ fn main() {
 
     // Create a new session for the game menu. Each session is it's own bones world with it's own
     // plugins, systems, and entities.
-    game.sessions.create_with("menu", |session| {
-        session
-            // Install the default bones_framework plugin for this session
-            .install_plugin(DefaultSessionPlugin)
-            // Add our menu system to the update stage
-            .add_system_to_stage(Update, menu_system);
-    });
+    game.sessions
+        .create_with("menu", |session: &mut SessionBuilder| {
+            session
+                // Install the default bones_framework plugin for this session
+                .install_plugin(DefaultSessionPlugin)
+                // Add our menu system to the update stage
+                .add_system_to_stage(Update, menu_system);
+        });
 
     BonesBevyRenderer::new(game).app().run();
 }

--- a/demos/scripting/src/main.rs
+++ b/demos/scripting/src/main.rs
@@ -22,9 +22,10 @@ fn main() {
         .register_default_assets();
     GameMeta::register_schema();
 
-    game.sessions.create_with("launch", |builder| {
-        builder.add_startup_system(launch_game_session);
-    });
+    game.sessions
+        .create_with("launch", |builder: &mut SessionBuilder| {
+            builder.add_startup_system(launch_game_session);
+        });
 
     let mut renderer = BonesBevyRenderer::new(game);
     renderer.app_namespace = (
@@ -42,7 +43,7 @@ fn launch_game_session(
 ) {
     session_ops.delete = true;
     // Build game session and add to `Sessions`
-    sessions.create_with("game", |builder| {
+    sessions.create_with("game", |builder: &mut SessionBuilder| {
         builder
             .install_plugin(DefaultSessionPlugin)
             // Install the plugin that will load our lua plugins and run them in the game session

--- a/framework_crates/bones_framework/tests/reset.rs
+++ b/framework_crates/bones_framework/tests/reset.rs
@@ -11,12 +11,13 @@ pub fn startup_system_reset() {
     game.init_shared_resource::<Counter>();
 
     // Session startup increments counter by 1
-    game.sessions.create_with("game", |builder| {
-        builder.add_startup_system(|mut counter: ResMut<Counter>| {
-            // Increment to 1
-            counter.0 += 1;
+    game.sessions
+        .create_with("game", |builder: &mut SessionBuilder| {
+            builder.add_startup_system(|mut counter: ResMut<Counter>| {
+                // Increment to 1
+                counter.0 += 1;
+            });
         });
-    });
 
     // Step twice, startup system should only run once
     game.step(Instant::now());
@@ -52,23 +53,24 @@ pub fn single_success_system_reset() {
     let mut game = Game::new();
 
     // Session startup increments counter by 1
-    game.sessions.create_with("game", |builder| {
-        builder.init_resource::<Counter>();
-        {
-            let res = builder.resource_mut::<Counter>().unwrap();
-            assert_eq!(res.0, 0);
-        }
-        // system
-        builder.add_single_success_system(|mut counter: ResMut<Counter>| -> Option<()> {
-            // Increment until 2
-            counter.0 += 1;
-            if counter.0 >= 2 {
-                return Some(());
+    game.sessions
+        .create_with("game", |builder: &mut SessionBuilder| {
+            builder.init_resource::<Counter>();
+            {
+                let res = builder.resource_mut::<Counter>().unwrap();
+                assert_eq!(res.0, 0);
             }
+            // system
+            builder.add_single_success_system(|mut counter: ResMut<Counter>| -> Option<()> {
+                // Increment until 2
+                counter.0 += 1;
+                if counter.0 >= 2 {
+                    return Some(());
+                }
 
-            None
+                None
+            });
         });
-    });
 
     // Step three times, single success should've incremented counter to 2 and completed.
     game.step(Instant::now());
@@ -126,9 +128,10 @@ pub fn reset_world_resource_override() {
     let mut game = Game::new();
 
     // insert counter resource
-    game.sessions.create_with("game", |builder| {
-        builder.init_resource::<Counter>();
-    });
+    game.sessions
+        .create_with("game", |builder: &mut SessionBuilder| {
+            builder.init_resource::<Counter>();
+        });
 
     game.step(Instant::now());
     {
@@ -165,9 +168,10 @@ pub fn reset_world_emtpy_resource() {
     let mut game = Game::new();
 
     // insert counter resource
-    game.sessions.create_with("game", |builder| {
-        builder.init_resource::<Counter>();
-    });
+    game.sessions
+        .create_with("game", |builder: &mut SessionBuilder| {
+            builder.init_resource::<Counter>();
+        });
 
     game.step(Instant::now());
     {

--- a/framework_crates/bones_lib/src/lib.rs
+++ b/framework_crates/bones_lib/src/lib.rs
@@ -792,13 +792,13 @@ impl Sessions {
     pub fn create_with<N: TryInto<Ustr>>(
         &mut self,
         name: N,
-        build_function: impl FnOnce(&mut SessionBuilder),
+        plugin: impl SessionPlugin,
     ) -> &mut Session
     where
         <N as TryInto<Ustr>>::Error: Debug,
     {
         let mut builder = SessionBuilder::new(name);
-        build_function(&mut builder);
+        builder.install_plugin(plugin);
         builder.finish_and_add(self)
     }
 

--- a/framework_crates/bones_schema/src/alloc/layout.rs
+++ b/framework_crates/bones_schema/src/alloc/layout.rs
@@ -41,8 +41,6 @@ const LAYOUT_ERR: LayoutError = if let Err(e) = Layout::from_size_align(0, 0) {
 };
 
 impl LayoutExt for Layout {
-    #[must_use = "this returns the padding needed, \
-                  without modifying the `Layout`"]
     #[inline]
     fn padding_needed_for(&self, align: usize) -> usize {
         let len = self.size();


### PR DESCRIPTION
I'm opening this PR for @TekhnaeRaav, but I'm not sure about this one yet, since it does require annotating the argument type when passing in a closure, which isn't as nice, even though it's more flexible because you can pass in any plugin.

I'm a little less acquainted with this API right now.

@MaxCWhitehead whenever you get the chance to take a peek at this I wonder if you have thoughts.