### PR TITLE
refactor!: add configurable service for LAN matchmaking and fix bug when stopping hosting.

### DIFF
--- a/framework_crates/bones_framework/src/networking.rs
+++ b/framework_crates/bones_framework/src/networking.rs
@@ -22,6 +22,8 @@ use {
 
 use crate::input::PlayerControls as PlayerControlsTrait;
 
+pub use iroh;
+
 pub mod input;
 pub mod lan;
 pub mod online;

--- a/framework_crates/bones_framework/src/networking/lan.rs
+++ b/framework_crates/bones_framework/src/networking/lan.rs
@@ -86,6 +86,9 @@ pub fn stop_server(server: &ServerInfo) {
     if let Err(err) = stop_server_by_name(server.service.get_fullname()) {
         warn!("Lan: failed to stop server: {err:?}");
     }
+    LAN_MATCHMAKER
+        .try_send(LanMatchmakerRequest::StopServer)
+        .unwrap();
 }
 
 /// Stop hosting a server specified by name. (Use [`ServiceInfo::get_fullname()`].)

--- a/framework_crates/bones_framework/src/networking/lan.rs
+++ b/framework_crates/bones_framework/src/networking/lan.rs
@@ -239,16 +239,10 @@ pub async fn prepare_to_host<'a>(
         let mut props = std::collections::HashMap::default();
         let addr_encoded = hex::encode(postcard::to_stdvec(&my_addr).unwrap());
         props.insert("node-addr".to_string(), addr_encoded);
-        let service = mdns_sd::ServiceInfo::new(
-            service_type,
-            service_name,
-            service_name,
-            "",
-            port,
-            props,
-        )
-        .unwrap()
-        .enable_addr_auto();
+        let service =
+            mdns_sd::ServiceInfo::new(service_type, service_name, service_name, "", port, props)
+                .unwrap()
+                .enable_addr_auto();
         ServerInfo {
             service,
             ping: None,


### PR DESCRIPTION
Also re-exports the `iroh` crate in the networking module.