### PR TITLE
feat: publicize bones_bevy_renderer modules.

### DIFF
--- a/framework_crates/bones_bevy_renderer/src/convert.rs
+++ b/framework_crates/bones_bevy_renderer/src/convert.rs
@@ -5,10 +5,16 @@ use bevy::{
 };
 use bones_framework::prelude as bones;
 
+/// Trait for converting types similar to bevy into their bevy compatible
+/// versions.
 pub trait IntoBevy<T> {
+    /// Converts this type into its bevy compatible equivalent.
     fn into_bevy(self) -> T;
 }
+/// Trait for converting types similar to bones into their bones compatible
+/// versions.
 pub trait IntoBones<T> {
+    /// Converts this type into its bones compatible equivalent.
     fn into_bones(self) -> T;
 }
 

--- a/framework_crates/bones_bevy_renderer/src/input.rs
+++ b/framework_crates/bones_bevy_renderer/src/input.rs
@@ -9,6 +9,8 @@ use bevy::{
 use bones::{MouseScreenPosition, MouseWorldPosition};
 use bones_framework::input::gilrs::process_gamepad_events;
 
+/// Bevy system that takes the bones input resources as input and inserts them
+/// into the [`BonesGame`].
 pub fn insert_bones_input(
     In((mouse_inputs, keyboard_inputs, gamepad_inputs)): In<(
         bones::MouseInputs,
@@ -23,6 +25,7 @@ pub fn insert_bones_input(
     game.insert_shared_resource(gamepad_inputs);
 }
 
+/// Bevy system that gets the input events and returns the bones versions.
 pub fn get_bones_input(
     mut mouse_button_input_events: EventReader<MouseButtonInput>,
     mut mouse_motion_events: EventReader<MouseMotion>,
@@ -70,6 +73,8 @@ pub fn get_bones_input(
     )
 }
 
+/// Bevy system that takes the mouse positions for the world and screen as input
+/// and inserts them into the [`BonesGame`].
 pub fn insert_mouse_position(
     In((screen_pos, world_pos)): In<(Option<Vec2>, Option<Vec2>)>,
     mut game: ResMut<BonesGame>,
@@ -79,6 +84,7 @@ pub fn insert_mouse_position(
 }
 
 // Source: https://bevy-cheatbook.github.io/cookbook/cursor2world.html
+/// Bevy system that returns the mouse positions for the screen and world.
 pub fn get_mouse_position(
     mut q_primary_windows: Query<&Window, With<PrimaryWindow>>,
     q_camera: Query<(&Camera, &GlobalTransform)>,

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -12,18 +12,18 @@ pub mod prelude {
     pub use crate::*;
 }
 
-mod debug;
-mod storage;
+pub mod debug;
+pub mod storage;
 
-mod convert;
+pub mod convert;
 use convert::*;
-mod input;
+pub mod input;
 use input::*;
-mod render;
+pub mod render;
 use render::*;
-mod ui;
+pub mod ui;
 use ui::*;
-mod rumble;
+pub mod rumble;
 use bevy::{log::LogPlugin, prelude::*};
 use bones::GamepadsRumble;
 use bones_framework::prelude as bones;

--- a/framework_crates/bones_bevy_renderer/src/lib.rs
+++ b/framework_crates/bones_bevy_renderer/src/lib.rs
@@ -13,16 +13,26 @@ pub mod prelude {
 }
 
 pub mod debug;
+/// Contains the filesystem storage backend types.
 pub mod storage;
 
+/// Traits and implementations for converting between bevy and bones.
 pub mod convert;
 use convert::*;
+
+/// Input syncing and getting.
 pub mod input;
 use input::*;
+
+/// Contains the systems for extracting, syncing, and loading bones renderables.
 pub mod render;
 use render::*;
+
+/// Systems for syncing and modifying egui. Contains the default game loading ui system.
 pub mod ui;
 use ui::*;
+
+/// Systems for syncing bones rumble controls.
 pub mod rumble;
 use bevy::{log::LogPlugin, prelude::*};
 use bones::GamepadsRumble;

--- a/framework_crates/bones_bevy_renderer/src/render.rs
+++ b/framework_crates/bones_bevy_renderer/src/render.rs
@@ -91,6 +91,7 @@ impl BonesImageIds {
     }
 }
 
+/// Updates the [`BonesGame`]'s [`bones::ClearColor`] with the [`ClearColor`] from bevy.
 pub fn sync_clear_color(mut clear_color: ResMut<ClearColor>, game: Res<BonesGame>) {
     for name in &game.sorted_session_keys {
         let session = game.sessions.get(*name).unwrap();
@@ -231,6 +232,7 @@ pub fn sync_cameras(
     }
 }
 
+/// Extracts the [`bones::Sprite`]s to be used in bevy's rendering.
 pub fn extract_bones_sprites(
     mut extracted_sprites: ResMut<ExtractedSprites>,
     game: Extract<Res<BonesGame>>,
@@ -363,6 +365,7 @@ pub fn extract_bones_sprites(
     }
 }
 
+/// Extracts the [`bones::TileLayer`]s & [`bones::Tile`]s to be used in bevy's rendering.
 pub fn extract_bones_tilemaps(
     mut extracted_sprites: ResMut<ExtractedSprites>,
     game: Extract<Res<BonesGame>>,
@@ -465,6 +468,7 @@ pub fn extract_bones_tilemaps(
     }
 }
 
+/// Syncs the [`bones::Path2d`]s with bevy's [`lyon::Path`]s.
 pub fn sync_bones_path2ds(
     game: Res<BonesGame>,
     mut commands: Commands,

--- a/framework_crates/bones_bevy_renderer/src/storage.rs
+++ b/framework_crates/bones_bevy_renderer/src/storage.rs
@@ -7,11 +7,14 @@ pub use wasm::StorageBackend;
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::*;
+
+    /// Contains a namespace that is used for saving data in the filesystem.
     pub struct StorageBackend {
         storage_key: String,
     }
 
     impl StorageBackend {
+        /// Create a new [`StorageBackend`].
         pub fn new(qualifier: &str, organization: &str, application: &str) -> Self {
             Self {
                 storage_key: format!("{qualifier}.{organization}.{application}.storage"),
@@ -53,11 +56,13 @@ pub use native::StorageBackend;
 mod native {
     use super::*;
 
+    /// Contains a namespace that is used for saving data in the filesystem.
     pub struct StorageBackend {
         storage_path: std::path::PathBuf,
     }
 
     impl StorageBackend {
+        /// Create a new [`StorageBackend`].
         pub fn new(qualifier: &str, organization: &str, application: &str) -> Self {
             let project_dirs = directories::ProjectDirs::from(qualifier, organization, application)
                 .expect("Identify system data dir path");

--- a/framework_crates/bones_bevy_renderer/src/ui.rs
+++ b/framework_crates/bones_bevy_renderer/src/ui.rs
@@ -27,6 +27,7 @@ pub fn setup_egui(world: &mut World) {
     });
 }
 
+/// Applies the modifications setup in the [`bones::EguiInputHook`] resource.
 pub fn egui_input_hook(
     mut egui_query: Query<&mut bevy_egui::EguiInput, With<Window>>,
     mut game: ResMut<BonesGame>,
@@ -38,6 +39,7 @@ pub fn egui_input_hook(
     }
 }
 
+/// Syncs the [`bones::EguiSettings`] with the [`bevy_egui::EguiSettings`].
 pub fn sync_egui_settings(
     game: Res<BonesGame>,
     mut bevy_egui_settings: ResMut<bevy_egui::EguiSettings>,
@@ -52,6 +54,7 @@ pub fn sync_egui_settings(
     }
 }
 
+/// Updates the egui fonts based on [`bones::Font`]s in the [`bones::AssetServer`].
 pub fn update_egui_fonts(ctx: &bevy_egui::egui::Context, bones_assets: &bones::AssetServer) {
     use bevy_egui::egui;
     let mut fonts = egui::FontDefinitions::default();
@@ -80,6 +83,7 @@ pub fn update_egui_fonts(ctx: &bevy_egui::egui::Context, bones_assets: &bones::A
     ctx.set_fonts(fonts);
 }
 
+/// The system for displaying the default egui loading screen.
 pub fn default_load_progress(asset_server: &bones::AssetServer, ctx: &bevy_egui::egui::Context) {
     use bevy_egui::egui;
     let errored = asset_server.load_progress.errored();


### PR DESCRIPTION
Particularly, this allows integrating render steps in the Bevy App outside of the crate.